### PR TITLE
feat(ux): v02 overhaul — onboarding, Google OAuth step-by-step guide, tab reorder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # Invite Automation Suite — Claude Guide
 
+Author: Lenya Chan
+Updated: 2026-04-24
+
+## Planning docs
+- `docs/ROADMAP.md` — prioritized UX improvement roadmap with persona analysis
+- `docs/PROGRESS.md` — per-version changelog of UX work completed
+- `docs/TASKS.md` — current and backlog task list with implementation notes
+
+## File versioning
+Active production files: `index.html`, `inviteflow.html`, `contactscout.html`
+Iterations use the pattern `{name}_v{N:02d}.html` (e.g. `inviteflow_v02.html`).
+When a version is approved, promote it by replacing the production file.
+Public-facing files carry author credit "by Lenya Chan" near their title.
+
 ## Architecture
 Two self-contained vanilla JS HTML apps. No build step. No dependencies.
 
@@ -22,7 +36,7 @@ Two self-contained vanilla JS HTML apps. No build step. No dependencies.
 - Schema mgmt: saveSchema(), loadSchema(), deleteSchema(), exportSchema()
 - Persistence: localStorage key `inviteflow_state` — includes googleClientId, tplMode, htmlBody, schemas
 - Template tokens: {{FirstName}}, {{LastName}}, {{FullName}}, {{EventName}}, {{EventDate}}, {{Venue}}, {{RSVP_Link}}, {{FullTitle}}, {{OrgName}}, {{ContactName}}, {{ContactEmail}}, {{VIPStart}}, {{VIPEnd}}, {{Date_Sent}}
-- Tabs (7): Events, Setup, Invitees, Compose, Send, Tracker, Sync
+- Tabs (7): Setup, Invitees, Compose, Send, Tracker, Sync, Configs — Setup is tab 0 (v02+, was Events first in v01)
 - Master sheet columns: FirstName, LastName, Title, Category, Email, RSVP_Link, InviteSent, InviteSentDate, RSVP_Status, RSVP_Date, Notes
 - Secrets: googleClientId stored in localStorage only — never hardcode. Claude API key in contactscout uses sessionStorage.
 
@@ -31,3 +45,11 @@ Two self-contained vanilla JS HTML apps. No build step. No dependencies.
 - saveState() called at end of render()
 - No frameworks, no imports, no fetch except Claude API (contactscout) + Google APIs (inviteflow)
 - Google APIs called with OAuth2 Bearer token from getGoogleToken() — never API keys in source
+
+## UX conventions
+- First-run experience: inviteflow shows a 3-step welcome card (setupComplete() hides it) — keep it updated if new required steps are added
+- Google OAuth section in renderSetup() has two states: 5-step guide (no clientId) and compact confirmed state (clientId set)
+- Empty states must include actionable buttons; passive "nothing here" messages are not acceptable
+- All tab index references must be updated together: TABS array, render() switch, any onclick="S.tab=N", render checks like `if (S.tab===N)`
+- ContactScout: needsCustomization() detects [YOUR STATE] placeholders — keep it in sync if placeholder patterns change
+- Dates: YYYY-MM-DD in all docs and filenames

--- a/contactscout_v02.html
+++ b/contactscout_v02.html
@@ -1,0 +1,521 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ContactScout</title>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Syne:wght@700;800&display=swap');
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:#080c10;color:#c9d1d9;font-family:'DM Mono','Courier New',monospace;height:100vh;overflow:hidden;display:flex;flex-direction:column}
+::-webkit-scrollbar{width:5px}::-webkit-scrollbar-track{background:#0d1117}::-webkit-scrollbar-thumb{background:#21262d;border-radius:3px}
+.btn{border:1px solid #21262d;background:#0d1117;color:#8b949e;padding:6px 13px;border-radius:5px;cursor:pointer;font-family:inherit;font-size:11px;letter-spacing:.05em;transition:all .15s}
+.btn:hover{border-color:#58a6ff;color:#58a6ff}
+.btn.pri{background:#1f6feb;border-color:#1f6feb;color:#fff}.btn.pri:hover{background:#388bfd}
+.btn.grn{background:#238636;border-color:#238636;color:#fff}.btn.grn:hover{background:#2ea043}
+.btn.sm{padding:4px 9px;font-size:10px}
+.btn.stop{border-color:#da3633;color:#f85149}.btn.stop:hover{background:#da3633;color:#fff}
+.btn:disabled{opacity:.35;cursor:not-allowed}
+.tag{display:inline-block;font-size:9px;padding:2px 6px;border-radius:3px;letter-spacing:.07em;border:1px solid}
+.pulse{animation:pl 1.4s ease-in-out infinite}@keyframes pl{0%,100%{opacity:1}50%{opacity:.3}}
+.cat{border:1px solid #21262d;background:transparent;color:#6e7681;padding:4px 10px;border-radius:20px;cursor:pointer;font-family:inherit;font-size:10px;letter-spacing:.07em;transition:all .15s}
+.cat.on{border-color:#1f6feb;color:#58a6ff;background:#0c2d6b}.cat:hover:not(.on){color:#c9d1d9;border-color:#30363d}
+input[type=checkbox]{accent-color:#1f6feb}
+.ritem{transition:background .1s;cursor:pointer}.ritem:hover{background:#0d1117}
+.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.7);display:flex;align-items:center;justify-content:center;z-index:100}
+.modal{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:22px 24px;width:380px;max-width:90vw}
+.modal h2{font-family:'Syne',sans-serif;font-size:14px;color:#f0f6fc;margin-bottom:6px}
+.modal p{font-size:10px;color:#6e7681;line-height:1.6;margin-bottom:14px}
+.modal input{width:100%;background:#010409;border:1px solid #30363d;border-radius:4px;color:#c9d1d9;font-family:inherit;font-size:11px;padding:7px 10px;outline:none;margin-bottom:10px}
+.modal input:focus{border-color:#1f6feb}
+.modal-err{font-size:10px;color:#f85149;margin-bottom:8px;display:none}
+.modal-row{display:flex;gap:7px;justify-content:flex-end}
+</style>
+</head>
+<body>
+<div id="root" style="display:flex;flex-direction:column;height:100vh;overflow:hidden"></div>
+<input id="importfile" type="file" accept=".json" style="display:none" onchange="importProfile(this.files[0]);this.value=''">
+<div id="keymodal" class="modal-overlay" style="display:none">
+  <div class="modal">
+    <h2>Claude API Key</h2>
+    <p>Enter your Anthropic API key to use ContactScout. Get a free key at <a href="https://console.anthropic.com/" target="_blank" style="color:#58a6ff">console.anthropic.com</a> — sign in, go to API Keys, and click Create Key. The key starts with <code>sk-ant-</code>. It is stored only in this browser session and is never sent anywhere except the Anthropic API.</p>
+    <input id="keyinput" type="password" placeholder="sk-ant-..." autocomplete="off" onkeydown="if(event.key==='Enter')saveKey()">
+    <div id="keyerr" class="modal-err">Invalid key format — must start with sk-ant-</div>
+    <div class="modal-row">
+      <button class="btn sm" onclick="closeKeyModal()">Cancel</button>
+      <button class="btn sm pri" onclick="saveKey()">Save</button>
+    </div>
+  </div>
+</div>
+<script>
+// Start with an empty list — populate via the Scan tab or manual add
+const OFFICIALS_BASE = [];
+
+const SCAN_TARGETS = [
+  {id:"us-congress",  label:"US Congress — all seats",          desc:"All current US reps + senators for your state"},
+  {id:"state-exec",   label:"State Executive Branch",           desc:"Governor, Lt. Gov, AG, Treasurer, Auditor, commissioners"},
+  {id:"state-senate", label:"State Senate — all seats",         desc:"Full current state senate roster"},
+  {id:"state-house",  label:"State House — tracked counties",   desc:"House members for your tracked counties"},
+  {id:"city-1",       label:"City Council (City 1)",            desc:"Current mayor and all council members"},
+  {id:"city-2",       label:"City Council (City 2)",            desc:"Current mayor and all council members"},
+  {id:"city-3",       label:"City Council (City 3)",            desc:"Current mayor and all council members"},
+];
+
+const SCAN_PROMPTS = {
+  "us-congress":  "Search for every current US Congress member for [YOUR STATE] (119th Congress 2025-2026): all House reps + 2 senators. For each: full name, title, district, official scheduler/contact email.",
+  "state-exec":   "Search for all current [YOUR STATE] statewide executive elected officials as of 2025: Governor, Lt. Governor, AG, Treasurer, Auditor, Superintendent of Public Instruction, and other commissioners. Full name, title, email.",
+  "state-senate": "Search for all current [YOUR STATE] State Senate members as of 2025. Full name, district, official email.",
+  "state-house":  "Search for all current [YOUR STATE] House members for [YOUR COUNTIES] as of 2025. Full name, district, county, official email.",
+  "city-1":       "Search for current [CITY 1] City Council as of 2025. Mayor + every council member: full name, title, official email.",
+  "city-2":       "Search for current [CITY 2] City Council as of 2025. Mayor + every council member: full name, title, official email.",
+  "city-3":       "Search for current [CITY 3] City Council as of 2025. Mayor + every council member: full name, title, official email.",
+};
+
+const VERIFY_SYS = `Verify this elected official for 2025-2026 using web search. Respond ONLY with valid JSON no markdown:
+{"stillInOffice":true,"currentTitle":"","directEmail":"","officeEmail":"","officePhone":"","changes":"No changes detected","flags":"","replacedBy":"","confidence":"high"}`;
+const SCAN_SYS = `Find all current elected officials for 2025-2026 using web search. Respond ONLY with valid JSON no markdown:
+{"officials":[{"name":"","title":"","district":"","county":"","category":"US Senate|US House|Executive|State Senate|House|City Council","directEmail":"","officeEmail":"","officePhone":""}],"confidence":"high","notes":""}`;
+
+const CATS = ["All","US Senate","US House","Executive","State Senate","House","City Council"];
+const TAG={pending:'#30363d:#6e7681',checking:'#f59e0b:#f59e0b',done:'#238636:#3fb950',changed:'#1f6feb:#58a6ff',left_office:'#da3633:#f85149',error:'#bb8009:#e3b341'};
+const SL={pending:'PENDING',checking:'CHECKING',done:'VERIFIED',changed:'CHANGED',left_office:'LEFT OFFICE',error:'ERROR'};
+function ts(k){const[b,c]=(TAG[k]||TAG.pending).split(':');return `border-color:${b};color:${c}`;}
+
+// STATE
+const S = {
+  tab:0,
+  officials: OFFICIALS_BASE.map(o=>({...o,status:'pending',result:null})),
+  newOfficials:[],
+  scanStatus:{},scanMeta:{},
+  activeCat:'All',
+  selected:new Set(),
+  running:false,progress:{done:0,total:0},
+  log:[],
+  apiKey: sessionStorage.getItem('cs_api_key')||'',
+  unsaved:false,
+};
+let abortFlag=false;
+let _pendingAction=null;
+
+// ── PERSISTENCE ──────────────────────────────────────────────────────────────
+const LS_KEY='contactscout_state';
+
+function saveState(){
+  try{
+    localStorage.setItem(LS_KEY,JSON.stringify({
+      officials:S.officials,
+      newOfficials:S.newOfficials,
+      scanStatus:S.scanStatus,
+      scanMeta:S.scanMeta,
+    }));
+  }catch(e){}
+}
+
+function loadState(){
+  try{
+    const raw=localStorage.getItem(LS_KEY);
+    if(!raw)return;
+    const d=JSON.parse(raw);
+    if(d.officials)    S.officials    =d.officials.map(o=>({...o,result:o.result||null}));
+    if(d.newOfficials) S.newOfficials =d.newOfficials;
+    if(d.scanStatus)   S.scanStatus   =d.scanStatus;
+    if(d.scanMeta)     S.scanMeta     =d.scanMeta;
+    S.unsaved=false;
+  }catch(e){/* corrupt data — start fresh */}
+}
+
+function clearSavedState(){
+  if(!confirm('Clear all saved officials and scan data? This cannot be undone.'))return;
+  localStorage.removeItem(LS_KEY);
+  S.officials=[];S.newOfficials=[];S.scanStatus={};S.scanMeta={};
+  S.unsaved=false;
+  log('✓ Saved data cleared.');render();
+}
+
+function exportProfile(){
+  const blob=new Blob([JSON.stringify({
+    exportedAt:new Date().toISOString(),
+    source:'ContactScout',
+    officials:S.officials,
+    newOfficials:S.newOfficials,
+    scanStatus:S.scanStatus,
+    scanMeta:S.scanMeta,
+  },null,2)],{type:'application/json'});
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download=`contactscout-backup-${new Date().toISOString().slice(0,10)}.json`;
+  a.click();
+  S.unsaved=false;
+  log(`✓ Backup saved (${S.officials.length} officials).`);render();
+}
+
+function importProfile(file){
+  if(!file)return;
+  const r=new FileReader();
+  r.onload=e=>{
+    try{
+      const d=JSON.parse(e.target.result);
+      if(d.officials)    S.officials    =d.officials.map(o=>({...o,result:o.result||null}));
+      if(d.newOfficials) S.newOfficials =d.newOfficials||[];
+      if(d.scanStatus)   S.scanStatus   =d.scanStatus||{};
+      if(d.scanMeta)     S.scanMeta     =d.scanMeta||{};
+      S.unsaved=false;
+      log(`✓ Backup loaded: ${S.officials.length} officials.`);render();
+    }catch(err){log(`✗ Import failed: ${err.message}`);}
+  };
+  r.readAsText(file);
+}
+
+loadState();
+
+// HELPERS
+const sleep=ms=>new Promise(r=>setTimeout(r,ms));
+function log(m){S.log=[`[${new Date().toLocaleTimeString()}] ${m}`,...S.log.slice(0,99)];renderLog();}
+function upd(name,p){S.officials=S.officials.map(o=>o.name===name?{...o,...p}:o);S.unsaved=true;render();}
+function filtered(){return S.officials.filter(o=>S.activeCat==='All'||o.category===S.activeCat);}
+
+// API KEY MODAL
+function openKeyModal(onSave){
+  _pendingAction=onSave||null;
+  document.getElementById('keyinput').value=S.apiKey||'';
+  document.getElementById('keyerr').style.display='none';
+  document.getElementById('keymodal').style.display='flex';
+  setTimeout(()=>document.getElementById('keyinput').focus(),50);
+}
+function closeKeyModal(){document.getElementById('keymodal').style.display='none';}
+function saveKey(){
+  const k=document.getElementById('keyinput').value.trim();
+  if(!k.startsWith('sk-ant-')){document.getElementById('keyerr').style.display='block';return;}
+  S.apiKey=k;sessionStorage.setItem('cs_api_key',k);
+  closeKeyModal();
+  render();
+  if(_pendingAction){const fn=_pendingAction;_pendingAction=null;fn();}
+}
+
+// API
+async function callClaude(sys,user){
+  if(!S.apiKey){
+    return new Promise((_,reject)=>{
+      openKeyModal(()=>callClaude(sys,user).then(_).catch(reject));
+    });
+  }
+  const res=await fetch('https://api.anthropic.com/v1/messages',{
+    method:'POST',
+    headers:{
+      'Content-Type':'application/json',
+      'x-api-key':S.apiKey,
+      'anthropic-version':'2023-06-01',
+      'anthropic-dangerous-direct-browser-access':'true',
+    },
+    body:JSON.stringify({model:'claude-sonnet-4-20250514',max_tokens:1500,system:sys,
+      tools:[{type:'web_search_20250305',name:'web_search'}],
+      messages:[{role:'user',content:user}]}),
+  });
+  if(res.status===401){S.apiKey='';sessionStorage.removeItem('cs_api_key');render();throw new Error('Invalid API key');}
+  const d=await res.json();
+  if(d.error) throw new Error(d.error.message||'API error');
+  const t=d.content?.find(b=>b.type==='text')?.text||'';
+  if(!t) throw new Error('No text response');
+  return JSON.parse(t.replace(/```json|```/g,'').trim());
+}
+
+// VERIFY
+async function runVerify(names){
+  if(!S.apiKey){openKeyModal(()=>runVerify(names));return;}
+  abortFlag=false;S.running=true;S.progress={done:0,total:names.length};render();
+  for(let i=0;i<names.length;i++){
+    if(abortFlag) break;
+    const name=names[i],o=S.officials.find(x=>x.name===name);
+    log(`Verifying ${name}…`);upd(name,{status:'checking'});
+    try{
+      const r=await callClaude(VERIFY_SYS,`Verify for 2025-2026:
+Name: ${o.name}
+Title: ${o.title}
+Category: ${o.category}
+District: ${o.district||'N/A'}
+Email: ${o.directEmail||o.officeEmail||'none'}`);
+      const ch=!r.stillInOffice||r.changes!=='No changes detected'||r.flags;
+      upd(name,{status:!r.stillInOffice?'left_office':ch?'changed':'done',result:r,
+        directEmail:r.directEmail||o.directEmail,officeEmail:r.officeEmail||o.officeEmail,
+        officePhone:r.officePhone||o.officePhone,title:r.currentTitle||o.title});
+      log(`✓ ${name}: ${r.stillInOffice?'In office':'⚠ LEFT OFFICE'} — ${r.changes}`);
+    }catch(e){upd(name,{status:'error',result:{error:e.message}});log(`✗ ${name}: ${e.message}`);}
+    S.progress.done=i+1;render();
+    if(i<names.length-1) await sleep(700);
+  }
+  S.running=false;render();log(`Done — ${names.length} checked.`);
+}
+
+// SCAN
+async function runScan(id){
+  if(S.running) return;
+  if(!S.apiKey){openKeyModal(()=>runScan(id));return;}
+  abortFlag=false;S.running=true;S.scanStatus[id]='scanning';render();
+  log(`Scanning: ${SCAN_TARGETS.find(t=>t.id===id).label}…`);
+  try{
+    const r=await callClaude(SCAN_SYS,SCAN_PROMPTS[id]);
+    const cur=new Set(S.officials.map(o=>o.name.toLowerCase().trim()));
+    const fresh=(r.officials||[]).filter(o=>!cur.has(o.name.toLowerCase().trim()));
+    S.scanStatus[id]='done';
+    S.scanMeta[id]={total:r.officials?.length||0,confidence:r.confidence,notes:r.notes};
+    if(fresh.length>0){
+      const ex=new Set(S.newOfficials.map(x=>x.name.toLowerCase()));
+      S.newOfficials=[...S.newOfficials,...fresh.filter(x=>!ex.has(x.name.toLowerCase())).map(x=>({...x,_scanId:id}))];
+      S.unsaved=true;log(`✓ ${fresh.length} new found.`);
+    } else log(`✓ All ${r.officials?.length||0} already in list.`);
+    if(r.notes) log(`ℹ ${r.notes}`);
+  }catch(e){S.scanStatus[id]='error';log(`✗ Scan: ${e.message}`);}
+  S.running=false;render();
+}
+
+function addNew(o){
+  S.officials=[...S.officials,{...o,status:'pending',result:null}];
+  S.newOfficials=S.newOfficials.filter(x=>x.name!==o.name);
+  S.unsaved=true;log(`+ Added ${o.name}`);render();
+}
+function dismissNew(name){S.newOfficials=S.newOfficials.filter(x=>x.name!==name);render();}
+function toggleSel(name){S.selected.has(name)?S.selected.delete(name):S.selected.add(name);render();}
+function toggleExpand(id){
+  const d=document.getElementById('det_'+id),a=document.getElementById('arr_'+id);
+  if(d)d.style.display=d.style.display==='none'?'block':'none';
+  if(a)a.textContent=a.textContent==='▼'?'▲':'▼';
+}
+
+// EXPORT — standardized format for InviteFlow connector
+function exportForMailer(){
+  const out=S.officials
+    .filter(o=>o.status!=='left_office')
+    .map(o=>({
+      name:o.name,title:o.title,district:o.district,county:o.county,
+      category:o.category,email:o.officeEmail||o.directEmail||'',
+      directEmail:o.directEmail,officeEmail:o.officeEmail,officePhone:o.officePhone,
+      verifyStatus:o.status,changes:o.result?.changes||'',flags:o.result?.flags||'',
+    }));
+  const blob=new Blob([JSON.stringify({
+    exportedAt:new Date().toISOString(),
+    source:'ContactScout',
+    count:out.length,
+    invitees:out,
+  },null,2)],{type:'application/json'});
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download=`contactscout-invitees-${new Date().toISOString().slice(0,10)}.json`;
+  a.click();
+  log(`✓ Exported ${out.length} invitees for InviteFlow.`);
+}
+
+function exportCSV(){
+  const h=['Name','Title','District','County','Category','Direct Email','Office Email','Phone','Status','Changes','Flags','Replaced By','Confidence'];
+  const rows=S.officials.map(o=>[o.name,o.title,o.district,o.county,o.category,o.directEmail,o.officeEmail,o.officePhone,o.status,o.result?.changes||'',o.result?.flags||'',o.result?.replacedBy||'',o.result?.confidence||'']);
+  const csv=[h,...rows].map(r=>r.map(c=>`"${(c||'').replace(/"/g,'""')}"`).join(',')).join('\n');
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(new Blob([csv],{type:'text/csv'}));
+  a.download=`contactscout-officials-${new Date().toISOString().slice(0,10)}.csv`;a.click();
+  log('✓ CSV exported.');
+}
+
+// RENDER
+function render(){
+  const c={
+    total:S.officials.length,
+    done:S.officials.filter(o=>o.status==='done').length,
+    changed:S.officials.filter(o=>o.status==='changed').length,
+    left:S.officials.filter(o=>o.status==='left_office').length,
+    ready:S.officials.filter(o=>o.status!=='left_office'&&(o.officeEmail||o.directEmail)).length,
+  };
+  const pct=S.progress.total?Math.round(S.progress.done/S.progress.total*100):0;
+  const filt=filtered();
+  const keySet=!!S.apiKey;
+
+  document.getElementById('root').innerHTML=`
+  <div style="border-bottom:1px solid #21262d;padding:11px 20px;display:flex;justify-content:space-between;align-items:center;flex-shrink:0;background:#080c10">
+    <div>
+      <div style="font-family:'Syne',sans-serif;font-size:17px;font-weight:800;color:#f0f6fc;letter-spacing:-.02em">CONTACT SCOUT</div>
+      <div style="font-size:9px;color:#6e7681;margin-top:2px;letter-spacing:.1em">ELECTED OFFICIALS · VERIFY + DISCOVER</div>
+    </div>
+    <div style="display:flex;gap:7px;align-items:center">
+      ${S.newOfficials.length>0?`<span style="background:#0c1a2e;color:#58a6ff;border:1px solid #1f6feb;border-radius:4px;padding:3px 9px;font-size:10px">${S.newOfficials.length} NEW</span>`:''}
+      ${S.unsaved&&S.officials.length>0?`<span style="background:#2a1a00;color:#C8A84B;border:1px solid #C8A84B;border-radius:4px;padding:2px 8px;font-size:9px">● UNSAVED</span>`:''}
+      <button class="btn sm" onclick="openKeyModal()" title="${keySet?'API key set — click to change':'No API key set'}" style="${keySet?'border-color:#238636;color:#3fb950':'border-color:#da3633;color:#f85149'}">⚙ Key${keySet?' ✓':''}</button>
+      <button class="btn sm" onclick="document.getElementById('importfile').click()" title="Load a .json backup">↑ Import</button>
+      <button class="btn sm" onclick="exportProfile()" title="Save full backup as .json">↓ Backup</button>
+      <button class="btn sm" onclick="exportCSV()">↓ CSV</button>
+      <button class="btn sm grn" onclick="exportForMailer()" title="Export invitee list for InviteFlow">⬡ Export → InviteFlow</button>
+      <button class="btn sm stop" onclick="abortFlag=true" ${!S.running?'disabled':''}>■ Stop</button>
+    </div>
+  </div>
+
+  <div style="padding:6px 20px;border-bottom:1px solid #161b22;display:flex;gap:14px;flex-wrap:wrap;align-items:center;flex-shrink:0">
+    ${[['TOTAL',c.total,'#8b949e'],['VERIFIED',c.done,'#3fb950'],['CHANGED',c.changed,'#58a6ff'],['LEFT OFFICE',c.left,'#f85149'],['READY TO INVITE',c.ready,'#a371f7']].map(([l,n,col])=>`
+    <div style="display:flex;align-items:center;gap:5px">
+      <span style="width:5px;height:5px;border-radius:50%;background:${col};display:inline-block"></span>
+      <span style="font-size:9px;color:#6e7681;letter-spacing:.1em">${l}</span>
+      <span style="font-size:12px;font-weight:500;color:${col}">${n}</span>
+    </div>`).join('')}
+    ${S.running?`<div style="margin-left:auto;display:flex;align-items:center;gap:7px">
+      <div style="width:90px;height:3px;background:#21262d;border-radius:2px"><div style="width:${pct}%;height:100%;background:#1f6feb;border-radius:2px"></div></div>
+      <span style="font-size:10px;color:#58a6ff">${S.progress.done}/${S.progress.total}</span></div>`:''}
+  </div>
+
+  ${!keySet ? `
+  <div style="background:#060d1a;border-bottom:1px solid #1f6feb;padding:14px 20px;flex-shrink:0">
+    <div style="font-size:12px;color:#58a6ff;font-weight:600;margin-bottom:4px">Welcome to ContactScout — by Lenya Chan</div>
+    <div style="font-size:10px;color:#8b949e;line-height:1.7;margin-bottom:10px">ContactScout uses Claude AI to find and verify elected officials for your state and city. To get started, add your Claude API key. Then go to the Scan tab and update the targets for your jurisdiction.</div>
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+      <button class="btn sm pri" onclick="openKeyModal()">→ Add Claude API Key</button>
+      <span style="font-size:9px;color:#6e7681">Free key at <a href="https://console.anthropic.com/" target="_blank" style="color:#58a6ff">console.anthropic.com</a> → API Keys → Create Key</span>
+    </div>
+  </div>` : ''}
+
+  <div style="border-bottom:1px solid #21262d;display:flex;flex-shrink:0">
+    ${['✓ Verify Existing','＋ Scan for New'].map((t,i)=>`
+    <button onclick="S.tab=${i};render()" style="background:none;border:none;cursor:pointer;font-family:inherit;font-size:11px;letter-spacing:.04em;padding:8px 16px;color:${S.tab===i?'#f0f6fc':'#6e7681'};border-bottom:${S.tab===i?'2px solid #1f6feb':'2px solid transparent'}">
+      ${t}${i===1&&S.newOfficials.length>0?` (${S.newOfficials.length})`:''}</button>`).join('')}
+  </div>
+
+  <div style="display:grid;grid-template-columns:1fr 220px;flex:1;overflow:hidden;min-height:0">
+    <div style="overflow-y:auto;min-height:0">${S.tab===0?renderVerify(filt):renderScan()}</div>
+    <div style="overflow-y:auto;padding:11px 13px;background:#050709;border-left:1px solid #161b22;min-height:0" id="logpanel">
+      <div style="font-size:9px;color:#6e7681;letter-spacing:.14em;margin-bottom:7px">ACTIVITY LOG</div>
+      <div style="font-size:10px;color:#21262d;font-style:italic;margin-bottom:6px">⬡ Export → InviteFlow sends verified list to InviteFlow app.</div>
+      ${S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#8b949e':'#2d3340'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #1f6feb':'2px solid transparent'};padding-left:6px">${e}</div>`).join('')}
+      <div style="margin-top:12px;padding-top:10px;border-top:1px solid #161b22">
+        <div style="font-size:9px;color:#6e7681;letter-spacing:.1em;margin-bottom:6px">DATA</div>
+        <button class="btn sm" style="width:100%;margin-bottom:4px;text-align:left" onclick="exportProfile()">↓ Backup (.json)</button>
+        <button class="btn sm" style="width:100%;margin-bottom:4px;text-align:left" onclick="document.getElementById('importfile').click()">↑ Import backup</button>
+        <button class="btn sm stop" style="width:100%;text-align:left" onclick="clearSavedState()">✕ Clear all data</button>
+      </div>
+    </div>
+  </div>
+  `;
+  saveState();
+}
+
+function renderLog(){
+  const el=document.getElementById('logpanel');if(!el)return;
+  el.innerHTML=`<div style="font-size:9px;color:#6e7681;letter-spacing:.14em;margin-bottom:7px">ACTIVITY LOG</div>
+  <div style="font-size:10px;color:#21262d;font-style:italic;margin-bottom:6px">⬡ Export → InviteFlow sends verified list to InviteFlow app.</div>
+  ${S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#8b949e':'#2d3340'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #1f6feb':'2px solid transparent'};padding-left:6px">${e}</div>`).join('')}`;
+}
+
+function renderVerify(filt){
+  const names=filt.map(o=>o.name);
+  return `
+  <div style="padding:7px 18px;border-bottom:1px solid #161b22;display:flex;gap:5px;align-items:center;flex-wrap:wrap;position:sticky;top:0;background:#080c10;z-index:2">
+    <div style="display:flex;gap:4px;flex-wrap:wrap;flex:1">
+      ${CATS.map(c=>`<button class="cat${S.activeCat===c?' on':''}" onclick="S.activeCat='${c}';render()">${c.toUpperCase()}</button>`).join('')}
+    </div>
+    <div style="display:flex;gap:4px">
+      <button class="btn sm" onclick="S.selected=new Set(${JSON.stringify(names)});render()" ${S.running?'disabled':''}>Sel All</button>
+      <button class="btn sm" onclick="S.selected=new Set();render()" ${S.running?'disabled':''}>Clear</button>
+      <button class="btn sm pri" onclick="runVerify([...S.selected])" ${S.running||S.selected.size===0?'disabled':''}>▶ (${S.selected.size})</button>
+      <button class="btn sm pri" onclick="runVerify(${JSON.stringify(names)})" ${S.running?'disabled':''}>▶ All</button>
+    </div>
+  </div>
+  ${filt.length===0?`<div style="padding:40px 20px;text-align:center;color:#6e7681;font-size:11px">No officials yet. Use the <strong style="color:#c9d1d9">＋ Scan for New</strong> tab to discover officials,<br>or add them manually with the button below.<br><br><button class="btn sm" onclick="promptAddManual()">+ Add Manually</button></div>`:''}
+  ${filt.map(o=>{
+    const id=o.name.replace(/[^a-z0-9]/gi,'_');
+    const det=o.result?(o.result.error?
+      `<div style="color:#e3b341">Error: ${o.result.error}</div>`:
+      `${o.result.stillInOffice!==undefined?`<div><span style="color:#6e7681">IN OFFICE </span>${o.result.stillInOffice?'<span style="color:#3fb950">Yes</span>':`<span style="color:#f85149">No${o.result.replacedBy?' → '+o.result.replacedBy:''}</span>`}</div>`:''}`+
+      `${o.result.currentTitle?`<div><span style="color:#6e7681">TITLE </span>${o.result.currentTitle}</div>`:''}`+
+      `${o.result.directEmail?`<div><span style="color:#6e7681">DIRECT </span>${o.result.directEmail}</div>`:''}`+
+      `${o.result.officeEmail?`<div><span style="color:#6e7681">OFFICE </span>${o.result.officeEmail}</div>`:''}`+
+      `${o.result.changes&&o.result.changes!=='No changes detected'?`<div style="color:#58a6ff"><span style="color:#6e7681">CHANGES </span>${o.result.changes}</div>`:''}`+
+      `${o.result.flags?`<div style="color:#e3b341"><span style="color:#6e7681">FLAGS </span>${o.result.flags}</div>`:''}`+
+      `<div><span style="color:#6e7681">CONF </span><span style="color:${o.result.confidence==='high'?'#3fb950':o.result.confidence==='medium'?'#e3b341':'#f85149'}">${(o.result.confidence||'').toUpperCase()}</span></div>`
+    ):'<span style="color:#6e7681;font-style:italic">Not yet verified.</span>';
+    return `
+    <div style="border-bottom:1px solid #0d1117">
+      <div class="ritem" style="display:grid;grid-template-columns:20px 1fr 105px 82px 14px;gap:7px;padding:8px 18px" onclick="toggleExpand('${id}')">
+        <input type="checkbox" ${S.selected.has(o.name)?'checked':''} onclick="event.stopPropagation();toggleSel('${o.name.replace(/'/g,"\'")}')">
+        <div>
+          <div style="font-size:11px;font-weight:500;color:#f0f6fc">${o.name}</div>
+          <div style="font-size:9px;color:#8b949e">${o.title}${o.district?' · D'+o.district:''}${o.county?' · '+o.county:''}</div>
+          <div style="font-size:9px;color:#6e7681;font-style:italic">${o.directEmail||o.officeEmail||'no email'}</div>
+        </div>
+        <div style="font-size:9px;color:#6e7681;padding-top:1px">${o.category}</div>
+        <div><span class="tag${o.status==='checking'?' pulse':''}" style="${ts(o.status)};font-size:8px">${SL[o.status]||'PENDING'}</span></div>
+        <div style="font-size:10px;color:#30363d" id="arr_${id}">▼</div>
+      </div>
+      <div id="det_${id}" style="display:none;padding:0 18px 9px 45px">
+        <div style="background:#0d1117;border:1px solid #21262d;border-radius:5px;padding:8px 12px;font-size:10px;line-height:1.8">${det}</div>
+      </div>
+    </div>`;
+  }).join('')}`;
+}
+
+function promptAddManual(){
+  const name=prompt('Full name:');if(!name)return;
+  const title=prompt('Title:','');
+  const email=prompt('Email:','');
+  const cat=prompt('Category (US Senate/US House/Executive/State Senate/House/City Council):','City Council');
+  S.officials=[...S.officials,{name,title:title||'',directEmail:email||'',officeEmail:'',officePhone:'',district:'',county:'',category:cat||'City Council',status:'pending',result:null}];
+  log(`+ Added ${name}`);render();
+}
+
+function needsCustomization(){
+  return Object.values(SCAN_PROMPTS).some(p=>p.includes('[YOUR STATE]')||p.includes('[YOUR COUNTIES]')||p.includes('[CITY'));
+}
+
+function renderScan(){
+  return `<div style="padding:14px 20px">
+    ${needsCustomization()?`<div style="background:#1a0e00;border:1px solid #bb8009;border-radius:7px;padding:12px 16px;margin-bottom:14px">
+      <div style="font-size:11px;color:#e3b341;font-weight:600;margin-bottom:5px">Scan targets need customization before use</div>
+      <div style="font-size:10px;color:#8b949e;line-height:1.8">
+        The scan prompts still contain placeholder text like <code style="color:#C8A84B">[YOUR STATE]</code> and <code style="color:#C8A84B">[CITY 1]</code>.<br>
+        Open <code style="color:#C8A84B">contactscout_v02.html</code> in any text editor (Notepad, TextEdit, VS Code).<br>
+        Near the top of the &lt;script&gt; block, find the <code style="color:#C8A84B">SCAN_TARGETS</code> and <code style="color:#C8A84B">SCAN_PROMPTS</code> arrays
+        and replace the bracketed placeholders with your state name, county names, and city names.
+      </div>
+    </div>`:''}
+    <div style="font-size:11px;color:#8b949e;line-height:1.6;margin-bottom:14px">Each scan searches the live web for all officials in that category. New officials not in your list surface as add candidates. Customize the scan prompts in the source file for your jurisdiction. Run after each election cycle, then <strong style="color:#f0f6fc">Export → InviteFlow</strong> to send the updated list.</div>
+    ${SCAN_TARGETS.map(t=>{
+      const st=S.scanStatus[t.id],meta=S.scanMeta[t.id];
+      const fresh=S.newOfficials.filter(o=>o._scanId===t.id);
+      return `
+      <div style="margin-bottom:11px">
+        <div style="background:#0d1117;border:1px solid #21262d;border-radius:7px;padding:12px 15px">
+          <div style="display:flex;justify-content:space-between;align-items:center;gap:10px">
+            <div style="flex:1">
+              <div style="font-size:12px;color:#f0f6fc;font-weight:500">${t.label}</div>
+              <div style="font-size:10px;color:#6e7681;margin-top:2px">${t.desc}</div>
+              ${meta?`<div style="margin-top:3px;font-size:10px;color:#8b949e">Found ${meta.total} · <span style="color:${meta.confidence==='high'?'#3fb950':meta.confidence==='medium'?'#e3b341':'#f85149'}">${meta.confidence}</span>${meta.notes?` · <span style="color:#e3b341">${meta.notes}</span>`:''}</div>`:''}
+            </div>
+            <div style="display:flex;gap:5px;align-items:center;flex-shrink:0">
+              ${st==='scanning'?'<span class="tag pulse" style="border-color:#f59e0b;color:#f59e0b">SCANNING</span>':''}
+              ${st==='done'?'<span class="tag" style="border-color:#238636;color:#3fb950">DONE</span>':''}
+              ${st==='error'?'<span class="tag" style="border-color:#da3633;color:#f85149">ERROR</span>':''}
+              <button class="btn sm pri" onclick="runScan('${t.id}')" ${S.running?'disabled':''}>${st==='done'?'↻ Re-scan':'▶ Scan'}</button>
+            </div>
+          </div>
+        </div>
+        ${fresh.length>0?`
+        <div style="margin:3px 0 0 11px;padding-left:11px;border-left:2px solid #1f6feb">
+          <div style="font-size:9px;color:#58a6ff;letter-spacing:.1em;margin:6px 0 4px">NEW (${fresh.length})</div>
+          ${fresh.map(o=>`
+          <div style="background:#0c1a2e;border:1px solid #1f4f99;border-radius:5px;padding:8px 11px;margin-bottom:4px;display:flex;justify-content:space-between;align-items:center">
+            <div>
+              <div style="font-size:11px;color:#f0f6fc;font-weight:500">${o.name}</div>
+              <div style="font-size:9px;color:#8b949e">${o.title}${o.district?' · D'+o.district:''}${o.county?' · '+o.county:''}</div>
+              ${(o.directEmail||o.officeEmail)?`<div style="font-size:9px;color:#6e7681">${o.directEmail||o.officeEmail}</div>`:''}
+            </div>
+            <div style="display:flex;gap:4px;margin-left:8px">
+              <button class="btn sm grn" onclick='addNew(${JSON.stringify(o)})'>+ Add</button>
+              <button class="btn sm" onclick="dismissNew('${o.name.replace(/'/g,"\'")}')">✕</button>
+            </div>
+          </div>`).join('')}
+        </div>`:''}
+        ${st==='done'&&fresh.length===0&&meta?`<div style="margin:3px 0 0 11px;padding:4px 0 4px 11px;border-left:2px solid #238636;font-size:10px;color:#3fb950">✓ All ${meta.total} already in list.</div>`:''}
+      </div>`;
+    }).join('')}
+  </div>`;
+}
+
+window.addEventListener('beforeunload',e=>{
+  if(S.unsaved&&S.officials.length>0){e.preventDefault();e.returnValue='You have unsaved changes. Export a backup before leaving?';}
+});
+
+render();
+</script>
+</body>
+</html>

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,64 @@
+# UX Improvement Progress
+
+Author: Lenya Chan
+Updated: 2026-04-24
+
+---
+
+## v02 — 2026-04-24 — First UX Overhaul
+
+### InviteFlow (inviteflow_v02.html)
+
+- [x] Reordered tabs: Setup is now the first tab (was "Events" / schema management).
+      New order: Setup → Invitees → Compose → Send → Tracker → Sync → Configs
+- [x] Renamed "Events" tab to "Configs" (the function `renderEvents()` is unchanged internally).
+- [x] Added welcome card at the top of Setup that shows until all three setup steps are done
+      (Google connected, event name filled, invitees imported). Steps show as green checkmarks
+      as the user completes them.
+- [x] Rewrote Google OAuth section from 3 terse lines into a 5-step guide:
+      Step 1 — Open Google Cloud Console (direct link)
+      Step 2 — Create project and enable Gmail API + Google Sheets API
+      Step 3 — Configure OAuth consent screen (External, add yourself as test user)
+      Step 4 — Create OAuth 2.0 Client ID (Web application, add authorized origins)
+      Step 5 — Paste Client ID into the app
+      The section collapses to a compact confirmed state once the Client ID is entered.
+- [x] Invitees tab empty state now shows actionable buttons (Import from Sheet, Upload CSV, Add
+      manually) and a context-aware hint directing users to Setup if Google isn't connected yet.
+- [x] Send tab no-OAuth state: replaced the small warning badge with a full explanation card
+      ("Google account not connected") with a direct "Go to Setup" button and a note about
+      the manual Gmail fallback.
+- [x] Author credit "by Lenya Chan" added as subtitle in the welcome card.
+- [x] `loadSchema()` now navigates to tab 0 (Setup) instead of tab 1 after loading a schema.
+- [x] `render()` compose preview check updated from `S.tab===3` to `S.tab===2` after reorder.
+
+### ContactScout (contactscout_v02.html)
+
+- [x] Welcome banner added at the top of the page when no API key is set. Explains what
+      ContactScout does, what the Claude API key is for, and links to console.anthropic.com.
+- [x] Customization notice added in the Scan tab: detects if any SCAN_PROMPTS still contain
+      "[YOUR STATE]" and shows a yellow notice box explaining that the scan targets need to be
+      updated in the HTML source for the user's state/city. Includes the exact location in the
+      file and what to change.
+- [x] API key modal description updated: added link to console.anthropic.com and clarified
+      that free-tier keys work.
+
+### Index (index.html)
+
+- [x] Links updated to point to inviteflow_v02.html and contactscout_v02.html.
+- [x] "What you'll need" prerequisites section added below the flow diagram.
+
+### CLAUDE.md
+
+- [x] Author credit (Lenya Chan) added.
+- [x] Version naming convention documented.
+- [x] UX conventions section added.
+- [x] Reference to docs/ planning files added.
+
+---
+
+## v01 — Original
+
+- Initial implementation of two-app suite.
+- InviteFlow: 7-tab UI, Google Sheets + Gmail OAuth2 integration, schema management.
+- ContactScout: Claude API + web search for elected official discovery and verification.
+- No onboarding, no first-run experience, no step-by-step Google setup guide.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,110 @@
+# Invite Automation Suite — UX Improvement Roadmap
+
+Author: Lenya Chan
+Created: 2026-04-24
+
+---
+
+## Why This Exists
+
+The suite started as a personal tool and grew complex without a first-run experience or
+onboarding path. Even the author found it unclear where to start. This roadmap tracks the
+work needed to make the workflow clear enough that a person who only knows Google Docs and
+Sheets can complete an invite campaign without reading the README.
+
+---
+
+## The Core Problem
+
+Four blockers prevent a new user from getting anything done:
+
+1. The app opens on a "Events" tab that shows schema/config management — an alien concept
+   for someone who just wants to send invitations.
+2. Google OAuth setup requires creating a Google Cloud project, enabling two APIs, configuring
+   an OAuth consent screen, and generating credentials — with no step-by-step guide in the app.
+3. Tab order (Events → Setup → Invitees → Compose → Send → Tracker → Sync) doesn't match
+   the actual workflow (Setup → Invitees → Compose → Send → Track → Sync).
+4. Empty states are passive ("No invitees yet") rather than actionable guides.
+
+---
+
+## User Personas
+
+**Power user** — comfortable with APIs, GCP, OAuth. Can get going in 15 minutes. Current
+friction: tab ordering doesn't match workflow, "Events" tab name is misleading.
+
+**Semi-tech user** — reads READMEs, edits config files, not a developer. Understands what
+OAuth is conceptually but has never set up a GCP project. Current friction: OAuth setup
+requires undocumented steps (consent screen, test users, exact authorized origins).
+
+**Non-tech user** — knows how to open and edit Google Docs and Sheets, nothing more. Current
+friction: everything past the landing page. No onboarding, no plain-language explanations,
+no workflow guidance.
+
+---
+
+## Priority Groups
+
+### P0 — First-Run Blockers (all users hit these)
+
+- [x] Tab order does not match workflow — fixed in v02
+- [x] "Events" tab name is misleading — renamed to "Configs" in v02
+- [x] No onboarding or welcome state — welcome card added in v02
+- [x] Google OAuth setup is 3 lines of jargon — full 5-step guide added in v02
+- [x] Invitees empty state is passive — actionable buttons added in v02
+- [x] Send tab no-OAuth message is cryptic — plain-language guide added in v02
+- [x] ContactScout shows no guidance when API key is missing — welcome card added in v02
+- [x] ContactScout still has [YOUR STATE] placeholders with no notice — warning added in v02
+
+### P1 — High Value (each fixes 30–60% of remaining friction)
+
+- [ ] Google OAuth: Add "Test connection" button after Client ID is entered.
+      Currently the user cannot verify their Client ID works until they try to send or import,
+      which is the worst moment to discover a misconfiguration. A test button that calls a
+      minimal API endpoint would confirm connectivity immediately.
+
+- [ ] Google OAuth: Improve error messages from GSI.
+      Errors like "popup_closed_by_user", "access_denied", and "invalid_client" appear raw
+      in the activity log. Each should map to a plain-language explanation and a suggested fix.
+
+- [ ] Google OAuth: Token re-auth flow.
+      Tokens expire after ~1 hour. Currently, sending fails silently when a token expires mid-batch.
+      The app should detect expiry before bulk send and prompt for re-auth gracefully.
+
+- [ ] ContactScout: UI for configuring scan targets.
+      The current [YOUR STATE] / [YOUR COUNTIES] / [CITY N] placeholders in SCAN_TARGETS and
+      SCAN_PROMPTS require editing the HTML source. Non-tech and semi-tech users cannot do this.
+      A jurisdiction settings panel stored in localStorage would solve this.
+
+- [ ] Index page: Prerequisites checklist before entering the apps.
+      "What you'll need: a Google account, 5 minutes to set up Google Cloud, your guest list
+      as a spreadsheet or CSV." This sets expectations before anyone gets frustrated.
+
+### P2 — Polish (meaningful but not blocking)
+
+- [ ] Mobile / responsive layout. The apps are desktop-only; the stat card grids overflow on
+      small screens.
+
+- [ ] Error recovery: if a Gmail send fails partway through a batch, the log shows individual
+      errors but there's no "retry failed" button.
+
+- [ ] InviteFlow: Email preview in the Tracker tab so you can see what was sent to each invitee.
+
+- [ ] ContactScout: "Verify all" with a smarter rate-limit backoff (currently fixed 700ms sleep).
+
+### P3 — Future / Low Priority
+
+- [ ] Multi-event support (currently one active config at a time in InviteFlow).
+- [ ] Dark/light mode toggle.
+- [ ] CC/BCC support in bulk Gmail send.
+- [ ] Browser notification when a bulk send batch completes.
+- [ ] Internationalization (non-English recipient support).
+
+---
+
+## Assumptions
+
+- The GitHub Pages URL stays at `https://lychan110.github.io/automate-invite-emails/`.
+- The app remains no-build-step, no-framework, vanilla JS.
+- Google OAuth remains "external" app type in GCP (required for personal use outside a Workspace org).
+- File iteration naming: `{name}_v{N:02d}.html`, with the latest promoted to `{name}.html` once stable.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,92 @@
+# Current UX Tasks
+
+Author: Lenya Chan
+Updated: 2026-04-24
+
+---
+
+## In Progress
+
+None — v02 implementation just completed.
+
+---
+
+## Next Up (P1)
+
+### 1. Add "Test Google Connection" button in Setup
+
+When a user enters a Client ID, they have no way to know if it works until they attempt a
+real action (send or import). A failed send is the worst time to discover a misconfiguration.
+
+**Approach:** After Client ID is pasted, show a "Test connection" button. Clicking it calls
+`getGoogleToken('spreadsheets')` and then makes a minimal Sheets API call (list the user's
+spreadsheets). If it succeeds, show "✓ Connection verified". If it fails, show the specific
+error with a suggested fix (e.g., "invalid_client → check that your authorized origins
+include this page's URL").
+
+**Files:** `inviteflow_v02.html`, `getGoogleToken()` section, `renderSetup()`.
+
+---
+
+### 2. Map GSI errors to plain-language messages
+
+Raw error codes from Google Identity Services appear in the activity log without context.
+Common codes and their plain-language fixes:
+
+| GSI error | Plain-language explanation |
+|-----------|---------------------------|
+| `popup_closed_by_user` | You closed the Google sign-in popup. Click the button again. |
+| `access_denied` | You did not grant permission. Try again and click "Allow". |
+| `invalid_client` | The Client ID is wrong or your page URL is not in the authorized origins list. |
+| `popup_blocked_by_browser` | Your browser blocked the popup. Allow popups for this site, then try again. |
+
+**Approach:** Wrap `getGoogleToken()` catch blocks with a lookup map. Append the plain-language
+message to the log entry.
+
+**Files:** `inviteflow_v02.html`, `getGoogleToken()`.
+
+---
+
+### 3. Handle token expiry before bulk send
+
+Tokens from Google Identity Services expire after ~1 hour. If a batch send starts and the
+token expires mid-batch, sends fail silently. The user sees "failed: Unauthorized" with no
+explanation.
+
+**Approach:** In `sendBulkEmails()`, check `_tokens['gmail.send']?.expires` against
+`Date.now()` before starting the loop. If the token is expired or within 5 minutes of
+expiring, call `getGoogleToken('gmail.send')` first (which triggers re-auth). Also add a
+note in the Send tab UI showing when the current token expires.
+
+**Files:** `inviteflow_v02.html`, `sendBulkEmails()`, `renderSend()`.
+
+---
+
+### 4. ContactScout: Jurisdiction settings panel
+
+The [YOUR STATE], [YOUR COUNTIES], and [CITY N] placeholders in `SCAN_TARGETS` and
+`SCAN_PROMPTS` require editing the HTML source. This is impossible for non-tech users and
+inconvenient even for power users.
+
+**Approach:** Add a "Jurisdiction" settings section in a new Settings modal or sidebar panel.
+Store jurisdiction values (state name, county names, city names) in localStorage under a new
+key `contactscout_jurisdiction`. At startup, replace placeholder strings in SCAN_PROMPTS with
+values from localStorage. Provide a form UI to configure state, counties (comma-separated),
+and up to 3 cities.
+
+**Files:** `contactscout_v02.html`, new Settings modal, SCAN_PROMPTS generation.
+
+---
+
+## Backlog (P2/P3)
+
+- [ ] Mobile-responsive layouts (stat card grids overflow on screens < 480px).
+- [ ] Retry failed sends: after bulk send, show a "Retry X failed" button that re-runs only
+      the failed recipients.
+- [ ] Email preview in Tracker: for each sent invitee, show a preview of the email they received.
+- [ ] InviteFlow: CC/BCC field support in bulk Gmail send.
+- [ ] ContactScout: smarter rate-limit backoff for verify batch (currently fixed 700ms between
+      calls regardless of API response headers).
+- [ ] Browser notification on bulk send completion (Notifications API, requires permission).
+- [ ] Multi-event mode: allow switching between multiple active InviteFlow configs without
+      losing invitee data.

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ h1{font-family:'Syne',sans-serif;font-size:26px;font-weight:800;color:#f0f6fc;le
 <body>
 <div class="wrap">
   <h1>INVITE AUTOMATION SUITE</h1>
-  <div class="sub">CONTACT RESEARCH · INVITE WORKFLOW · RSVP TRACKING</div>
+  <div class="sub">CONTACT RESEARCH · INVITE WORKFLOW · RSVP TRACKING · BY LENYA CHAN</div>
 
   <div class="flow">
     <span class="flow-step">1. ContactScout</span>
@@ -42,7 +42,7 @@ h1{font-family:'Syne',sans-serif;font-size:26px;font-weight:800;color:#f0f6fc;le
   </div>
 
   <div class="cards">
-    <a class="card" href="contactscout.html">
+    <a class="card" href="contactscout_v02.html">
       <div class="card-name">ContactScout <span class="badge" style="border-color:#1f6feb;color:#58a6ff">CLAUDE API</span></div>
       <div class="card-file">contactscout.html</div>
       <div class="card-desc">
@@ -51,7 +51,7 @@ h1{font-family:'Syne',sans-serif;font-size:26px;font-weight:800;color:#f0f6fc;le
         Export a verified contact list for InviteFlow.
       </div>
     </a>
-    <a class="card" href="inviteflow.html">
+    <a class="card" href="inviteflow_v02.html">
       <div class="card-name">InviteFlow <span class="badge" style="border-color:#238636;color:#3fb950">AUTO-SAVE</span></div>
       <div class="card-file">inviteflow.html</div>
       <div class="card-desc">
@@ -60,6 +60,28 @@ h1{font-family:'Syne',sans-serif;font-size:26px;font-weight:800;color:#f0f6fc;le
         Track sent / RSVP status. Auto-saves to browser storage.
       </div>
     </a>
+  </div>
+
+  <div style="background:#0d1117;border:1px solid #21262d;border-radius:6px;padding:16px 18px;margin-bottom:28px">
+    <div style="font-size:9px;color:#6e7681;letter-spacing:.12em;margin-bottom:10px">WHAT YOU WILL NEED</div>
+    <div style="display:flex;flex-direction:column;gap:7px">
+      <div style="display:flex;gap:10px;align-items:flex-start">
+        <span style="color:#3fb950;font-size:11px;flex-shrink:0">✓</span>
+        <div style="font-size:11px;color:#8b949e;line-height:1.6"><strong style="color:#c9d1d9">A Google account</strong> — the same one you use for Gmail and Google Sheets. Used by InviteFlow to send email and read/write spreadsheets.</div>
+      </div>
+      <div style="display:flex;gap:10px;align-items:flex-start">
+        <span style="color:#3fb950;font-size:11px;flex-shrink:0">✓</span>
+        <div style="font-size:11px;color:#8b949e;line-height:1.6"><strong style="color:#c9d1d9">5 minutes to set up Google Cloud</strong> — free, one-time setup. InviteFlow walks you through it step by step in the Setup tab.</div>
+      </div>
+      <div style="display:flex;gap:10px;align-items:flex-start">
+        <span style="color:#e3b341;font-size:11px;flex-shrink:0">○</span>
+        <div style="font-size:11px;color:#8b949e;line-height:1.6"><strong style="color:#c9d1d9">A Claude API key</strong> (ContactScout only) — free tier available at <a href="https://console.anthropic.com/" target="_blank" style="color:#58a6ff">console.anthropic.com</a>. Not needed for InviteFlow.</div>
+      </div>
+      <div style="display:flex;gap:10px;align-items:flex-start">
+        <span style="color:#e3b341;font-size:11px;flex-shrink:0">○</span>
+        <div style="font-size:11px;color:#8b949e;line-height:1.6"><strong style="color:#c9d1d9">Your guest list</strong> — as a Google Sheet or a CSV file, or you can add people manually inside InviteFlow.</div>
+      </div>
+    </div>
   </div>
 
   <div class="footer">OPEN IN BROWSER · NO INSTALL · NO SERVER REQUIRED</div>

--- a/inviteflow_v02.html
+++ b/inviteflow_v02.html
@@ -1,0 +1,1400 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>InviteFlow — Invite Automation Suite</title>
+<!-- Google Identity Services for OAuth2 (Gmail + Sheets) -->
+<script src="https://accounts.google.com/gsi/client" async defer></script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Syne:wght@700;800&display=swap');
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:#080c10;color:#c9d1d9;font-family:'DM Mono','Courier New',monospace;height:100vh;overflow:hidden;display:flex;flex-direction:column}
+::-webkit-scrollbar{width:5px}::-webkit-scrollbar-track{background:#0d1117}::-webkit-scrollbar-thumb{background:#21262d;border-radius:3px}
+.btn{border:1px solid #21262d;background:#0d1117;color:#8b949e;padding:6px 13px;border-radius:5px;cursor:pointer;font-family:inherit;font-size:11px;letter-spacing:.05em;transition:all .15s}
+.btn:hover{border-color:#58a6ff;color:#58a6ff}
+.btn.pri{background:#1f6feb;border-color:#1f6feb;color:#fff}.btn.pri:hover{background:#388bfd}
+.btn.grn{background:#238636;border-color:#238636;color:#fff}.btn.grn:hover{background:#2ea043}
+.btn.gold{background:#3d2800;border-color:#C8A84B;color:#C8A84B}.btn.gold:hover{background:#C8A84B;color:#000}
+.btn.sm{padding:4px 9px;font-size:10px}
+.btn.stop{border-color:#da3633;color:#f85149}.btn.stop:hover{background:#da3633;color:#fff}
+.btn:disabled{opacity:.35;cursor:not-allowed}
+.tag{display:inline-block;font-size:9px;padding:2px 6px;border-radius:3px;letter-spacing:.07em;border:1px solid}
+.cat{border:1px solid #21262d;background:transparent;color:#6e7681;padding:4px 10px;border-radius:20px;cursor:pointer;font-family:inherit;font-size:10px;transition:all .15s}
+.cat.on{border-color:#C8A84B;color:#C8A84B;background:#2a1a00}.cat:hover:not(.on){color:#c9d1d9;border-color:#30363d}
+input[type=checkbox]{accent-color:#C8A84B}
+.ifield{background:#0d1117;border:1px solid #21262d;color:#c9d1d9;padding:6px 10px;border-radius:5px;font-family:inherit;font-size:11px;outline:none;width:100%;transition:border-color .15s}
+.ifield:focus{border-color:#C8A84B}
+.ritem{transition:background .1s;cursor:pointer}.ritem:hover{background:#0d1117}
+.card{background:#0d1117;border:1px solid #21262d;border-radius:7px;padding:14px 16px;margin-bottom:10px}
+.sl{font-size:9px;color:#6e7681;letter-spacing:.12em;margin-bottom:7px;margin-top:14px}
+.modal-bg{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.88);z-index:200;display:flex;align-items:center;justify-content:center}
+.modal{background:#0d1117;border:1px solid #21262d;border-radius:8px;width:560px;max-height:82vh;overflow-y:auto;padding:22px 26px}
+.pbar-wrap{height:4px;background:#161b22;border-radius:2px;overflow:hidden;margin-top:8px}
+.pbar{height:100%;background:#C8A84B;border-radius:2px;transition:width .3s}
+/* pie chart pure CSS */
+.pie-seg{display:inline-block;width:14px;height:14px;border-radius:50%;vertical-align:middle;margin-right:5px}
+</style>
+</head>
+<body>
+<div id="root" style="display:flex;flex-direction:column;height:100vh;overflow:hidden"></div>
+<script>
+// ═══════════════════════════════════════════════════════════════════════════════
+// IMAGES
+// ═══════════════════════════════════════════════════════════════════════════════
+const IMAGES = { EMBLEM:'', LOGO:'', SIGNATURE:'' };
+let IMAGE_OVERRIDES = { EMBLEM:'', LOGO:'', SIGNATURE:'' };
+function img(key) {
+  const ov = IMAGE_OVERRIDES[key];
+  if (ov) {
+    if (IMAGE_OVERRIDES[key+'_mode']==='gdrive')
+      return 'https://drive.google.com/uc?export=view&id='+ov.trim();
+    return ov.trim();
+  }
+  return IMAGES[key];
+}
+function syncImageOverrides() {
+  IMAGE_OVERRIDES = {
+    EMBLEM: S.event.imgEmblemUrl||'', LOGO: S.event.imgLogoUrl||'', SIGNATURE: S.event.imgSigUrl||'',
+    EMBLEM_mode: S.event.imgEmblemMode||'embedded',
+    LOGO_mode:   S.event.imgLogoMode||'embedded',
+    SIGNATURE_mode: S.event.imgSigMode||'embedded',
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// EMAIL TEMPLATE
+// ═══════════════════════════════════════════════════════════════════════════════
+const EMAIL_TEMPLATE = `
+<div style="width:100%;max-width:680px;min-width:280px;margin:0 auto;font-family:Georgia,'Times New Roman',serif;color:#1a1a1a;background:#ffffff">
+  <div style="background:#8B1A1A;height:5px"></div>
+  <div style="background:linear-gradient(90deg,#8B1A1A 0%,#C8A84B 50%,#8B1A1A 100%);height:1px"></div>
+  <div style="background:#0d0d0d;padding:32px 44px 26px;text-align:center">
+    <img src="__IMG_EMBLEM__" alt="Event Emblem" style="width:180px;max-width:180px;height:auto;display:inline-block;margin-bottom:18px">
+    <div style="color:#C8A84B;font-size:9px;letter-spacing:5px;font-family:Arial,sans-serif;text-transform:uppercase;margin-bottom:10px">{{OrgName}}</div>
+    <div style="background:linear-gradient(90deg,transparent,#C8A84B,transparent);height:1px;margin:0 40px 14px"></div>
+    <div style="color:#f5ede0;font-size:22px;font-weight:normal;line-height:1.35;letter-spacing:.5px">{{FullTitle}}</div>
+    <div style="color:#C8A84B;font-size:10px;letter-spacing:4px;font-family:Arial,sans-serif;margin-top:10px;text-transform:uppercase">{{EventName}} &nbsp;&middot;&nbsp; {{EventDate}}</div>
+    <div style="background:linear-gradient(90deg,transparent,#C8A84B,transparent);height:1px;margin:14px 40px 0"></div>
+  </div>
+  <div style="background:#8B1A1A;height:3px"></div>
+  <div style="padding:40px 48px 32px;background:#fffdf8">
+    <p style="font-size:13px;color:#777;font-family:Arial,sans-serif;margin:0 0 22px">{{Date_Sent}}</p>
+    <p style="font-size:15px;margin:0 0 22px;color:#1a1a1a;line-height:1.5">Dear Honorable {{FirstName}} {{LastName}},</p>
+    <p style="font-size:14px;line-height:1.9;margin:0 0 18px;color:#2c2c2c">
+      On behalf of <strong>{{OrgName}}</strong>, we respectfully invite you to <strong>{{EventName}}</strong> — <strong>{{FullTitle}}</strong> — on <strong>{{EventDate}}</strong>, at <strong>{{Venue}}</strong>.
+    </p>
+    <p style="font-size:14px;line-height:1.9;margin:0 0 18px;color:#2c2c2c">
+      We would be deeply honored to welcome you as our distinguished guest. The VIP program — including the Opening Ceremony and Reception — is scheduled from <strong>{{VIPStart}} until {{VIPEnd}}</strong>, featuring cultural stage performances and community festivities.
+    </p>
+    <div style="border-left:2px solid #C8A84B;margin:24px 0;padding:12px 20px;background:#fff8ee">
+      <p style="font-size:13px;color:#8B1A1A;font-style:italic;line-height:1.8;margin:0">
+        Dragon boat festivals draw hundreds of thousands of spectators worldwide. The Greater Triangle festival has grown to an estimated attendance of <strong>10,000</strong>, reflecting the region's vibrant and engaged Asian community.
+      </p>
+    </div>
+    <p style="font-size:14px;line-height:1.9;margin:0 0 28px;color:#2c2c2c">
+      To assist us in preparing the Opening Ceremony, we respectfully request your RSVP at your earliest convenience. Should you be unable to attend in person, you are most welcome to send a representative.
+    </p>
+    <div style="text-align:center;margin:30px 0 22px">
+      <a href="{{RSVP_Link}}" style="display:inline-block;background:#8B1A1A;color:#f5ede0;text-decoration:none;padding:15px 48px;font-family:Arial,sans-serif;font-size:12px;letter-spacing:3px;text-transform:uppercase;border:1px solid #C8A84B">RSVP &nbsp;&middot;&nbsp; Reserve Your Place</a>
+      <div style="margin-top:10px;font-size:11px;color:#aaa;font-family:Arial,sans-serif">or reply directly to this email</div>
+    </div>
+    <p style="font-size:13px;line-height:1.8;color:#555;font-family:Arial,sans-serif;margin:24px 0 0">
+      For inquiries, please contact <strong>{{ContactName}}</strong>, {{ContactTitle}}, at <a href="mailto:{{ContactEmail}}" style="color:#8B1A1A;text-decoration:underline">{{ContactEmail}}</a>.
+    </p>
+  </div>
+  <div style="background:linear-gradient(90deg,transparent,#C8A84B,transparent);height:1px;margin:0 48px"></div>
+  <div style="padding:28px 48px 32px;background:#fffdf8">
+    <p style="font-size:14px;line-height:1.7;margin:0 0 16px;color:#2c2c2c">We look forward to your presence at this important cultural celebration.</p>
+    <p style="font-size:14px;margin:0 0 10px;color:#2c2c2c">Respectfully yours,</p>
+    <img src="__IMG_LOGO__" alt="Signature" style="width:180px;max-width:180px;height:auto;display:block;margin:8px 0 0">
+  </div>
+  <div style="background:linear-gradient(90deg,transparent,#C8A84B,transparent);height:1px"></div>
+  <div style="background:#0d0d0d;padding:20px 36px">
+    <table style="width:100%;border-collapse:collapse"><tr>
+      <td style="vertical-align:middle;width:140px;padding:0">
+        <img src="__IMG_SIGNATURE__" alt="{{OrgName}}" style="width:120px;height:auto;display:block">
+      </td>
+      <td style="vertical-align:middle;padding:0 0 0 16px">
+        <div style="color:#C8A84B;font-size:10px;font-family:Arial,sans-serif;letter-spacing:2px;text-transform:uppercase">{{OrgName}}</div>
+        <div style="color:#666;font-size:10px;font-family:Arial,sans-serif;margin-top:4px;line-height:1.6">{{OrgLocation}}</div>
+      </td>
+    </tr></table>
+  </div>
+  <div style="background:linear-gradient(90deg,#8B1A1A 0%,#C8A84B 50%,#8B1A1A 100%);height:1px"></div>
+  <div style="background:#8B1A1A;height:4px"></div>
+</div>`;
+
+function buildEmail(firstName, lastName, event) {
+  const E = event || S.event;
+  const inv = {name: (firstName||'') + ' ' + (lastName||'')};
+  return EMAIL_TEMPLATE
+    .replace(/__IMG_EMBLEM__/g,    img('EMBLEM'))
+    .replace(/__IMG_LOGO__/g,      img('LOGO'))
+    .replace(/__IMG_SIGNATURE__/g, img('SIGNATURE'))
+    .replace(/\{\{Date_Sent\}\}/g,    E.sentDate     || '')
+    .replace(/\{\{FirstName\}\}/g,    firstName      || '')
+    .replace(/\{\{LastName\}\}/g,     lastName       || '')
+    .replace(/\{\{FullTitle\}\}/g,    E.fullTitle     || '')
+    .replace(/\{\{OrgName\}\}/g,      E.org          || '')
+    .replace(/\{\{EventName\}\}/g,    E.eventName    || '')
+    .replace(/\{\{EventDate\}\}/g,    E.eventDate    || '')
+    .replace(/\{\{Venue\}\}/g,        E.venue        || '')
+    .replace(/\{\{VIPStart\}\}/g,     E.vipStart     || '')
+    .replace(/\{\{VIPEnd\}\}/g,       E.vipEnd       || '')
+    .replace(/\{\{ContactName\}\}/g,  E.contactName  || '')
+    .replace(/\{\{ContactTitle\}\}/g, E.contactTitle || '')
+    .replace(/\{\{ContactEmail\}\}/g, E.contactEmail || '')
+    .replace(/\{\{OrgLocation\}\}/g,  E.orgLocation  || '')
+    .replace(/\{\{RSVP_Link\}\}/g,    buildRsvpLink(inv) || E.rsvpLink || '#');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// DEFAULTS & STATE
+// ═══════════════════════════════════════════════════════════════════════════════
+const DEFAULT_EVENT = {
+  profileName:'', eventName:'', fullTitle:'', eventDate:'', venue:'',
+  vipStart:'', vipEnd:'', rsvpLink:'', org:'', contactName:'', contactTitle:'',
+  contactEmail:'', emailSubject:'', orgLocation:'', sheetId:'',
+  sentDate: new Date().toLocaleDateString('en-US',{year:'numeric',month:'long',day:'numeric'}),
+  // Google integration
+  inviteeSheetUrl:'', masterSheetUrl:'', rsvpResponseUrl:'',
+  formUrl:'', entryName:'', entryEmail:'',
+  // Images
+  imgEmblemMode:'embedded', imgEmblemUrl:'',
+  imgLogoMode:'embedded',   imgLogoUrl:'',
+  imgSigMode:'embedded',    imgSigUrl:'',
+};
+
+const S = {
+  tab: 0, modal: null,
+  event: {...DEFAULT_EVENT},
+  invitees: [],
+  inviteFilter: 'all',
+  rsvpFilter: 'all',
+  previewName: null,
+  unsaved: false,
+  log: [],
+  // Email template
+  tplMode: 'html',
+  textSubject: "You're cordially invited: {{EventName}}",
+  textBody: "Dear Honorable {{FirstName}} {{LastName}},\n\nWe respectfully invite you to {{EventName}} on {{EventDate}} at {{Venue}}.\n\nPlease RSVP: {{RSVP_Link}}\n\nRespectfully,\n{{ContactName}}",
+  htmlBody: '',
+  // Send state
+  sending: false,
+  sendProgress: {sent:0, failed:0, total:0, current:''},
+  sendLog: [],
+  // Schemas
+  schemas: [],
+  schemaNameDraft: '',
+  activeSchemaId: null,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RSVP LINK BUILDER (client-side, no API needed)
+// ═══════════════════════════════════════════════════════════════════════════════
+function buildRsvpLink(inv) {
+  const e = S.event;
+  if (!e.formUrl) return e.rsvpLink || '';
+  const base = e.formUrl.replace(/\?.*$/, '');
+  const parts = [];
+  const nameParts = (inv.name||'').trim().split(/\s+/);
+  const firstName = nameParts[0]||'';
+  const lastName  = nameParts.slice(1).join(' ')||'';
+  const fullName  = inv.name||'';
+  if (e.entryName)  parts.push('entry.' + e.entryName  + '=' + encodeURIComponent(fullName));
+  if (e.entryEmail) parts.push('entry.' + e.entryEmail + '=' + encodeURIComponent(inv.email||''));
+  parts.push('usp=pp_url');
+  return base + '?' + parts.join('&');
+}
+
+function generateAllRsvpLinks() {
+  S.invitees.forEach(inv => { inv.rsvpLink = buildRsvpLink(inv); });
+  S.unsaved = true;
+  log('✓ RSVP links generated for ' + S.invitees.length + ' invitees.');
+  render();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GOOGLE OAUTH2
+// ═══════════════════════════════════════════════════════════════════════════════
+// One token client per scope (cached until page reload)
+const _tokenClients = {};
+let _tokens = {};
+
+function getGoogleToken(scope) {
+  return new Promise((resolve, reject) => {
+    const clientId = S.googleClientId;
+    if (!clientId) return reject(new Error('No Google OAuth Client ID configured. Go to Setup → Google API Keys.'));
+    if (!window.google) return reject(new Error('Google Identity Services not loaded yet — try again in a moment.'));
+    const cached = _tokens[scope];
+    if (cached && cached.expires > Date.now()) return resolve(cached.token);
+    if (!_tokenClients[scope]) {
+      _tokenClients[scope] = window.google.accounts.oauth2.initTokenClient({
+        client_id: clientId,
+        scope: 'https://www.googleapis.com/auth/' + scope,
+        callback: resp => {
+          if (resp.error) { _tokenClients[scope]._rej(new Error(resp.error)); return; }
+          _tokens[scope] = { token: resp.access_token, expires: Date.now() + (resp.expires_in||3500)*1000 };
+          _tokenClients[scope]._res(resp.access_token);
+        },
+      });
+    }
+    _tokenClients[scope]._res = resolve;
+    _tokenClients[scope]._rej = reject;
+    _tokenClients[scope].requestAccessToken({ prompt: '' });
+  });
+}
+
+function sheetIdFromUrl(url) {
+  if (!url) return '';
+  const m = url.match(/\/spreadsheets\/d\/([a-zA-Z0-9_-]+)/);
+  return m ? m[1] : url.trim();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GOOGLE SHEETS: IMPORT INVITEES
+// ═══════════════════════════════════════════════════════════════════════════════
+async function importFromSheet() {
+  const url = S.event.inviteeSheetUrl;
+  if (!url) { log('✗ Set Invitee Sheet URL in Setup first.'); return; }
+  log('Connecting to Google Sheets…');
+  let token;
+  try { token = await getGoogleToken('spreadsheets'); }
+  catch(e) { log('✗ Auth failed: ' + e.message); return; }
+  const sid = sheetIdFromUrl(url);
+  try {
+    const res = await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${sid}/values/A:Z`, {
+      headers: { Authorization: 'Bearer ' + token }
+    });
+    if (!res.ok) throw new Error('HTTP ' + res.status + ' — check Sheet is shared or URL is correct');
+    const data = await res.json();
+    const rows = data.values || [];
+    if (rows.length < 2) { log('✗ Sheet appears empty or has no data rows.'); return; }
+    const hdr = rows[0].map(h => h.toString().trim().toLowerCase().replace(/\s+/g,'_'));
+    const col = k => hdr.indexOf(k);
+    let added=0, updated=0;
+    rows.slice(1).forEach(row => {
+      const get = (k, ...alts) => {
+        const idx = col(k) >= 0 ? col(k) : alts.map(a=>col(a)).find(i=>i>=0) ?? -1;
+        return idx >= 0 ? (row[idx]||'').trim() : '';
+      };
+      const firstName = get('firstname','first_name','first');
+      const lastName  = get('lastname','last_name','last');
+      const name = get('name') || (firstName && lastName ? firstName+' '+lastName : firstName||lastName);
+      if (!name) return;
+      const email = get('email','office_email','direct_email','email_address');
+      const existing = S.invitees.find(i => i.name === name);
+      if (existing) {
+        existing.email    = email || existing.email;
+        existing.title    = get('title') || existing.title;
+        existing.category = get('category') || existing.category;
+        updated++;
+      } else {
+        S.invitees.push({
+          name, email,
+          title:    get('title'),
+          category: get('category'),
+          rsvpLink: '',
+          inviteStatus: 'not_sent', sentAt: '',
+          rsvpStatus: 'no_response', rsvpDate: '',
+          notes: get('notes'),
+        });
+        added++;
+      }
+    });
+    S.unsaved = true;
+    log(`✓ Sheet import: +${added} new, ${updated} updated. Total: ${S.invitees.length}`);
+    render();
+  } catch(e) { log('✗ Import failed: ' + e.message); }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GOOGLE SHEETS: SYNC TO MASTER
+// ═══════════════════════════════════════════════════════════════════════════════
+async function syncToMasterSheet() {
+  const url = S.event.masterSheetUrl;
+  if (!url) { log('✗ Set Master Sheet URL in Setup first.'); return; }
+  log('Syncing to Master Sheet…');
+  let token;
+  try { token = await getGoogleToken('spreadsheets'); }
+  catch(e) { log('✗ Auth failed: ' + e.message); return; }
+  const sid = sheetIdFromUrl(url);
+  const headers = ['FirstName','LastName','Title','Category','Email','RSVP_Link','InviteSent','InviteSentDate','RSVP_Status','RSVP_Date','Notes'];
+  const values = [headers, ...S.invitees.map(inv => {
+    const parts = (inv.name||'').trim().split(/\s+/);
+    return [
+      parts[0]||'', parts.slice(1).join(' ')||'',
+      inv.title||'', inv.category||'', inv.email||'',
+      inv.rsvpLink || buildRsvpLink(inv),
+      inv.inviteStatus==='sent'?'TRUE':'FALSE',
+      inv.sentAt ? new Date(inv.sentAt).toLocaleDateString() : '',
+      inv.rsvpStatus||'no_response',
+      inv.rsvpDate||'',
+      inv.notes||'',
+    ];
+  })];
+  try {
+    // Clear then write
+    await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${sid}/values/A:Z:clear`, {
+      method: 'POST', headers: { Authorization: 'Bearer ' + token, 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const res = await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${sid}/values/A1?valueInputOption=RAW`, {
+      method: 'PUT',
+      headers: { Authorization: 'Bearer ' + token, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ values }),
+    });
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    log(`✓ Master Sheet synced — ${S.invitees.length} rows written.`);
+  } catch(e) { log('✗ Sync failed: ' + e.message); }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GOOGLE SHEETS: SYNC RSVP RESPONSES
+// ═══════════════════════════════════════════════════════════════════════════════
+async function syncRsvpResponses() {
+  const url = S.event.rsvpResponseUrl;
+  if (!url) { log('✗ Set RSVP Response Sheet URL in Setup first.'); return; }
+  log('Reading RSVP responses…');
+  let token;
+  try { token = await getGoogleToken('spreadsheets'); }
+  catch(e) { log('✗ Auth failed: ' + e.message); return; }
+  const sid = sheetIdFromUrl(url);
+  try {
+    const res = await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${sid}/values/A:Z`, {
+      headers: { Authorization: 'Bearer ' + token }
+    });
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    const rows = data.values || [];
+    if (rows.length < 2) { log('No responses found in sheet.'); return; }
+    const hdr = rows[0].map(h => h.toString().trim().toLowerCase().replace(/\s+/g,'_'));
+    const emailCol = hdr.findIndex(h => h.includes('email'));
+    const rsvpCol  = hdr.findIndex(h => h.includes('rsvp') || h.includes('attend') || h.includes('status'));
+    const tsCol    = hdr.findIndex(h => h.includes('timestamp'));
+    if (emailCol < 0) { log('✗ No email column found in response sheet.'); return; }
+    // Build response map: email → {status, date}
+    const map = {};
+    rows.slice(1).forEach(row => {
+      const email = (row[emailCol]||'').trim().toLowerCase();
+      if (!email) return;
+      const rawStatus = (row[rsvpCol]||'').trim().toLowerCase();
+      const status = rawStatus.includes('yes')||rawStatus.includes('attend')||rawStatus.includes('confirm') ? 'confirmed'
+                   : rawStatus.includes('no')||rawStatus.includes('declin') ? 'declined' : 'pending';
+      const ts = tsCol >= 0 ? (row[tsCol]||'') : '';
+      const dateStr = ts ? new Date(ts).toLocaleDateString() : new Date().toLocaleDateString();
+      map[email] = { status, date: dateStr };
+    });
+    let updated = 0;
+    S.invitees.forEach(inv => {
+      const key = (inv.email||'').toLowerCase();
+      if (map[key]) {
+        inv.rsvpStatus = map[key].status;
+        inv.rsvpDate   = map[key].date;
+        updated++;
+      }
+    });
+    S.unsaved = true;
+    log(`✓ RSVP sync: ${updated} responses matched.`);
+    render();
+  } catch(e) { log('✗ RSVP sync failed: ' + e.message); }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GMAIL OAUTH2 SEND
+// ═══════════════════════════════════════════════════════════════════════════════
+function toBase64Url(str) {
+  const bytes = new TextEncoder().encode(str);
+  return btoa(String.fromCharCode(...bytes)).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+}
+
+function buildMimeRaw(toEmail, toName, subject, body, isHtml) {
+  return toBase64Url([
+    `To: "${toName}" <${toEmail}>`,
+    `Subject: ${subject}`,
+    'MIME-Version: 1.0',
+    `Content-Type: ${isHtml?'text/html':'text/plain'}; charset=utf-8`,
+    '',
+    body,
+  ].join('\r\n'));
+}
+
+function personalize(text, inv) {
+  const E = S.event;
+  const nameParts = (inv.name||'').trim().split(/\s+/);
+  return (text||'')
+    .replace(/\{\{FirstName\}\}/g,    nameParts[0]||'')
+    .replace(/\{\{LastName\}\}/g,     nameParts.slice(1).join(' ')||'')
+    .replace(/\{\{FullName\}\}/g,     inv.name||'')
+    .replace(/\{\{FullTitle\}\}/g,    E.fullTitle||'')
+    .replace(/\{\{EventName\}\}/g,    E.eventName||'')
+    .replace(/\{\{EventDate\}\}/g,    E.eventDate||'')
+    .replace(/\{\{Venue\}\}/g,        E.venue||'')
+    .replace(/\{\{VIPStart\}\}/g,     E.vipStart||'')
+    .replace(/\{\{VIPEnd\}\}/g,       E.vipEnd||'')
+    .replace(/\{\{OrgName\}\}/g,      E.org||'')
+    .replace(/\{\{ContactName\}\}/g,  E.contactName||'')
+    .replace(/\{\{ContactTitle\}\}/g, E.contactTitle||'')
+    .replace(/\{\{ContactEmail\}\}/g, E.contactEmail||'')
+    .replace(/\{\{Date_Sent\}\}/g,    E.sentDate||'')
+    .replace(/\{\{RSVP_Link\}\}/g,    inv.rsvpLink || buildRsvpLink(inv) || E.rsvpLink||'#');
+}
+
+let _sendAbort = false;
+
+async function sendBulkEmails(filter) {
+  if (S.sending) return;
+  const targets = filter==='unsent'
+    ? S.invitees.filter(i=>i.email && i.inviteStatus!=='sent' && i.inviteStatus!=='skipped')
+    : S.invitees.filter(i=>i.email && i.inviteStatus!=='skipped');
+  if (!targets.length) { log('No eligible invitees to send to.'); return; }
+
+  let token;
+  try { token = await getGoogleToken('gmail.send'); }
+  catch(e) { log('✗ Gmail auth failed: ' + e.message); return; }
+
+  _sendAbort = false;
+  S.sending = true;
+  S.sendProgress = {sent:0, failed:0, total:targets.length, current:''};
+  S.sendLog = [];
+  render();
+
+  for (const inv of targets) {
+    if (_sendAbort) break;
+    S.sendProgress.current = inv.name;
+    render();
+    const subject = personalize(S.event.emailSubject || S.textSubject, inv);
+    const body    = S.tplMode==='html' ? buildEmail(inv.name.split(' ')[0], inv.name.split(' ').slice(1).join(' ')) : personalize(S.textBody, inv);
+    const isHtml  = S.tplMode==='html';
+    let status = 'sent';
+    try {
+      const res = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer ' + token, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ raw: buildMimeRaw(inv.email, inv.name, subject, body, isHtml) }),
+      });
+      if (!res.ok) { const err = await res.json(); throw new Error(err.error?.message||'Send failed'); }
+      inv.inviteStatus = 'sent';
+      inv.sentAt = new Date().toISOString();
+      S.sendProgress.sent++;
+    } catch(e) {
+      status = 'failed: ' + e.message;
+      S.sendProgress.failed++;
+    }
+    S.sendLog.push({name:inv.name, email:inv.email, status, ts: new Date().toLocaleTimeString()});
+    await new Promise(r=>setTimeout(r,350));
+  }
+  S.sending = false;
+  S.sendProgress.current = '';
+  S.unsaved = true;
+  log(`✓ Done: ${S.sendProgress.sent} sent, ${S.sendProgress.failed} failed.`);
+  render();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// LOCAL STORAGE
+// ═══════════════════════════════════════════════════════════════════════════════
+const LS_KEY = 'inviteflow_state';
+
+function saveState() {
+  try {
+    localStorage.setItem(LS_KEY, JSON.stringify({
+      event: S.event, invitees: S.invitees,
+      tplMode: S.tplMode, textSubject: S.textSubject,
+      textBody: S.textBody, htmlBody: S.htmlBody,
+      schemas: S.schemas, activeSchemaId: S.activeSchemaId,
+      schemaNameDraft: S.schemaNameDraft,
+      googleClientId: S.googleClientId||'',
+    }));
+  } catch(e) {}
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return;
+    const d = JSON.parse(raw);
+    if (d.event)     { S.event = {...DEFAULT_EVENT, ...d.event}; syncImageOverrides(); }
+    if (d.invitees)  S.invitees = d.invitees.map(i=>({rsvpLink:'',inviteStatus:'not_sent',rsvpStatus:'no_response',rsvpDate:'',sentAt:'',notes:'',...i}));
+    if (d.tplMode)   S.tplMode = d.tplMode;
+    if (d.textSubject) S.textSubject = d.textSubject;
+    if (d.textBody)  S.textBody = d.textBody;
+    if (d.htmlBody)  S.htmlBody = d.htmlBody;
+    if (d.schemas)   S.schemas = d.schemas;
+    if (d.activeSchemaId) S.activeSchemaId = d.activeSchemaId;
+    if (d.schemaNameDraft) S.schemaNameDraft = d.schemaNameDraft;
+    if (d.googleClientId) S.googleClientId = d.googleClientId;
+    S.unsaved = false;
+  } catch(e) {}
+}
+
+function clearSavedState() {
+  localStorage.removeItem(LS_KEY);
+  Object.assign(S, {event:{...DEFAULT_EVENT},invitees:[],tplMode:'html',textSubject:"You're cordially invited: {{EventName}}",textBody:'',htmlBody:'',sendLog:[],schemas:[],activeSchemaId:null,schemaNameDraft:'',unsaved:false,modal:null});
+  syncImageOverrides();
+  log('✓ Saved data cleared.'); render();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SCHEMA MANAGEMENT (saved event configs)
+// ═══════════════════════════════════════════════════════════════════════════════
+function currentSchema() {
+  return {
+    id: S.activeSchemaId || 'schema_' + Date.now(),
+    name: S.schemaNameDraft || S.event.profileName || 'Untitled',
+    savedAt: new Date().toISOString(),
+    event: {...S.event},
+    tplMode: S.tplMode, textSubject: S.textSubject,
+    textBody: S.textBody, htmlBody: S.htmlBody,
+  };
+}
+
+function saveSchema() {
+  if (!S.schemaNameDraft.trim()) { log('Enter a schema name first.'); return; }
+  const sc = currentSchema();
+  S.schemas = [sc, ...S.schemas.filter(s=>s.id!==sc.id)];
+  S.activeSchemaId = sc.id;
+  log('✓ Schema saved: ' + sc.name); render();
+}
+
+function loadSchema(sc) {
+  S.event = {...DEFAULT_EVENT, ...sc.event};
+  S.tplMode = sc.tplMode||'html';
+  S.textSubject = sc.textSubject||S.textSubject;
+  S.textBody    = sc.textBody||S.textBody;
+  S.htmlBody    = sc.htmlBody||S.htmlBody;
+  S.activeSchemaId = sc.id;
+  S.schemaNameDraft = sc.name||'';
+  syncImageOverrides();
+  S.tab = 0; // go to Setup
+  log('✓ Loaded schema: ' + sc.name); render();
+}
+
+function deleteSchema(id) {
+  S.schemas = S.schemas.filter(s=>s.id!==id);
+  if (S.activeSchemaId===id) S.activeSchemaId=null;
+  log('Schema deleted.'); render();
+}
+
+function exportSchema() {
+  const sc = currentSchema();
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(new Blob([JSON.stringify(sc,null,2)],{type:'application/json'}));
+  a.download = 'inviteflow-schema-' + sc.name.replace(/[^a-z0-9]/gi,'-').toLowerCase() + '.json';
+  a.click(); log('✓ Schema exported.');
+}
+
+function importSchemaFile(file) {
+  const r = new FileReader();
+  r.onload = e => {
+    try { loadSchema(JSON.parse(e.target.result)); }
+    catch(err) { log('✗ Invalid schema file: ' + err.message); }
+  };
+  r.readAsText(file);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// PROFILE / CSV  (existing functionality kept)
+// ═══════════════════════════════════════════════════════════════════════════════
+function exportProfile() {
+  const out = {schema:'vip-mailer-profile-v1',exportedAt:new Date().toISOString(),event:{...S.event},invitees:S.invitees.map(i=>({...i}))};
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(new Blob([JSON.stringify(out,null,2)],{type:'application/json'}));
+  a.download = 'vip-mailer-' + (S.event.profileName||'profile').replace(/[^a-z0-9]/gi,'-') + '-' + new Date().toISOString().slice(0,10) + '.json';
+  a.click(); S.unsaved=false; log('✓ Profile exported.'); render();
+}
+
+function importProfile(file) {
+  const r = new FileReader();
+  r.onload = e => {
+    try {
+      const d = JSON.parse(e.target.result);
+      if (d.event)    S.event = {...DEFAULT_EVENT,...d.event};
+      if (d.invitees) S.invitees = d.invitees.map(i=>({rsvpLink:'',inviteStatus:'not_sent',rsvpStatus:'no_response',rsvpDate:'',sentAt:'',notes:'',...i}));
+      syncImageOverrides(); S.unsaved=false; S.modal=null;
+      log('✓ Profile loaded: '+(S.event.profileName||'?')+' ('+S.invitees.length+' invitees)'); render();
+    } catch(err) { log('✗ Import failed: '+err.message); }
+  };
+  r.readAsText(file);
+}
+
+function importResearcher(file) {
+  const r = new FileReader();
+  r.onload = e => {
+    try {
+      const d = JSON.parse(e.target.result);
+      const list = (d.invitees||d).filter(x=>x.name && x.verifyStatus!=='left_office');
+      let added=0,updated=0;
+      list.forEach(x => {
+        const email = x.email||x.officeEmail||x.directEmail||'';
+        const ex = S.invitees.find(i=>i.name===x.name);
+        if (ex) { ex.email=email||ex.email; ex.title=x.title||ex.title; ex.category=x.category||ex.category; updated++; }
+        else { S.invitees.push({name:x.name,title:x.title||'',category:x.category||'',email,rsvpLink:'',inviteStatus:'not_sent',sentAt:'',rsvpStatus:'no_response',rsvpDate:'',notes:''}); added++; }
+      });
+      S.unsaved=true; S.modal=null;
+      log('✓ Researcher: +'+added+' new, '+updated+' updated. Total: '+S.invitees.length); render();
+    } catch(err) { log('✗ Import failed: '+err.message); }
+  };
+  r.readAsText(file);
+}
+
+function importCSV(file) {
+  const r = new FileReader();
+  r.onload = e => {
+    const lines = e.target.result.split('\n').filter(l=>l.trim());
+    const hdr = lines[0].split(',').map(h=>h.replace(/"/g,'').trim().toLowerCase().replace(/\s+/g,'_'));
+    let added=0;
+    lines.slice(1).forEach(line => {
+      const cols = line.match(/(".*?"|[^,]+)(?=,|$)/g)||[];
+      const row = {}; hdr.forEach((h,i)=>row[h]=(cols[i]||'').replace(/"/g,'').trim());
+      const name = row.name||row.full_name||((row.first_name||row.firstname||'') + ' ' + (row.last_name||row.lastname||'')).trim();
+      if (!name) return;
+      const email = row.email||row.office_email||row.direct_email||'';
+      if (!S.invitees.find(i=>i.name===name)) {
+        S.invitees.push({name,title:row.title||'',category:row.category||'',email,rsvpLink:'',inviteStatus:'not_sent',sentAt:'',rsvpStatus:'no_response',rsvpDate:'',notes:''});
+        added++;
+      }
+    });
+    S.unsaved=true; S.modal=null;
+    log('✓ CSV: +'+added+' added. Total: '+S.invitees.length); render();
+  };
+  r.readAsText(file);
+}
+
+function exportCSV() {
+  const h = ['FirstName','LastName','Title','Category','Email','RSVP_Link','InviteSent','InviteSentDate','RSVP_Status','RSVP_Date'];
+  const rows = S.invitees.map(inv => {
+    const parts = (inv.name||'').trim().split(/\s+/);
+    return [parts[0]||'',parts.slice(1).join(' ')||'',inv.title||'',inv.category||'',inv.email||'',
+      inv.rsvpLink||buildRsvpLink(inv),
+      inv.inviteStatus==='sent'?'TRUE':'FALSE',
+      inv.sentAt?new Date(inv.sentAt).toLocaleDateString():'',
+      inv.rsvpStatus||'no_response', inv.rsvpDate||''];
+  });
+  const csv = [h,...rows].map(r=>r.map(c=>'"'+(c||'').replace(/"/g,'""')+'"').join(',')).join('\n');
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(new Blob([csv],{type:'text/csv'}));
+  a.download = 'inviteflow-' + new Date().toISOString().slice(0,10) + '.csv'; a.click();
+  log('✓ CSV exported (10 columns).');
+}
+
+// Misc helpers
+function openGmailFallback(inv) {
+  const to = encodeURIComponent(inv.email||'');
+  const sub = encodeURIComponent(S.event.emailSubject||'VIP Invitation');
+  window.open('https://mail.google.com/mail/?view=cm&fs=1&to='+to+'&su='+sub, '_blank');
+  const idx = S.invitees.findIndex(i=>i.name===inv.name);
+  if (idx>=0) { S.invitees[idx].inviteStatus='sent'; S.invitees[idx].sentAt=new Date().toISOString(); }
+  S.unsaved=true; log('✉ Gmail compose opened for '+inv.name); render();
+}
+
+function updInvitee(name, patch) {
+  const i = S.invitees.findIndex(x=>x.name===name);
+  if (i>=0) Object.assign(S.invitees[i], patch);
+  S.unsaved=true; render();
+}
+
+function log(m) { S.log = ['['+new Date().toLocaleTimeString()+'] '+m, ...S.log.slice(0,99)]; renderLog(); }
+
+function triggerFile(handler, accept) {
+  const f = document.createElement('input'); f.type='file'; f.accept=accept||'*';
+  f.onchange = e => handler(e.target.files[0]); f.click();
+}
+
+function testImg(key) {
+  const src = img(key);
+  if (!src||src.startsWith('data:')) { log('✓ '+key+': embedded'); return; }
+  const el = new Image();
+  el.onload  = () => log('✓ '+key+': loaded OK');
+  el.onerror = () => log('✗ '+key+': FAILED — check URL/sharing');
+  el.src = src; log('Testing '+key+'…');
+}
+
+const ITAG = {not_sent:'#30363d:#6e7681',sent:'#238636:#3fb950',skipped:'#bb8009:#e3b341',bounced:'#da3633:#f85149'};
+const IL   = {not_sent:'NOT SENT',sent:'SENT',skipped:'SKIPPED',bounced:'BOUNCED'};
+function its(k) { const[b,c]=(ITAG[k]||ITAG.not_sent).split(':'); return 'border-color:'+b+';color:'+c; }
+
+const RTAG = {confirmed:'#238636:#3fb950',declined:'#da3633:#f85149',pending:'#bb8009:#e3b341',no_response:'#30363d:#6e7681'};
+const RL   = {confirmed:'CONFIRMED',declined:'DECLINED',pending:'PENDING',no_response:'NO RESP'};
+function rts(k) { const[b,c]=(RTAG[k]||RTAG.no_response).split(':'); return 'border-color:'+b+';color:'+c; }
+
+function writePreview(html, frameId) {
+  const frame = document.getElementById(frameId||'preview-frame'); if (!frame) return;
+  try {
+    frame.contentDocument.open();
+    frame.contentDocument.write('<!DOCTYPE html><html><head><meta charset="UTF-8"><style>body{margin:0;padding:0}</style></head><body>'+html+'</body></html>');
+    frame.contentDocument.close();
+  } catch(e) {}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RENDER ROOT
+// ═══════════════════════════════════════════════════════════════════════════════
+const TABS = ['⚙ Setup','👥 Invitees','✉ Compose','▶ Send','📊 Tracker','⬡ Sync','⬡ Configs'];
+
+function render() {
+  const sent       = S.invitees.filter(i=>i.inviteStatus==='sent').length;
+  const confirmed  = S.invitees.filter(i=>i.rsvpStatus==='confirmed').length;
+  const hasGoogle  = !!S.googleClientId;
+
+  document.getElementById('root').innerHTML = `
+  <!-- HEADER -->
+  <div style="border-bottom:1px solid #21262d;padding:8px 18px;display:flex;justify-content:space-between;align-items:center;flex-shrink:0;background:#080c10">
+    <div style="display:flex;align-items:center;gap:10px">
+      <div>
+        <div style="font-family:'Syne',sans-serif;font-size:16px;font-weight:800;color:#f0f6fc;letter-spacing:-.02em">VIP MAILER</div>
+        <div style="font-size:9px;color:#6e7681;letter-spacing:.1em">${S.event.profileName||'Untitled'}</div>
+      </div>
+      ${S.unsaved?'<span style="background:#2a1a00;border:1px solid #C8A84B;border-radius:4px;padding:2px 8px;font-size:9px;color:#C8A84B">● UNSAVED</span>':''}
+    </div>
+    <div style="display:flex;gap:5px;align-items:center">
+      ${!hasGoogle?'<span style="font-size:9px;padding:2px 7px;border-radius:4px;background:#1a0a00;color:#e3b341;border:1px solid #bb8009">🔒 Add Google OAuth Client ID in Setup</span>':''}
+      <span style="font-size:10px;color:#6e7681">${S.invitees.length} invitees · ${sent} sent · ${confirmed} confirmed</span>
+      <button class="btn sm" onclick="exportCSV()">↓ CSV</button>
+      <button class="btn sm gold" onclick="exportProfile()">↓ Profile</button>
+      <button class="btn sm" onclick="triggerFile(importProfile,'.json')">↑ Load</button>
+      <button class="btn sm" onclick="S.modal='new';render()">＋ New</button>
+    </div>
+  </div>
+
+  <!-- STAT BAR -->
+  <div style="padding:4px 18px;border-bottom:1px solid #161b22;display:flex;gap:12px;flex-wrap:wrap;align-items:center;flex-shrink:0">
+    ${[['TOTAL',S.invitees.length,'#8b949e'],['SENT',sent,'#3fb950'],['CONFIRMED',confirmed,'#3fb950'],['DECLINED',S.invitees.filter(i=>i.rsvpStatus==='declined').length,'#f85149'],['PENDING',S.invitees.filter(i=>i.rsvpStatus==='pending').length,'#e3b341'],['NO RSVP',S.invitees.filter(i=>i.rsvpStatus==='no_response').length,'#6e7681']].map(([l,n,c])=>`
+    <div style="display:flex;align-items:center;gap:4px">
+      <span style="width:5px;height:5px;border-radius:50%;background:${c};display:inline-block"></span>
+      <span style="font-size:9px;color:#6e7681;letter-spacing:.08em">${l}</span>
+      <span style="font-size:12px;font-weight:500;color:${c}">${n}</span>
+    </div>`).join('')}
+  </div>
+
+  <!-- TABS -->
+  <div style="border-bottom:1px solid #21262d;display:flex;flex-shrink:0;overflow-x:auto">
+    ${TABS.map((t,i)=>`<button onclick="S.tab=${i};render()" style="background:none;border:none;cursor:pointer;font-family:inherit;font-size:10px;letter-spacing:.04em;padding:7px 13px;white-space:nowrap;color:${S.tab===i?'#f0f6fc':'#6e7681'};border-bottom:${S.tab===i?'2px solid #C8A84B':'2px solid transparent'}">${t}</button>`).join('')}
+  </div>
+
+  <!-- CONTENT + LOG PANEL -->
+  <div style="display:grid;grid-template-columns:1fr 200px;flex:1;overflow:hidden;min-height:0">
+    <div style="overflow-y:auto;min-height:0" id="main-content">
+      ${S.tab===0?renderSetup():S.tab===1?renderInvitees():S.tab===2?renderCompose():S.tab===3?renderSend():S.tab===4?renderTracker():S.tab===5?renderSync():renderEvents()}
+    </div>
+    <div style="overflow-y:auto;padding:10px 11px;background:#050709;border-left:1px solid #161b22;min-height:0" id="logpanel">
+      <div style="font-size:9px;color:#6e7681;letter-spacing:.14em;margin-bottom:6px">ACTIVITY LOG</div>
+      ${S.log.length===0?'<div style="font-size:10px;color:#21262d;font-style:italic">No activity…</div>':''}
+      ${S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#8b949e':'#2d3340'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #C8A84B':'2px solid transparent'};padding-left:6px">${e}</div>`).join('')}
+    </div>
+  </div>
+  ${renderModal()}`;
+
+  if (S.tab===2 && S.previewName) requestAnimationFrame(refreshComposePreview);
+  saveState();
+}
+
+function renderLog() {
+  const el = document.getElementById('logpanel'); if (!el) return;
+  el.innerHTML = '<div style="font-size:9px;color:#6e7681;letter-spacing:.14em;margin-bottom:6px">ACTIVITY LOG</div>' +
+    (S.log.length===0?'<div style="font-size:10px;color:#21262d;font-style:italic">No activity…</div>':'') +
+    S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#8b949e':'#2d3340'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #C8A84B':'2px solid transparent'};padding-left:6px">${e}</div>`).join('');
+}
+
+// ─── Setup helpers ───────────────────────────────────────────────────────────
+function setupComplete() {
+  return !!S.googleClientId && !!S.event.eventName && S.invitees.length > 0;
+}
+
+// ─── Tab 6: Configs (schema management) ──────────────────────────────────────
+function renderEvents() {
+  return `<div style="padding:16px 20px;max-width:640px">
+    <div class="card">
+      <div style="font-size:11px;color:#f0f6fc;margin-bottom:10px">Save current config as a named schema</div>
+      <div style="display:flex;gap:7px;align-items:flex-end;flex-wrap:wrap">
+        <div style="flex:1;min-width:160px">
+          <div style="font-size:9px;color:#6e7681;margin-bottom:3px">SCHEMA NAME</div>
+          <input class="ifield" type="text" placeholder="${S.event.profileName||'My Event 2025'}" value="${(S.schemaNameDraft||'').replace(/"/g,'&quot;')}"
+            oninput="S.schemaNameDraft=this.value">
+        </div>
+        <button class="btn gold" onclick="saveSchema()">Save</button>
+        <button class="btn sm" onclick="exportSchema()">↓ Export</button>
+        <button class="btn sm" onclick="triggerFile(importSchemaFile,'.json')">↑ Import</button>
+      </div>
+      <div style="font-size:9px;color:#6e7681;margin-top:7px;line-height:1.5">Schemas include event config and email templates. They never include invitee data or API keys — safe to share and version-control.</div>
+    </div>
+    ${S.schemas.length===0?`<div style="text-align:center;padding:32px;color:#30363d;font-size:11px">No saved schemas yet — save your current config above.</div>`:''}
+    ${S.schemas.map(sc=>`
+    <div class="card" style="display:flex;justify-content:space-between;align-items:center;gap:10px">
+      <div>
+        <div style="font-size:12px;color:#f0f6fc;font-weight:500;display:flex;align-items:center;gap:6px">
+          ${esc(sc.name)} ${sc.id===S.activeSchemaId?'<span style="font-size:9px;background:#0c2d0c;border:1px solid #238636;color:#3fb950;border-radius:3px;padding:1px 5px">active</span>':''}
+        </div>
+        <div style="font-size:9px;color:#6e7681;margin-top:3px">${sc.event?.eventDate||''} · ${sc.event?.venue||''}</div>
+        <div style="font-size:9px;color:#6e7681">Saved ${new Date(sc.savedAt).toLocaleString()}</div>
+      </div>
+      <div style="display:flex;gap:5px;flex-shrink:0">
+        <button class="btn sm pri" onclick="loadSchema(${JSON.stringify(sc).replace(/"/g,'&quot;')})">Load</button>
+        <button class="btn sm stop" onclick="deleteSchema('${sc.id}')">Delete</button>
+      </div>
+    </div>`).join('')}
+  </div>`;
+}
+
+function esc(s) { return (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+// ─── Tab 1: Setup ─────────────────────────────────────────────────────────────
+function renderSetup() {
+  const e = S.event;
+  const ml = {embedded:'Embedded',gdrive:'Google Drive ID',url:'Direct URL'};
+  const imgDefs = [{key:'Emblem',label:'Header Emblem',hint:'Main event image'},{key:'Logo',label:'Signature',hint:'Small signature image'},{key:'Sig',label:'Footer Logo',hint:'Org footer/letterhead'}];
+  return `<div style="padding:16px 20px;max-width:600px">
+
+    ${!setupComplete() ? `
+    <div style="background:linear-gradient(135deg,#0a1a2e 0%,#080c10 100%);border:1px solid #1f6feb;border-radius:8px;padding:20px 22px;margin-bottom:20px">
+      <div style="font-family:'Syne',sans-serif;font-size:15px;font-weight:800;color:#f0f6fc;letter-spacing:-.02em;margin-bottom:2px">Welcome to InviteFlow</div>
+      <div style="font-size:9px;color:#6e7681;letter-spacing:.1em;margin-bottom:14px">BY LENYA CHAN · INVITE AUTOMATION SUITE</div>
+      <div style="font-size:11px;color:#8b949e;line-height:1.8;margin-bottom:16px">InviteFlow sends personalized VIP invitations from your Gmail and tracks RSVPs in Google Sheets. Complete these three steps to get started:</div>
+      <div style="display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:10px">
+          <span style="width:20px;height:20px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;flex-shrink:0;background:${S.googleClientId?'#238636':'#1f6feb'};color:#fff">${S.googleClientId?'✓':'1'}</span>
+          <span style="font-size:11px;color:${S.googleClientId?'#3fb950':'#c9d1d9'}">Connect your Google account${S.googleClientId?' — done':' (see below)'}</span>
+        </div>
+        <div style="display:flex;align-items:center;gap:10px">
+          <span style="width:20px;height:20px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;flex-shrink:0;background:${S.event.eventName?'#238636':'#21262d'};color:${S.event.eventName?'#fff':'#6e7681'}">${S.event.eventName?'✓':'2'}</span>
+          <span style="font-size:11px;color:${S.event.eventName?'#3fb950':'#6e7681'}">Fill in your event details (Event Details section below)</span>
+        </div>
+        <div style="display:flex;align-items:center;gap:10px">
+          <span style="width:20px;height:20px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;flex-shrink:0;background:${S.invitees.length?'#238636':'#21262d'};color:${S.invitees.length?'#fff':'#6e7681'}">${S.invitees.length?'✓':'3'}</span>
+          <span style="font-size:11px;color:${S.invitees.length?'#3fb950':'#6e7681'}">Import your guest list (Invitees tab)</span>
+        </div>
+      </div>
+    </div>` : ''}
+
+    <div class="sl">EVENT DETAILS</div>
+    <div class="card">
+      ${[['Profile Name','profileName'],['Event Display Name','eventName'],['Full Title','fullTitle'],['Date','eventDate'],['Venue','venue'],['VIP Start','vipStart'],['VIP End','vipEnd']].map(([lbl,key])=>`
+      <div style="margin-bottom:8px">
+        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">${lbl}</div>
+        <input class="ifield" type="text" value="${(e[key]||'').replace(/"/g,'&quot;')}" oninput="S.event['${key}']=this.value;S.unsaved=true">
+      </div>`).join('')}
+    </div>
+
+    <div class="sl">EMAIL</div>
+    <div class="card">
+      ${[['Email Subject','emailSubject'],['Org Name','org'],['Contact Name','contactName'],['Contact Title','contactTitle'],['Contact Email','contactEmail'],['Date Shown in Letter','sentDate'],['Org Location','orgLocation']].map(([lbl,key])=>`
+      <div style="margin-bottom:8px">
+        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">${lbl}</div>
+        <input class="ifield" type="text" value="${(e[key]||'').replace(/"/g,'&quot;')}" oninput="S.event['${key}']=this.value;S.unsaved=true">
+      </div>`).join('')}
+    </div>
+
+    <div class="sl">CONNECT TO GOOGLE</div>
+    <div class="card" style="background:#060d1a;border-color:${S.googleClientId?'#238636':'#1f6feb'}">
+      ${S.googleClientId ? `
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px">
+        <span style="font-size:20px;color:#3fb950">✓</span>
+        <div>
+          <div style="font-size:12px;color:#3fb950;font-weight:500">Google account connected</div>
+          <div style="font-size:9px;color:#6e7681;margin-top:2px">Gmail sending and Google Sheets sync are active.</div>
+        </div>
+      </div>
+      <div style="font-size:9px;color:#6e7681;margin-bottom:3px">CLIENT ID</div>
+      <input class="ifield" type="text" value="${(S.googleClientId||'').replace(/"/g,'&quot;')}"
+        oninput="S.googleClientId=this.value;S.unsaved=true;render()"
+        style="border-color:#238636;font-size:10px">
+      <div style="font-size:9px;color:#6e7681;margin-top:5px">To disconnect, clear the field above.</div>
+      ` : `
+      <div style="font-size:13px;color:#58a6ff;font-weight:600;margin-bottom:6px">Connect your Google account</div>
+      <div style="font-size:11px;color:#8b949e;line-height:1.7;margin-bottom:16px">
+        This one-time setup (about 5 minutes) lets InviteFlow send emails from your Gmail
+        and read/write your Google Sheets. You need a free Google Cloud account — the same
+        Google account you use for Gmail and Sheets.
+      </div>
+      <div style="display:flex;flex-direction:column;gap:8px;margin-bottom:4px">
+        <div style="background:#0d1117;border:1px solid #21262d;border-radius:6px;padding:11px 14px">
+          <div style="font-size:10px;color:#58a6ff;letter-spacing:.07em;margin-bottom:6px">STEP 1 — Open Google Cloud Console</div>
+          <a href="https://console.cloud.google.com/" target="_blank"
+             style="display:inline-block;background:#1f6feb;border:1px solid #1f6feb;color:#fff;padding:5px 12px;border-radius:5px;font-family:inherit;font-size:10px;text-decoration:none;letter-spacing:.04em">
+            Open console.cloud.google.com →
+          </a>
+          <div style="font-size:9px;color:#6e7681;margin-top:6px">Sign in with the Google account you want to send email from. It is free to use.</div>
+        </div>
+        <div style="background:#0d1117;border:1px solid #21262d;border-radius:6px;padding:11px 14px">
+          <div style="font-size:10px;color:#58a6ff;letter-spacing:.07em;margin-bottom:6px">STEP 2 — Create a project and enable two APIs</div>
+          <div style="font-size:10px;color:#8b949e;line-height:1.9">
+            1. At the top, click <strong style="color:#c9d1d9">Select a project</strong> → <strong style="color:#c9d1d9">New Project</strong> (name it anything, e.g. "Invite Tool")<br>
+            2. In the left menu go to <strong style="color:#c9d1d9">APIs &amp; Services → Library</strong><br>
+            3. Search <strong style="color:#C8A84B">Gmail API</strong> → click it → click <strong style="color:#c9d1d9">Enable</strong><br>
+            4. Search <strong style="color:#C8A84B">Google Sheets API</strong> → click it → click <strong style="color:#c9d1d9">Enable</strong>
+          </div>
+        </div>
+        <div style="background:#0d1117;border:1px solid #21262d;border-radius:6px;padding:11px 14px">
+          <div style="font-size:10px;color:#58a6ff;letter-spacing:.07em;margin-bottom:6px">STEP 3 — Set up the consent screen</div>
+          <div style="font-size:10px;color:#8b949e;line-height:1.9">
+            Go to <strong style="color:#c9d1d9">OAuth consent screen</strong> in the left menu:<br>
+            • User type: <strong style="color:#C8A84B">External</strong> → click <strong style="color:#c9d1d9">Create</strong><br>
+            • App name: anything (e.g. "InviteFlow") — fill in your email for the contact fields<br>
+            • On the <strong style="color:#c9d1d9">Test users</strong> step, click <strong style="color:#c9d1d9">Add users</strong> and add <strong style="color:#C8A84B">your own Gmail address</strong><br>
+            • Click through to finish — you do not need to publish the app
+          </div>
+        </div>
+        <div style="background:#0d1117;border:1px solid #21262d;border-radius:6px;padding:11px 14px">
+          <div style="font-size:10px;color:#58a6ff;letter-spacing:.07em;margin-bottom:6px">STEP 4 — Create your credential</div>
+          <div style="font-size:10px;color:#8b949e;line-height:1.9">
+            Go to <strong style="color:#c9d1d9">Credentials</strong> → <strong style="color:#c9d1d9">Create Credentials</strong> → <strong style="color:#c9d1d9">OAuth 2.0 Client ID</strong><br>
+            • Application type: <strong style="color:#C8A84B">Web application</strong><br>
+            • Under <em>Authorized JavaScript origins</em>, click <strong style="color:#c9d1d9">Add URI</strong> twice and add:<br>
+            &nbsp;&nbsp;&nbsp;<code style="color:#C8A84B;font-size:9px">https://lychan110.github.io</code><br>
+            &nbsp;&nbsp;&nbsp;<code style="color:#C8A84B;font-size:9px">http://localhost</code><br>
+            • Click <strong style="color:#c9d1d9">Create</strong> — a popup shows your Client ID
+          </div>
+        </div>
+        <div style="background:#0a1a0a;border:1px solid #238636;border-radius:6px;padding:11px 14px">
+          <div style="font-size:10px;color:#3fb950;letter-spacing:.07em;margin-bottom:6px">STEP 5 — Paste your Client ID here</div>
+          <div style="font-size:9px;color:#6e7681;margin-bottom:8px">Copy the Client ID from the popup (looks like <code style="color:#C8A84B">123456789-abc.apps.googleusercontent.com</code>). Do not copy the Client Secret — only the Client ID is needed.</div>
+          <input class="ifield" type="text" placeholder="123456789-abc.apps.googleusercontent.com"
+            value="${(S.googleClientId||'').replace(/"/g,'&quot;')}"
+            oninput="S.googleClientId=this.value;S.unsaved=true;render()"
+            style="border-color:#238636">
+        </div>
+      </div>
+      `}
+    </div>
+
+    <div class="sl">GOOGLE SHEETS URLS</div>
+    <div class="card">
+      ${[['Invitee List Sheet URL (import from)','inviteeSheetUrl','https://docs.google.com/spreadsheets/d/...'],
+         ['Master Sheet URL (sync tracking to)','masterSheetUrl','https://docs.google.com/spreadsheets/d/...'],
+         ['RSVP Form Response Sheet URL','rsvpResponseUrl','https://docs.google.com/spreadsheets/d/...']].map(([lbl,key,ph])=>`
+      <div style="margin-bottom:8px">
+        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">${lbl}</div>
+        <input class="ifield" type="text" placeholder="${ph}" value="${(e[key]||'').replace(/"/g,'&quot;')}" oninput="S.event['${key}']=this.value;S.unsaved=true">
+      </div>`).join('')}
+    </div>
+
+    <div class="sl">RSVP FORM PREFILL</div>
+    <div class="card">
+      <div style="font-size:9px;color:#8b949e;margin-bottom:8px;line-height:1.6">In Google Forms, click ⋮ → "Get pre-filled link" → fill sample data → copy the URL. The entry IDs look like <code style="color:#C8A84B">entry.123456789</code>.</div>
+      ${[['Google Form Base URL','formUrl','https://docs.google.com/forms/d/e/FORM_ID/viewform'],
+         ['Name Entry ID (digits only)','entryName','e.g. 123456789'],
+         ['Email Entry ID (digits only)','entryEmail','e.g. 987654321']].map(([lbl,key,ph])=>`
+      <div style="margin-bottom:8px">
+        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">${lbl}</div>
+        <input class="ifield" type="text" placeholder="${ph}" value="${(e[key]||'').replace(/"/g,'&quot;')}" oninput="S.event['${key}']=this.value;S.unsaved=true">
+      </div>`).join('')}
+      ${e.formUrl?`<div style="margin-top:6px;padding:6px 8px;background:#161b22;border-radius:4px;font-size:9px;color:#6e7681;word-break:break-all">Preview: ${buildRsvpLink({name:'Sample Official',email:'sample@example.gov'})}</div>`:''}
+    </div>
+
+    <div class="sl">IMAGES</div>
+    ${imgDefs.map(({key,label,hint}) => {
+      const modeKey='img'+key+'Mode', urlKey='img'+key+'Url';
+      const mode=e[modeKey]||'embedded', url=e[urlKey]||'';
+      return `<div class="card">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:7px">
+          <div><span style="font-size:11px;color:#f0f6fc">${label}</span> <span style="font-size:9px;color:#6e7681">${hint}</span></div>
+          <button class="btn sm" onclick="syncImageOverrides();testImg('${key.toUpperCase()}')">Test</button>
+        </div>
+        <div style="display:flex;gap:4px;margin-bottom:6px">
+          ${['embedded','gdrive','url'].map(m=>`<button class="cat${mode===m?' on':''}" onclick="S.event['${modeKey}']='${m}';S.unsaved=true;syncImageOverrides();render()">${ml[m]}</button>`).join('')}
+        </div>
+        ${mode==='embedded'?`<div style="font-size:9px;color:#6e7681">Embedded base64 — token: <code style="color:#C8A84B">__IMG_${key.toUpperCase()}__</code></div>`
+          :mode==='gdrive'?`<input class="ifield" type="text" placeholder="Paste Google Drive file ID" value="${url.replace(/"/g,'&quot;')}" oninput="S.event['${urlKey}']=this.value;S.unsaved=true;syncImageOverrides()">
+             ${url?`<div style="font-size:9px;color:#6e7681;margin-top:3px">→ drive.google.com/uc?export=view&id=${url}</div>`:''}`
+          :`<input class="ifield" type="text" placeholder="https://example.org/image.png" value="${url.replace(/"/g,'&quot;')}" oninput="S.event['${urlKey}']=this.value;S.unsaved=true;syncImageOverrides()">`}
+      </div>`;
+    }).join('')}
+
+    <div style="margin-top:14px;padding-top:12px;border-top:1px solid #161b22">
+      <div style="font-size:9px;color:#6e7681;letter-spacing:.1em;margin-bottom:7px">DATA MANAGEMENT</div>
+      <div style="display:flex;gap:6px;flex-wrap:wrap">
+        <button class="btn sm gold" onclick="exportProfile()">↓ Export Profile JSON</button>
+        <button class="btn sm stop" onclick="if(confirm('Clear all saved data?'))clearSavedState()">✕ Clear All</button>
+      </div>
+    </div>
+  </div>`;
+}
+
+// ─── Tab 2: Invitees ──────────────────────────────────────────────────────────
+function renderInvitees() {
+  return `<div style="padding:14px 18px">
+    <div style="display:flex;gap:5px;align-items:center;margin-bottom:10px;flex-wrap:wrap">
+      <span style="font-size:11px;color:#f0f6fc">${S.invitees.length} invitees</span>
+      <div style="display:flex;gap:5px;margin-left:auto;flex-wrap:wrap">
+        <button class="btn sm pri" onclick="importFromSheet()" ${!S.googleClientId?'disabled title="Add Google OAuth Client ID in Setup"':''}>⬡ Import from Sheet</button>
+        <button class="btn sm gold" onclick="generateAllRsvpLinks()" ${!S.event.formUrl?'disabled title="Set Form URL in Setup first"':''}>🔗 Generate RSVP Links</button>
+        <button class="btn sm gold" onclick="S.modal='researcher';render()">⬡ From Researcher</button>
+        <button class="btn sm" onclick="triggerFile(importCSV,'.csv')">↑ CSV</button>
+        <button class="btn sm" onclick="S.modal='add';render()">＋ Add</button>
+        <button class="btn sm stop" onclick="if(confirm('Clear ALL invitees?')){S.invitees=[];S.unsaved=true;render();}">Clear</button>
+      </div>
+    </div>
+    ${S.invitees.length===0?`<div style="padding:32px 20px;max-width:480px;margin:0 auto">
+      <div style="font-size:24px;text-align:center;margin-bottom:12px">📋</div>
+      <div style="font-size:13px;color:#c9d1d9;text-align:center;margin-bottom:6px">No invitees yet</div>
+      <div style="font-size:11px;color:#6e7681;text-align:center;line-height:1.7;margin-bottom:20px">
+        Add your guest list by importing from a Google Sheet, uploading a CSV, or adding people one at a time.
+        ${!S.googleClientId ? '<div style="margin-top:8px;color:#e3b341;font-size:10px">To import from Google Sheets, connect your Google account in Setup first.</div>' : ''}
+      </div>
+      <div style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap">
+        ${S.googleClientId
+          ? `<button class="btn pri sm" onclick="importFromSheet()">⬡ Import from Google Sheet</button>`
+          : `<button class="btn sm gold" onclick="S.tab=0;render()">→ Connect Google first</button>`}
+        <button class="btn sm" onclick="triggerFile(importCSV,'.csv')">↑ Upload CSV</button>
+        <button class="btn sm" onclick="S.modal='add';render()">＋ Add manually</button>
+      </div>
+    </div>`:''}
+    ${S.invitees.map((inv,idx) => `
+    <div style="display:grid;grid-template-columns:1fr 130px 70px 70px 20px;gap:5px;padding:6px 0;border-bottom:1px solid #0d1117;align-items:center">
+      <div>
+        <div style="font-size:11px;color:#f0f6fc">${esc(inv.name)}</div>
+        <div style="font-size:9px;color:#6e7681">${inv.title?esc(inv.title)+' · ':''} ${inv.category||''}</div>
+      </div>
+      <input class="ifield" type="text" value="${(inv.email||'').replace(/"/g,'&quot;')}" placeholder="email"
+        oninput="S.invitees[${idx}].email=this.value;S.unsaved=true" style="font-size:9px;padding:3px 7px">
+      <span class="tag" style="${its(inv.inviteStatus)};font-size:8px">${IL[inv.inviteStatus]||'NOT SENT'}</span>
+      <span class="tag" style="${rts(inv.rsvpStatus)};font-size:8px">${RL[inv.rsvpStatus]||'NO RESP'}</span>
+      <button class="btn sm stop" onclick="S.invitees.splice(${idx},1);S.unsaved=true;render()" style="padding:2px 5px">✕</button>
+    </div>`).join('')}
+    ${S.invitees.length>0?`
+    <div style="padding:8px 0;font-size:9px;color:#6e7681">
+      ${S.invitees.filter(i=>!i.email).length} missing email ·
+      ${S.invitees.filter(i=>i.rsvpLink).length} with RSVP links ·
+      ${S.invitees.filter(i=>i.inviteStatus==='sent').length} sent
+    </div>`:''}
+  </div>`;
+}
+
+// ─── Tab 3: Compose ────────────────────────────────────────────────────────────
+function renderCompose() {
+  const prevInv = S.previewName ? S.invitees.find(x=>x.name===S.previewName) : S.invitees[0];
+  const prevFirst = prevInv ? prevInv.name.split(' ')[0] : 'Sample';
+  const prevLast  = prevInv ? prevInv.name.split(' ').slice(1).join(' ') : 'Official';
+  return `<div style="display:grid;grid-template-columns:1fr 1fr;height:100%;overflow:hidden">
+    <!-- Left: editor -->
+    <div style="overflow-y:auto;padding:14px 16px;border-right:1px solid #21262d">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px">
+        <div style="display:flex;gap:3px">
+          ${['html','text'].map(m=>`<button class="cat${S.tplMode===m?' on':''}" onclick="S.tplMode='${m}';render()">${m.toUpperCase()}</button>`).join('')}
+        </div>
+        <button class="btn sm gold" onclick="openFullPreview()">⛶ Full Preview</button>
+      </div>
+
+      ${S.tplMode==='html'?`
+      <div style="font-size:9px;color:#6e7681;margin-bottom:4px">HTML EMAIL TEMPLATE</div>
+      <textarea style="background:#0d1117;border:1px solid #21262d;color:#c9d1d9;padding:8px 10px;border-radius:5px;font-family:'DM Mono',monospace;font-size:10px;width:100%;min-height:300px;outline:none;resize:vertical;line-height:1.5"
+        oninput="S.htmlBody=this.value;S.unsaved=true;requestAnimationFrame(refreshComposePreview)">${esc(S.htmlBody||EMAIL_TEMPLATE.trim())}</textarea>
+      <button class="btn sm" style="margin-top:5px" onclick="S.htmlBody='';S.unsaved=true;render()">↺ Reset to default</button>
+      `:
+      `<div style="margin-bottom:8px">
+        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">SUBJECT</div>
+        <input class="ifield" type="text" value="${(S.textSubject||'').replace(/"/g,'&quot;')}" oninput="S.textSubject=this.value;S.unsaved=true;requestAnimationFrame(refreshComposePreview)">
+      </div>
+      <div>
+        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">BODY</div>
+        <textarea style="background:#0d1117;border:1px solid #21262d;color:#c9d1d9;padding:8px 10px;border-radius:5px;font-family:'DM Mono',monospace;font-size:11px;width:100%;min-height:260px;outline:none;resize:vertical;line-height:1.7"
+          oninput="S.textBody=this.value;S.unsaved=true">${esc(S.textBody)}</textarea>
+      </div>`}
+
+      <div style="margin-top:10px;padding:8px 10px;background:#0d1117;border:1px solid #21262d;border-radius:5px">
+        <div style="font-size:9px;color:#6e7681;margin-bottom:5px;letter-spacing:.1em">TOKENS — click to copy</div>
+        <div style="display:flex;flex-wrap:wrap;gap:4px">
+          ${['{{FirstName}}','{{LastName}}','{{FullTitle}}','{{EventName}}','{{EventDate}}','{{Venue}}','{{RSVP_Link}}','{{OrgName}}','{{ContactName}}','{{ContactEmail}}','{{VIPStart}}','{{VIPEnd}}','{{Date_Sent}}'].map(v=>`
+          <code style="font-size:10px;padding:2px 6px;background:#161b22;border:1px solid #21262d;border-radius:3px;cursor:pointer;color:#C8A84B" onclick="navigator.clipboard.writeText('${v}');log('Copied ${v}')">${v}</code>`).join('')}
+        </div>
+      </div>
+    </div>
+
+    <!-- Right: preview -->
+    <div style="display:flex;flex-direction:column;overflow:hidden">
+      <div style="padding:8px 12px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:8px;flex-shrink:0">
+        <div style="font-size:9px;color:#6e7681">PREVIEW FOR</div>
+        <select style="background:#0d1117;border:1px solid #21262d;color:#c9d1d9;padding:3px 6px;border-radius:4px;font-family:inherit;font-size:10px;outline:none" onchange="S.previewName=this.value;render()">
+          ${S.invitees.length===0?'<option>Sample Official</option>':''}
+          ${S.invitees.map(inv=>`<option value="${inv.name.replace(/"/g,'&quot;')}" ${S.previewName===inv.name?'selected':''}>${esc(inv.name)}</option>`).join('')}
+        </select>
+      </div>
+      ${S.tplMode==='html'?
+        `<iframe id="preview-frame" style="flex:1;border:none;background:#fff"></iframe>`:
+        `<div style="flex:1;overflow-y:auto;padding:16px;background:#fff;color:#1a1a1a;font-family:Georgia,serif;font-size:13px;line-height:1.8;white-space:pre-wrap">${esc(personalize(S.textBody, prevInv||{name:'Sample Official',email:'sample@example.gov',rsvpLink:''}))}</div>`
+      }
+    </div>
+  </div>`;
+}
+
+function refreshComposePreview() {
+  if (S.tab!==3) return;
+  const inv = S.previewName ? S.invitees.find(x=>x.name===S.previewName) : (S.invitees[0]||{name:'Sample Official',email:'',rsvpLink:''});
+  const nameParts = (inv.name||'Sample Official').split(' ');
+  const html = S.htmlBody ? personalize(S.htmlBody, inv)
+                           : buildEmail(nameParts[0], nameParts.slice(1).join(' '));
+  writePreview(html, 'preview-frame');
+}
+
+// ─── Tab 4: Send ──────────────────────────────────────────────────────────────
+function renderSend() {
+  const unsent = S.invitees.filter(i=>i.email && i.inviteStatus!=='sent' && i.inviteStatus!=='skipped');
+  const pct = S.sendProgress.total>0 ? Math.round(((S.sendProgress.sent+S.sendProgress.failed)/S.sendProgress.total)*100) : 0;
+  const hasOAuth = !!S.googleClientId;
+  return `<div style="padding:16px 20px;max-width:580px">
+    ${!hasOAuth?`<div style="background:#0d1117;border:1px solid #bb8009;border-radius:8px;padding:16px 20px;margin-bottom:16px">
+      <div style="font-size:13px;color:#e3b341;font-weight:600;margin-bottom:6px">Google account not connected</div>
+      <div style="font-size:11px;color:#8b949e;line-height:1.7;margin-bottom:12px">
+        To send emails directly from your Gmail, you need to connect your Google account once.
+        The setup takes about 5 minutes and is done entirely in your browser — no passwords
+        are shared with this app.
+      </div>
+      <button class="btn gold" onclick="S.tab=0;render()">→ Go to Setup to connect Google</button>
+      <div style="font-size:10px;color:#6e7681;margin-top:10px;padding-top:10px;border-top:1px solid #21262d">
+        <strong style="color:#8b949e">No Google account?</strong> Use the manual Gmail fallback at the bottom of this page — it opens Gmail compose in a new browser tab.
+      </div>
+    </div>`:''}
+
+    <div class="card">
+      <div style="font-size:12px;color:#f0f6fc;margin-bottom:12px">Send via Gmail API</div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:14px">
+        <div style="background:#161b22;border-radius:6px;padding:11px 13px">
+          <div style="font-size:20px;font-weight:500;color:#f0f6fc">${unsent.length}</div>
+          <div style="font-size:9px;color:#6e7681;margin-top:2px">Unsent invitees</div>
+        </div>
+        <div style="background:#0c1a0c;border-radius:6px;padding:11px 13px">
+          <div style="font-size:20px;font-weight:500;color:#3fb950">${S.invitees.filter(i=>i.inviteStatus==='sent').length}</div>
+          <div style="font-size:9px;color:#3fb950;margin-top:2px">Already sent</div>
+        </div>
+      </div>
+      <div style="display:flex;gap:7px;flex-wrap:wrap">
+        <button class="btn pri" ${S.sending||!hasOAuth?'disabled':''} onclick="sendBulkEmails('unsent')">
+          ${S.sending?`Sending… ${S.sendProgress.sent}/${S.sendProgress.total}`:`▶ Send new only (${unsent.length})`}
+        </button>
+        <button class="btn" ${S.sending||!hasOAuth?'disabled':''} onclick="sendBulkEmails('all')">
+          Send all (${S.invitees.filter(i=>i.email).length})
+        </button>
+        ${S.sending?`<button class="btn stop" onclick="_sendAbort=true">■ Stop</button>`:''}
+      </div>
+      ${(S.sending||S.sendProgress.total>0)?`
+      <div style="margin-top:10px">
+        <div style="display:flex;justify-content:space-between;font-size:9px;color:#6e7681;margin-bottom:4px">
+          <span>${S.sending?'Sending to '+S.sendProgress.current+'…':'Done'}</span>
+          <span>${S.sendProgress.sent} sent · ${S.sendProgress.failed} failed · ${pct}%</span>
+        </div>
+        <div class="pbar-wrap"><div class="pbar" style="width:${pct}%"></div></div>
+      </div>`:''}
+    </div>
+
+    ${S.sendLog.length>0?`
+    <div class="card">
+      <div style="font-size:11px;color:#f0f6fc;margin-bottom:10px">Send Log</div>
+      <div style="max-height:240px;overflow-y:auto">
+        ${S.sendLog.map(entry=>`
+        <div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #161b22;font-size:11px">
+          <span style="color:#f0f6fc;font-weight:500">${esc(entry.name)}</span>
+          <div style="display:flex;gap:10px;align-items:center">
+            <span style="font-size:9px;color:#6e7681">${entry.email}</span>
+            <span style="font-size:10px;font-weight:500;color:${entry.status==='sent'?'#3fb950':'#f85149'}">${entry.status==='sent'?'✓ Sent':'✗ '+entry.status}</span>
+            <span style="font-size:9px;color:#6e7681">${entry.ts}</span>
+          </div>
+        </div>`).join('')}
+      </div>
+    </div>`:''}
+
+    <div class="card" style="background:#0a0d14;border-color:#1f6feb">
+      <div style="font-size:10px;color:#58a6ff;margin-bottom:5px;font-weight:500">Manual fallback — Gmail compose</div>
+      <div style="font-size:9px;color:#8b949e;margin-bottom:8px;line-height:1.5">Opens Gmail in browser tab. HTML downloads for manual paste. Use if OAuth isn't configured.</div>
+      <div style="display:flex;gap:5px;flex-wrap:wrap">
+        ${S.invitees.filter(i=>i.email&&i.inviteStatus!=='sent').slice(0,5).map(inv=>`
+        <button class="btn sm" onclick='openGmailFallback(${JSON.stringify(inv).replace(/"/g,"&quot;")})' style="font-size:9px">✉ ${esc(inv.name.split(' ')[0])}</button>`).join('')}
+        ${S.invitees.filter(i=>i.email&&i.inviteStatus!=='sent').length>5?`<span style="font-size:9px;color:#6e7681;padding:4px 0">+${S.invitees.filter(i=>i.email&&i.inviteStatus!=='sent').length-5} more</span>`:''}
+      </div>
+    </div>
+  </div>`;
+}
+
+// ─── Tab 5: Tracker ───────────────────────────────────────────────────────────
+function renderTracker() {
+  const confirmed = S.invitees.filter(i=>i.rsvpStatus==='confirmed');
+  const declined  = S.invitees.filter(i=>i.rsvpStatus==='declined');
+  const pending   = S.invitees.filter(i=>i.rsvpStatus==='pending');
+  const noResp    = S.invitees.filter(i=>i.rsvpStatus==='no_response');
+  const total     = S.invitees.length || 1;
+  // Simple visual bar chart (pure CSS, no recharts)
+  const bars = [['Confirmed',confirmed.length,'#3fb950'],['Declined',declined.length,'#f85149'],['Pending',pending.length,'#e3b341'],['No RSVP',noResp.length,'#6e7681']];
+  return `<div style="padding:16px 20px">
+    <!-- Stat cards -->
+    <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:8px;margin-bottom:14px">
+      ${[['Total',S.invitees.length,'',''],['Confirmed',confirmed.length,'#0c1a0c','#3fb950'],['Declined',declined.length,'#1a0a0a','#f85149'],['Pending',pending.length,'#1a1400','#e3b341'],['No RSVP',noResp.length,'','#6e7681']].map(([l,v,bg,tc])=>`
+      <div style="background:${bg||'#161b22'};border:1px solid #21262d;border-radius:6px;padding:11px 12px">
+        <div style="font-size:22px;font-weight:500;color:${tc||'#f0f6fc'}">${v}</div>
+        <div style="font-size:9px;color:${tc||'#6e7681'};margin-top:2px;letter-spacing:.06em">${l}</div>
+      </div>`).join('')}
+    </div>
+
+    <!-- Sync bar -->
+    <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;padding:7px 11px;background:#0d1117;border:1px solid #21262d;border-radius:6px">
+      <button class="btn sm pri" onclick="syncRsvpResponses()" ${!S.googleClientId?'disabled title="Add Google OAuth Client ID in Setup"':''}>↻ Sync RSVP Responses</button>
+      <span style="font-size:10px;color:#6e7681">Reads your Google Form response sheet and matches by email.</span>
+      ${!S.googleClientId?'<span style="font-size:9px;color:#e3b341">🔒 OAuth needed</span>':''}
+    </div>
+
+    <!-- Bar chart -->
+    <div class="card" style="margin-bottom:12px">
+      <div style="font-size:10px;color:#f0f6fc;margin-bottom:12px">Response Breakdown</div>
+      ${bars.map(([label,count,color])=>`
+      <div style="margin-bottom:8px">
+        <div style="display:flex;justify-content:space-between;font-size:9px;color:#6e7681;margin-bottom:3px">
+          <span>${label}</span><span style="color:${color}">${count} (${Math.round(count/total*100)}%)</span>
+        </div>
+        <div style="height:8px;background:#161b22;border-radius:4px;overflow:hidden">
+          <div style="height:100%;width:${Math.round(count/total*100)}%;background:${color};border-radius:4px;transition:width .4s"></div>
+        </div>
+      </div>`).join('')}
+    </div>
+
+    <!-- Confirmed addresses -->
+    <div class="card">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px">
+        <div style="font-size:10px;color:#f0f6fc">Confirmed — Recent RSVPs</div>
+        <button class="btn sm" onclick="navigator.clipboard.writeText('${confirmed.map(i=>i.name+' <'+i.email+'>').join(', ')}');log('${confirmed.length} confirmed emails copied')">Copy emails</button>
+      </div>
+      ${confirmed.length===0?'<div style="font-size:10px;color:#6e7681">No confirmed attendees yet.</div>':''}
+      ${confirmed.slice(0,20).map(inv=>`
+      <div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #161b22;font-size:11px">
+        <div>
+          <span style="color:#f0f6fc;font-weight:500">${esc(inv.name)}</span>
+          <span style="color:#6e7681;font-size:9px;margin-left:8px">${esc(inv.title||'')}</span>
+        </div>
+        <div style="text-align:right;font-size:9px;color:#6e7681">
+          ${inv.rsvpDate?'<span style="color:#3fb950">'+inv.rsvpDate+'</span>':''}
+          <div>${esc(inv.email)}</div>
+        </div>
+      </div>`).join('')}
+      ${confirmed.length>20?`<div style="font-size:9px;color:#6e7681;padding-top:6px">+ ${confirmed.length-20} more</div>`:''}
+    </div>
+  </div>`;
+}
+
+// ─── Tab 6: Sync ──────────────────────────────────────────────────────────────
+function renderSync() {
+  const hasMaster = !!S.event.masterSheetUrl;
+  const hasOAuth  = !!S.googleClientId;
+  return `<div style="padding:16px 20px;max-width:560px">
+    <div class="card" style="background:#0a0f1a;border-color:#1f6feb">
+      <div style="font-size:12px;color:#58a6ff;margin-bottom:8px;font-weight:500">⬡ Sync to Master Google Sheet</div>
+      <div style="font-size:10px;color:#8b949e;line-height:1.6;margin-bottom:12px">
+        Writes all ${S.invitees.length} invitees with current invite + RSVP status to your master sheet.<br>
+        Columns: FirstName, LastName, Title, Category, Email, RSVP_Link, InviteSent, InviteSentDate, RSVP_Status, RSVP_Date, Notes
+      </div>
+      <div style="margin-bottom:10px">
+        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">MASTER SHEET URL</div>
+        <input class="ifield" type="text" placeholder="https://docs.google.com/spreadsheets/d/..."
+          value="${(S.event.masterSheetUrl||'').replace(/"/g,'&quot;')}"
+          oninput="S.event.masterSheetUrl=this.value;S.unsaved=true">
+      </div>
+      <div style="display:flex;gap:7px;flex-wrap:wrap;align-items:center">
+        <button class="btn pri" onclick="syncToMasterSheet()" ${!hasOAuth||!hasMaster?'disabled':''}>⬡ Sync to Sheet</button>
+        ${hasMaster?`<button class="btn sm" onclick="window.open('${S.event.masterSheetUrl}','_blank')">Open Sheet ↗</button>`:''}
+        ${!hasOAuth?'<span style="font-size:9px;color:#e3b341">🔒 OAuth needed — go to Setup</span>':''}
+        ${!hasMaster&&hasOAuth?'<span style="font-size:9px;color:#6e7681">Enter Sheet URL above</span>':''}
+      </div>
+    </div>
+
+    <div class="card">
+      <div style="font-size:11px;color:#f0f6fc;margin-bottom:8px">CSV Export (no OAuth needed)</div>
+      <div style="font-size:10px;color:#8b949e;margin-bottom:10px">Download all ${S.invitees.length} invitees as a CSV with all 10 tracking columns. Import into any spreadsheet.</div>
+      <button class="btn grn" onclick="exportCSV()">↓ Export Master CSV</button>
+    </div>
+
+    <div class="card" style="background:#0a0a0a">
+      <div style="font-size:10px;color:#6e7681;margin-bottom:8px">Google Apps Script (optional power tool)</div>
+      <div style="font-size:9px;color:#6e7681;line-height:1.6">
+        The <code style="color:#C8A84B">scripts/general_user_workflow.gs</code> file in this repo provides in-sheet menu actions:
+        Generate RSVP Links, Send Invites, Sync RSVPs — all runnable from within Google Sheets.<br>
+        Use this if you prefer managing the workflow from the spreadsheet side.
+      </div>
+    </div>
+
+    <div class="card" style="background:#0a1a0a;border-color:#238636">
+      <div style="font-size:10px;color:#3fb950;margin-bottom:8px">Workflow Summary</div>
+      <div style="font-size:10px;color:#8b949e;line-height:1.8">
+        1. <strong style="color:#f0f6fc">Invitees tab</strong> → Import from Sheet (or CSV)<br>
+        2. <strong style="color:#f0f6fc">Invitees tab</strong> → Generate RSVP Links<br>
+        3. <strong style="color:#f0f6fc">Compose tab</strong> → Review/customize email template<br>
+        4. <strong style="color:#f0f6fc">Send tab</strong> → Send new only (Gmail OAuth)<br>
+        5. <strong style="color:#f0f6fc">Tracker tab</strong> → Sync RSVP Responses from Form<br>
+        6. <strong style="color:#f0f6fc">Sync tab</strong> → Sync to Master Sheet
+      </div>
+    </div>
+  </div>`;
+}
+
+// ─── Full-screen preview ──────────────────────────────────────────────────────
+function openFullPreview() {
+  S.modal = 'fullpreview'; render();
+  requestAnimationFrame(() => {
+    const inv = S.invitees[0]||{name:'Sample Official',email:'',rsvpLink:''};
+    const nameParts = inv.name.split(' ');
+    const html = S.htmlBody ? personalize(S.htmlBody, inv) : buildEmail(nameParts[0], nameParts.slice(1).join(' '));
+    writePreview(html, 'full-preview-frame');
+  });
+}
+
+// ─── Modals ───────────────────────────────────────────────────────────────────
+function renderModal() {
+  if (!S.modal) return '';
+
+  if (S.modal==='new') return `
+  <div class="modal-bg" onclick="S.modal=null;render()"><div class="modal" onclick="event.stopPropagation()">
+    <div style="font-size:13px;color:#f0f6fc;margin-bottom:10px">Start New Event</div>
+    <p style="font-size:11px;color:#8b949e;line-height:1.6;margin-bottom:14px">This resets the current session. <strong style="color:#e3b341">Save your current profile first if you have unsaved work.</strong></p>
+    <button class="btn gold" onclick="exportProfile()">↓ Save Current Profile</button>
+    <button class="btn stop" style="margin-left:8px" onclick="S.event={...DEFAULT_EVENT};S.invitees=[];syncImageOverrides();S.unsaved=false;S.modal=null;log('New event started.');render()">Reset & Start Fresh</button>
+    <button class="btn sm" style="margin-left:8px" onclick="S.modal=null;render()">Cancel</button>
+  </div></div>`;
+
+  if (S.modal==='researcher') return `
+  <div class="modal-bg" onclick="S.modal=null;render()"><div class="modal" onclick="event.stopPropagation()">
+    <div style="font-size:13px;color:#f0f6fc;margin-bottom:10px">⬡ Import from VIP Researcher</div>
+    <p style="font-size:11px;color:#8b949e;line-height:1.7;margin-bottom:14px">
+      In VIP Researcher, click <strong style="color:#3fb950">⬡ Export → Mailer</strong> after verifying officials, then load that JSON file here.<br><br>
+      <strong style="color:#f0f6fc">Merge rules:</strong> New officials added as NOT SENT · Existing names get email refreshed, invite status preserved · Left-office excluded.
+    </p>
+    <button class="btn pri" onclick="triggerFile(importResearcher,'.json')">↑ Choose File</button>
+    <button class="btn sm" style="margin-left:8px" onclick="S.modal=null;render()">Cancel</button>
+  </div></div>`;
+
+  if (S.modal==='add') return `
+  <div class="modal-bg" onclick="S.modal=null;render()"><div class="modal" onclick="event.stopPropagation()">
+    <div style="font-size:13px;color:#f0f6fc;margin-bottom:14px">Add Invitee Manually</div>
+    ${[['Full Name *','m_name','Firstname Lastname'],['Title','m_title','e.g. US Representative'],['Email','m_email','scheduler@example.gov'],['Category','m_cat','e.g. US House']].map(([l,id,ph])=>`
+    <div style="margin-bottom:9px"><div style="font-size:9px;color:#6e7681;margin-bottom:3px">${l}</div><input id="${id}" class="ifield" type="text" placeholder="${ph}"></div>`).join('')}
+    <button class="btn pri" onclick="
+      const n=document.getElementById('m_name').value.trim();
+      if(!n){alert('Name required');return;}
+      S.invitees.push({name:n,title:document.getElementById('m_title').value.trim(),
+        email:document.getElementById('m_email').value.trim(),
+        category:document.getElementById('m_cat').value.trim(),
+        rsvpLink:'',inviteStatus:'not_sent',sentAt:'',rsvpStatus:'no_response',rsvpDate:'',notes:''});
+      S.unsaved=true;S.modal=null;log('+ Added '+n);render();">Add</button>
+    <button class="btn sm" style="margin-left:8px" onclick="S.modal=null;render()">Cancel</button>
+  </div></div>`;
+
+  if (S.modal==='fullpreview') return `
+  <div class="modal-bg" style="padding:0;align-items:stretch" onclick="S.modal=null;render()">
+  <div style="display:flex;flex-direction:column;width:100%;max-width:780px;margin:0 auto;background:#0d1117;height:100vh" onclick="event.stopPropagation()">
+    <div style="background:#080c10;padding:8px 15px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:10px;flex-shrink:0">
+      <span style="font-size:11px;color:#f0f6fc">Full Preview</span>
+      <button class="btn sm" style="margin-left:auto" onclick="S.modal=null;render()">✕ Close</button>
+    </div>
+    <iframe id="full-preview-frame" style="flex:1;border:none;background:#fff"></iframe>
+  </div></div>`;
+
+  return '';
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// INIT
+// ═══════════════════════════════════════════════════════════════════════════════
+window.addEventListener('beforeunload', e => {
+  if (S.unsaved) { e.preventDefault(); e.returnValue='Unsaved changes — export a profile backup first.'; }
+});
+
+loadState();
+syncImageOverrides();
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Problem:** The app had no first-run experience and no step-by-step guidance for Google OAuth setup. Even the author found it unclear where to start. Opening the app landed on a schema-management tab, Google auth instructions were 3 terse lines of jargon, and empty states offered no direction.
- **Solution:** Full UX pass across both apps, the landing page, and the docs directory.

## What changed

### `inviteflow_v02.html`
- Reordered tabs so **Setup is tab 0** (previously "Events"/schema management was first)
- Renamed "Events" tab → **"Configs"** (more accurate name)
- Added **welcome card** at the top of Setup: 3-step checklist with live status rings that turn green as the user completes each step; disappears once all three are done (`setupComplete()`)
- Rewrote the Google OAuth section from 3 lines into a **5-step guided setup** covering project creation, enabling Gmail API + Sheets API, configuring the OAuth consent screen (including the test-users step that trips most people), creating the Web application credential with authorized origins, and pasting the Client ID; collapses to a compact "connected" card once the ID is entered
- Improved **Invitees empty state**: actionable import buttons with a context-aware hint to connect Google first when not yet done
- Improved **Send tab no-OAuth state**: full explanation card with a direct "Go to Setup" button instead of a small yellow badge

### `contactscout_v02.html`
- Added **welcome banner** (shown when no API key is set) with a direct link to console.anthropic.com
- Added `needsCustomization()` helper that detects `[YOUR STATE]` / `[CITY N]` placeholders; shows a **yellow notice in the Scan tab** explaining exactly what to edit and where in the source file
- Updated key modal description with a link and clearer instructions

### `index.html`
- Added author credit to subtitle
- Updated card links to the v02 files
- Added **"What you'll need" prerequisites box** before the footer so users know what to prepare before entering either app

### `docs/`
- `ROADMAP.md` — persona analysis (power user / semi-tech / non-tech), P0–P3 priority groups
- `PROGRESS.md` — per-version changelog
- `TASKS.md` — next 4 P1 tasks with specific implementation notes

### `CLAUDE.md`
- Author, file versioning convention, planning docs references, UX conventions section

## Test plan

- [ ] Open `index.html` — verify "What you'll need" box appears and card links go to v02 files
- [ ] Open `inviteflow_v02.html` fresh (clear localStorage) — verify welcome card appears, Setup tab is active, Google OAuth section shows 5-step guide
- [ ] Enter a Client ID — verify section collapses to compact "connected" state, ring 1 turns green
- [ ] Fill in an event name — verify ring 2 turns green
- [ ] Go to Invitees tab — verify empty state shows actionable buttons; "Import from Sheet" enabled when Google connected
- [ ] Go to Send tab with no OAuth configured — verify full explanation card appears (not small badge)
- [ ] Open `contactscout_v02.html` fresh (no API key) — verify welcome banner appears
- [ ] Go to Scan tab — verify yellow customization notice appears (placeholders still in source)
- [ ] Click "⚙ Key" — verify modal shows link to console.anthropic.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)