### PR TITLE
feat: backend hardening, light theme overhaul, mobile-first layout, ContactScout de-emphasis

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,9 @@
       "Glob",
       "Bash(ls:*)",
       "Bash(cat:*)",
-      "Bash(node -e *)"
+      "Bash(node -e *)",
+      "Skill(commit-commands:commit-push-pr)",
+      "Skill(commit-commands:commit-push-pr:*)"
     ]
   }
 }

--- a/contactscout.html
+++ b/contactscout.html
@@ -37,7 +37,7 @@ input[type=checkbox]{accent-color:#1f6feb}
 <div id="keymodal" class="modal-overlay" style="display:none">
   <div class="modal">
     <h2>Claude API Key</h2>
-    <p>Enter your Anthropic API key to use ContactScout. The key is stored only in your browser session and never sent anywhere except the Anthropic API.</p>
+    <p>Enter your Anthropic API key to enable web-search powered official lookup. The key is stored only in your browser session — never saved to disk or sent anywhere except the Anthropic API directly.<br><br>Get a key at <a href="https://console.anthropic.com/settings/keys" target="_blank" style="color:#58a6ff">console.anthropic.com →</a></p>
     <input id="keyinput" type="password" placeholder="sk-ant-..." autocomplete="off" onkeydown="if(event.key==='Enter')saveKey()">
     <div id="keyerr" class="modal-err">Invalid key format — must start with sk-ant-</div>
     <div class="modal-row">
@@ -172,6 +172,7 @@ const sleep=ms=>new Promise(r=>setTimeout(r,ms));
 function log(m){S.log=[`[${new Date().toLocaleTimeString()}] ${m}`,...S.log.slice(0,99)];renderLog();}
 function upd(name,p){S.officials=S.officials.map(o=>o.name===name?{...o,...p}:o);S.unsaved=true;render();}
 function filtered(){return S.officials.filter(o=>S.activeCat==='All'||o.category===S.activeCat);}
+function needsCustomization(){return Object.values(SCAN_PROMPTS).some(p=>p.includes('[YOUR STATE]')||p.includes('[YOUR COUNTIES]')||p.includes('[CITY'));}
 
 // API KEY MODAL
 function openKeyModal(onSave){
@@ -206,7 +207,9 @@ async function callClaude(sys,user){
       'anthropic-version':'2023-06-01',
       'anthropic-dangerous-direct-browser-access':'true',
     },
-    body:JSON.stringify({model:'claude-sonnet-4-20250514',max_tokens:1500,system:sys,
+    body:JSON.stringify({model:'claude-sonnet-4-6',max_tokens:12000,
+      thinking:{type:'enabled',budget_tokens:8000},
+      system:sys,
       tools:[{type:'web_search_20250305',name:'web_search'}],
       messages:[{role:'user',content:user}]}),
   });
@@ -401,7 +404,19 @@ function renderVerify(filt){
       <button class="btn sm pri" onclick="runVerify(${JSON.stringify(names)})" ${S.running?'disabled':''}>▶ All</button>
     </div>
   </div>
-  ${filt.length===0?`<div style="padding:40px 20px;text-align:center;color:#6e7681;font-size:11px">No officials yet. Use the <strong style="color:#c9d1d9">＋ Scan for New</strong> tab to discover officials,<br>or add them manually with the button below.<br><br><button class="btn sm" onclick="promptAddManual()">+ Add Manually</button></div>`:''}
+  ${!S.apiKey&&S.officials.length===0?`
+  <div style="margin:20px;padding:18px 22px;background:#0c1a2e;border:1px solid #1f6feb;border-radius:8px">
+    <div style="font-size:13px;font-weight:500;color:#58a6ff;margin-bottom:8px">Get started with ContactScout</div>
+    <div style="font-size:11px;color:#8b949e;line-height:1.7;margin-bottom:14px">ContactScout uses Claude AI + live web search to find and verify elected officials. You need a free Anthropic API key to use it.</div>
+    <div style="display:flex;flex-direction:column;gap:8px;font-size:11px;color:#c9d1d9;margin-bottom:16px">
+      <div><span style="color:#58a6ff;margin-right:8px">1.</span>Get an API key at <a href="https://console.anthropic.com/settings/keys" target="_blank" style="color:#58a6ff">console.anthropic.com</a></div>
+      <div><span style="color:#58a6ff;margin-right:8px">2.</span>Click <strong>⚙ Key</strong> in the header and paste your key</div>
+      <div><span style="color:#58a6ff;margin-right:8px">3.</span>Go to <strong>＋ Scan for New</strong> to discover officials for your jurisdiction</div>
+      <div><span style="color:#58a6ff;margin-right:8px">4.</span>Verify, then <strong>Export → InviteFlow</strong> to send invitations</div>
+    </div>
+    <button class="btn sm pri" onclick="openKeyModal()">⚙ Enter API Key</button>
+  </div>`:''}
+  ${filt.length===0&&S.apiKey?`<div style="padding:40px 20px;text-align:center;color:#6e7681;font-size:11px">No officials yet. Use the <strong style="color:#c9d1d9">＋ Scan for New</strong> tab to discover officials,<br>or add them manually with the button below.<br><br><button class="btn sm" onclick="promptAddManual()">+ Add Manually</button></div>`:''}
   ${filt.map(o=>{
     const id=o.name.replace(/[^a-z0-9]/gi,'_');
     const det=o.result?(o.result.error?
@@ -445,6 +460,9 @@ function promptAddManual(){
 
 function renderScan(){
   return `<div style="padding:14px 20px">
+    ${needsCustomization()?`<div style="margin-bottom:14px;padding:12px 16px;background:#1a1200;border:1px solid #C8A84B;border-radius:6px;font-size:10px;color:#e3b341;line-height:1.7">
+      <strong>Setup required:</strong> The scan prompts still contain placeholders like <code>[YOUR STATE]</code>, <code>[YOUR COUNTIES]</code>, and <code>[CITY 1]</code>. Edit <code>SCAN_PROMPTS</code> in the source file to set your jurisdiction before scanning.
+    </div>`:''}
     <div style="font-size:11px;color:#8b949e;line-height:1.6;margin-bottom:14px">Each scan searches the live web for all officials in that category. New officials not in your list surface as add candidates. Customize the scan prompts in the source file for your jurisdiction. Run after each election cycle, then <strong style="color:#f0f6fc">Export → InviteFlow</strong> to send the updated list.</div>
     ${SCAN_TARGETS.map(t=>{
       const st=S.scanStatus[t.id],meta=S.scanMeta[t.id];

--- a/contactscout.html
+++ b/contactscout.html
@@ -1,34 +1,40 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <title>ContactScout</title>
 <style>
-@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Syne:wght@700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap');
 *{box-sizing:border-box;margin:0;padding:0}
-body{background:#080c10;color:#c9d1d9;font-family:'DM Mono','Courier New',monospace;height:100vh;overflow:hidden;display:flex;flex-direction:column}
-::-webkit-scrollbar{width:5px}::-webkit-scrollbar-track{background:#0d1117}::-webkit-scrollbar-thumb{background:#21262d;border-radius:3px}
-.btn{border:1px solid #21262d;background:#0d1117;color:#8b949e;padding:6px 13px;border-radius:5px;cursor:pointer;font-family:inherit;font-size:11px;letter-spacing:.05em;transition:all .15s}
-.btn:hover{border-color:#58a6ff;color:#58a6ff}
-.btn.pri{background:#1f6feb;border-color:#1f6feb;color:#fff}.btn.pri:hover{background:#388bfd}
-.btn.grn{background:#238636;border-color:#238636;color:#fff}.btn.grn:hover{background:#2ea043}
-.btn.sm{padding:4px 9px;font-size:10px}
-.btn.stop{border-color:#da3633;color:#f85149}.btn.stop:hover{background:#da3633;color:#fff}
-.btn:disabled{opacity:.35;cursor:not-allowed}
-.tag{display:inline-block;font-size:9px;padding:2px 6px;border-radius:3px;letter-spacing:.07em;border:1px solid}
+body{background:#f8fafc;color:#1e293b;font-family:'Inter',system-ui,-apple-system,sans-serif;height:100vh;overflow:hidden;display:flex;flex-direction:column}
+::-webkit-scrollbar{width:5px}::-webkit-scrollbar-track{background:#f1f5f9}::-webkit-scrollbar-thumb{background:#cbd5e1;border-radius:3px}
+.btn{border:1px solid #e2e8f0;background:#ffffff;color:#475569;padding:6px 13px;border-radius:6px;cursor:pointer;font-family:inherit;font-size:12px;font-weight:500;transition:all .15s;box-shadow:0 1px 2px rgba(0,0,0,.05)}
+.btn:hover{border-color:#93c5fd;color:#2563eb;background:#f0f9ff}
+.btn.pri{background:#2563eb;border-color:#2563eb;color:#fff;box-shadow:0 1px 3px rgba(37,99,235,.3)}.btn.pri:hover{background:#1d4ed8;border-color:#1d4ed8}
+.btn.grn{background:#16a34a;border-color:#16a34a;color:#fff;box-shadow:0 1px 3px rgba(22,163,74,.3)}.btn.grn:hover{background:#15803d;border-color:#15803d}
+.btn.sm{padding:4px 10px;font-size:11px}
+.btn.stop{border-color:#fca5a5;color:#dc2626;background:#fff}.btn.stop:hover{background:#fee2e2;border-color:#ef4444}
+.btn:disabled{opacity:.4;cursor:not-allowed;box-shadow:none}
+.tag{display:inline-flex;align-items:center;font-size:10px;font-weight:600;padding:2px 8px;border-radius:20px;letter-spacing:.03em;border:1px solid}
 .pulse{animation:pl 1.4s ease-in-out infinite}@keyframes pl{0%,100%{opacity:1}50%{opacity:.3}}
-.cat{border:1px solid #21262d;background:transparent;color:#6e7681;padding:4px 10px;border-radius:20px;cursor:pointer;font-family:inherit;font-size:10px;letter-spacing:.07em;transition:all .15s}
-.cat.on{border-color:#1f6feb;color:#58a6ff;background:#0c2d6b}.cat:hover:not(.on){color:#c9d1d9;border-color:#30363d}
-input[type=checkbox]{accent-color:#1f6feb}
-.ritem{transition:background .1s;cursor:pointer}.ritem:hover{background:#0d1117}
-.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.7);display:flex;align-items:center;justify-content:center;z-index:100}
-.modal{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:22px 24px;width:380px;max-width:90vw}
-.modal h2{font-family:'Syne',sans-serif;font-size:14px;color:#f0f6fc;margin-bottom:6px}
-.modal p{font-size:10px;color:#6e7681;line-height:1.6;margin-bottom:14px}
-.modal input{width:100%;background:#010409;border:1px solid #30363d;border-radius:4px;color:#c9d1d9;font-family:inherit;font-size:11px;padding:7px 10px;outline:none;margin-bottom:10px}
-.modal input:focus{border-color:#1f6feb}
-.modal-err{font-size:10px;color:#f85149;margin-bottom:8px;display:none}
-.modal-row{display:flex;gap:7px;justify-content:flex-end}
+.cat{border:1px solid #e2e8f0;background:#ffffff;color:#64748b;padding:4px 12px;border-radius:20px;cursor:pointer;font-family:inherit;font-size:11px;font-weight:500;transition:all .15s}
+.cat.on{border-color:#2563eb;color:#2563eb;background:#eff6ff}.cat:hover:not(.on){color:#1e293b;border-color:#94a3b8;background:#f8fafc}
+input[type=checkbox]{accent-color:#2563eb;width:14px;height:14px}
+.ritem{transition:background .1s;cursor:pointer;border-radius:6px}.ritem:hover{background:#f1f5f9}
+.modal-overlay{position:fixed;inset:0;background:rgba(15,23,42,.6);backdrop-filter:blur(4px);display:flex;align-items:center;justify-content:center;z-index:100;padding:16px}
+.modal{background:#ffffff;border:1px solid #e2e8f0;border-radius:12px;padding:24px 26px;width:400px;max-width:100%;box-shadow:0 20px 60px rgba(0,0,0,.15)}
+.modal h2{font-size:16px;font-weight:700;color:#0f172a;margin-bottom:8px}
+.modal p{font-size:13px;color:#475569;line-height:1.65;margin-bottom:16px}
+.modal input{width:100%;background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;color:#1e293b;font-family:inherit;font-size:13px;padding:9px 12px;outline:none;margin-bottom:12px;transition:border-color .15s;box-shadow:0 1px 2px rgba(0,0,0,.04)}
+.modal input:focus{border-color:#2563eb;box-shadow:0 0 0 3px rgba(37,99,235,.1)}
+.modal-err{font-size:12px;color:#dc2626;margin-bottom:10px;display:none}
+.modal-row{display:flex;gap:8px;justify-content:flex-end}
+/* ── Responsive ── */
+@media(max-width:768px){
+  body{height:auto!important;overflow:auto!important}
+  #root{height:auto!important;overflow:visible!important;min-height:100vh}
+  [style*="grid-template-columns:1fr 220px"]{grid-template-columns:1fr!important}
+}
 </style>
 </head>
 <body>
@@ -37,7 +43,7 @@ input[type=checkbox]{accent-color:#1f6feb}
 <div id="keymodal" class="modal-overlay" style="display:none">
   <div class="modal">
     <h2>Claude API Key</h2>
-    <p>Enter your Anthropic API key to enable web-search powered official lookup. The key is stored only in your browser session — never saved to disk or sent anywhere except the Anthropic API directly.<br><br>Get a key at <a href="https://console.anthropic.com/settings/keys" target="_blank" style="color:#58a6ff">console.anthropic.com →</a></p>
+    <p>Enter your Anthropic API key to enable web-search powered official lookup. The key is stored only in your browser session — never saved to disk or sent anywhere except the Anthropic API directly.<br><br>Get a key at <a href="https://console.anthropic.com/settings/keys" target="_blank" style="color:#3b82f6">console.anthropic.com →</a></p>
     <input id="keyinput" type="password" placeholder="sk-ant-..." autocomplete="off" onkeydown="if(event.key==='Enter')saveKey()">
     <div id="keyerr" class="modal-err">Invalid key format — must start with sk-ant-</div>
     <div class="modal-row">
@@ -76,7 +82,7 @@ const SCAN_SYS = `Find all current elected officials for 2025-2026 using web sea
 {"officials":[{"name":"","title":"","district":"","county":"","category":"US Senate|US House|Executive|State Senate|House|City Council","directEmail":"","officeEmail":"","officePhone":""}],"confidence":"high","notes":""}`;
 
 const CATS = ["All","US Senate","US House","Executive","State Senate","House","City Council"];
-const TAG={pending:'#30363d:#6e7681',checking:'#f59e0b:#f59e0b',done:'#238636:#3fb950',changed:'#1f6feb:#58a6ff',left_office:'#da3633:#f85149',error:'#bb8009:#e3b341'};
+const TAG={pending:'#94a3b8:#64748b',checking:'#f59e0b:#f59e0b',done:'#16a34a:#22c55e',changed:'#2563eb:#3b82f6',left_office:'#ef4444:#dc2626',error:'#b45309:#f59e0b'};
 const SL={pending:'PENDING',checking:'CHECKING',done:'VERIFIED',changed:'CHANGED',left_office:'LEFT OFFICE',error:'ERROR'};
 function ts(k){const[b,c]=(TAG[k]||TAG.pending).split(':');return `border-color:${b};color:${c}`;}
 
@@ -330,15 +336,15 @@ function render(){
   const keySet=!!S.apiKey;
 
   document.getElementById('root').innerHTML=`
-  <div style="border-bottom:1px solid #21262d;padding:11px 20px;display:flex;justify-content:space-between;align-items:center;flex-shrink:0;background:#080c10">
+  <div style="border-bottom:1px solid #e2e8f0;padding:11px 20px;display:flex;justify-content:space-between;align-items:center;flex-shrink:0;background:#f8fafc">
     <div>
-      <div style="font-family:'Syne',sans-serif;font-size:17px;font-weight:800;color:#f0f6fc;letter-spacing:-.02em">CONTACT SCOUT</div>
-      <div style="font-size:9px;color:#6e7681;margin-top:2px;letter-spacing:.1em">ELECTED OFFICIALS · VERIFY + DISCOVER</div>
+      <div style="font-size:16px;font-weight:700;color:#0f172a;letter-spacing:-.02em">ContactScout</div>
+      <div style="font-size:12px;color:#64748b;margin-top:1px">Elected officials · verify &amp; discover</div>
     </div>
     <div style="display:flex;gap:7px;align-items:center">
-      ${S.newOfficials.length>0?`<span style="background:#0c1a2e;color:#58a6ff;border:1px solid #1f6feb;border-radius:4px;padding:3px 9px;font-size:10px">${S.newOfficials.length} NEW</span>`:''}
-      ${S.unsaved&&S.officials.length>0?`<span style="background:#2a1a00;color:#C8A84B;border:1px solid #C8A84B;border-radius:4px;padding:2px 8px;font-size:9px">● UNSAVED</span>`:''}
-      <button class="btn sm" onclick="openKeyModal()" title="${keySet?'API key set — click to change':'No API key set'}" style="${keySet?'border-color:#238636;color:#3fb950':'border-color:#da3633;color:#f85149'}">⚙ Key${keySet?' ✓':''}</button>
+      ${S.newOfficials.length>0?`<span style="background:#eff6ff;color:#3b82f6;border:1px solid #2563eb;border-radius:4px;padding:3px 9px;font-size:10px">${S.newOfficials.length} NEW</span>`:''}
+      ${S.unsaved&&S.officials.length>0?`<span style="background:#fef3c7;color:#d97706;border:1px solid #d97706;border-radius:4px;padding:2px 8px;font-size:9px">● UNSAVED</span>`:''}
+      <button class="btn sm" onclick="openKeyModal()" title="${keySet?'API key set — click to change':'No API key set'}" style="${keySet?'border-color:#16a34a;color:#22c55e':'border-color:#ef4444;color:#dc2626'}">⚙ Key${keySet?' ✓':''}</button>
       <button class="btn sm" onclick="document.getElementById('importfile').click()" title="Load a .json backup">↑ Import</button>
       <button class="btn sm" onclick="exportProfile()" title="Save full backup as .json">↓ Backup</button>
       <button class="btn sm" onclick="exportCSV()">↓ CSV</button>
@@ -347,32 +353,32 @@ function render(){
     </div>
   </div>
 
-  <div style="padding:6px 20px;border-bottom:1px solid #161b22;display:flex;gap:14px;flex-wrap:wrap;align-items:center;flex-shrink:0">
-    ${[['TOTAL',c.total,'#8b949e'],['VERIFIED',c.done,'#3fb950'],['CHANGED',c.changed,'#58a6ff'],['LEFT OFFICE',c.left,'#f85149'],['READY TO INVITE',c.ready,'#a371f7']].map(([l,n,col])=>`
+  <div style="padding:6px 20px;border-bottom:1px solid #e2e8f0;display:flex;gap:14px;flex-wrap:wrap;align-items:center;flex-shrink:0">
+    ${[['TOTAL',c.total,'#475569'],['VERIFIED',c.done,'#22c55e'],['CHANGED',c.changed,'#3b82f6'],['LEFT OFFICE',c.left,'#dc2626'],['READY TO INVITE',c.ready,'#7c3aed']].map(([l,n,col])=>`
     <div style="display:flex;align-items:center;gap:5px">
       <span style="width:5px;height:5px;border-radius:50%;background:${col};display:inline-block"></span>
-      <span style="font-size:9px;color:#6e7681;letter-spacing:.1em">${l}</span>
+      <span style="font-size:9px;color:#64748b;letter-spacing:.03em">${l}</span>
       <span style="font-size:12px;font-weight:500;color:${col}">${n}</span>
     </div>`).join('')}
     ${S.running?`<div style="margin-left:auto;display:flex;align-items:center;gap:7px">
-      <div style="width:90px;height:3px;background:#21262d;border-radius:2px"><div style="width:${pct}%;height:100%;background:#1f6feb;border-radius:2px"></div></div>
-      <span style="font-size:10px;color:#58a6ff">${S.progress.done}/${S.progress.total}</span></div>`:''}
+      <div style="width:90px;height:3px;background:#e2e8f0;border-radius:2px"><div style="width:${pct}%;height:100%;background:#2563eb;border-radius:2px"></div></div>
+      <span style="font-size:10px;color:#3b82f6">${S.progress.done}/${S.progress.total}</span></div>`:''}
   </div>
 
-  <div style="border-bottom:1px solid #21262d;display:flex;flex-shrink:0">
+  <div style="border-bottom:1px solid #e2e8f0;display:flex;flex-shrink:0">
     ${['✓ Verify Existing','＋ Scan for New'].map((t,i)=>`
-    <button onclick="S.tab=${i};render()" style="background:none;border:none;cursor:pointer;font-family:inherit;font-size:11px;letter-spacing:.04em;padding:8px 16px;color:${S.tab===i?'#f0f6fc':'#6e7681'};border-bottom:${S.tab===i?'2px solid #1f6feb':'2px solid transparent'}">
+    <button onclick="S.tab=${i};render()" style="background:none;border:none;cursor:pointer;font-family:inherit;font-size:11px;letter-spacing:.04em;padding:8px 16px;color:${S.tab===i?'#0f172a':'#64748b'};border-bottom:${S.tab===i?'2px solid #2563eb':'2px solid transparent'}">
       ${t}${i===1&&S.newOfficials.length>0?` (${S.newOfficials.length})`:''}</button>`).join('')}
   </div>
 
   <div style="display:grid;grid-template-columns:1fr 220px;flex:1;overflow:hidden;min-height:0">
     <div style="overflow-y:auto;min-height:0">${S.tab===0?renderVerify(filt):renderScan()}</div>
-    <div style="overflow-y:auto;padding:11px 13px;background:#050709;border-left:1px solid #161b22;min-height:0" id="logpanel">
-      <div style="font-size:9px;color:#6e7681;letter-spacing:.14em;margin-bottom:7px">ACTIVITY LOG</div>
-      <div style="font-size:10px;color:#21262d;font-style:italic;margin-bottom:6px">⬡ Export → InviteFlow sends verified list to InviteFlow app.</div>
-      ${S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#8b949e':'#2d3340'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #1f6feb':'2px solid transparent'};padding-left:6px">${e}</div>`).join('')}
-      <div style="margin-top:12px;padding-top:10px;border-top:1px solid #161b22">
-        <div style="font-size:9px;color:#6e7681;letter-spacing:.1em;margin-bottom:6px">DATA</div>
+    <div style="overflow-y:auto;padding:11px 13px;background:#f8fafc;border-left:1px solid #e2e8f0;min-height:0" id="logpanel">
+      <div style="font-size:9px;color:#64748b;letter-spacing:.04em;margin-bottom:7px">ACTIVITY LOG</div>
+      <div style="font-size:10px;color:#94a3b8;font-style:italic;margin-bottom:6px">⬡ Export → InviteFlow sends verified list to InviteFlow app.</div>
+      ${S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#475569':'#94a3b8'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #2563eb':'2px solid transparent'};padding-left:6px">${e}</div>`).join('')}
+      <div style="margin-top:12px;padding-top:10px;border-top:1px solid #e2e8f0">
+        <div style="font-size:9px;color:#64748b;letter-spacing:.03em;margin-bottom:6px">DATA</div>
         <button class="btn sm" style="width:100%;margin-bottom:4px;text-align:left" onclick="exportProfile()">↓ Backup (.json)</button>
         <button class="btn sm" style="width:100%;margin-bottom:4px;text-align:left" onclick="document.getElementById('importfile').click()">↑ Import backup</button>
         <button class="btn sm stop" style="width:100%;text-align:left" onclick="clearSavedState()">✕ Clear all data</button>
@@ -385,15 +391,15 @@ function render(){
 
 function renderLog(){
   const el=document.getElementById('logpanel');if(!el)return;
-  el.innerHTML=`<div style="font-size:9px;color:#6e7681;letter-spacing:.14em;margin-bottom:7px">ACTIVITY LOG</div>
-  <div style="font-size:10px;color:#21262d;font-style:italic;margin-bottom:6px">⬡ Export → InviteFlow sends verified list to InviteFlow app.</div>
-  ${S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#8b949e':'#2d3340'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #1f6feb':'2px solid transparent'};padding-left:6px">${e}</div>`).join('')}`;
+  el.innerHTML=`<div style="font-size:9px;color:#64748b;letter-spacing:.04em;margin-bottom:7px">ACTIVITY LOG</div>
+  <div style="font-size:10px;color:#94a3b8;font-style:italic;margin-bottom:6px">⬡ Export → InviteFlow sends verified list to InviteFlow app.</div>
+  ${S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#475569':'#94a3b8'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #2563eb':'2px solid transparent'};padding-left:6px">${e}</div>`).join('')}`;
 }
 
 function renderVerify(filt){
   const names=filt.map(o=>o.name);
   return `
-  <div style="padding:7px 18px;border-bottom:1px solid #161b22;display:flex;gap:5px;align-items:center;flex-wrap:wrap;position:sticky;top:0;background:#080c10;z-index:2">
+  <div style="padding:7px 18px;border-bottom:1px solid #e2e8f0;display:flex;gap:5px;align-items:center;flex-wrap:wrap;position:sticky;top:0;background:#f8fafc;z-index:2">
     <div style="display:flex;gap:4px;flex-wrap:wrap;flex:1">
       ${CATS.map(c=>`<button class="cat${S.activeCat===c?' on':''}" onclick="S.activeCat='${c}';render()">${c.toUpperCase()}</button>`).join('')}
     </div>
@@ -405,45 +411,45 @@ function renderVerify(filt){
     </div>
   </div>
   ${!S.apiKey&&S.officials.length===0?`
-  <div style="margin:20px;padding:18px 22px;background:#0c1a2e;border:1px solid #1f6feb;border-radius:8px">
-    <div style="font-size:13px;font-weight:500;color:#58a6ff;margin-bottom:8px">Get started with ContactScout</div>
-    <div style="font-size:11px;color:#8b949e;line-height:1.7;margin-bottom:14px">ContactScout uses Claude AI + live web search to find and verify elected officials. You need a free Anthropic API key to use it.</div>
-    <div style="display:flex;flex-direction:column;gap:8px;font-size:11px;color:#c9d1d9;margin-bottom:16px">
-      <div><span style="color:#58a6ff;margin-right:8px">1.</span>Get an API key at <a href="https://console.anthropic.com/settings/keys" target="_blank" style="color:#58a6ff">console.anthropic.com</a></div>
-      <div><span style="color:#58a6ff;margin-right:8px">2.</span>Click <strong>⚙ Key</strong> in the header and paste your key</div>
-      <div><span style="color:#58a6ff;margin-right:8px">3.</span>Go to <strong>＋ Scan for New</strong> to discover officials for your jurisdiction</div>
-      <div><span style="color:#58a6ff;margin-right:8px">4.</span>Verify, then <strong>Export → InviteFlow</strong> to send invitations</div>
+  <div style="margin:20px;padding:18px 22px;background:#eff6ff;border:1px solid #2563eb;border-radius:8px">
+    <div style="font-size:13px;font-weight:500;color:#3b82f6;margin-bottom:8px">Get started with ContactScout</div>
+    <div style="font-size:11px;color:#475569;line-height:1.7;margin-bottom:14px">ContactScout uses Claude AI + live web search to find and verify elected officials. You need a free Anthropic API key to use it.</div>
+    <div style="display:flex;flex-direction:column;gap:8px;font-size:11px;color:#1e293b;margin-bottom:16px">
+      <div><span style="color:#3b82f6;margin-right:8px">1.</span>Get an API key at <a href="https://console.anthropic.com/settings/keys" target="_blank" style="color:#3b82f6">console.anthropic.com</a></div>
+      <div><span style="color:#3b82f6;margin-right:8px">2.</span>Click <strong>⚙ Key</strong> in the header and paste your key</div>
+      <div><span style="color:#3b82f6;margin-right:8px">3.</span>Go to <strong>＋ Scan for New</strong> to discover officials for your jurisdiction</div>
+      <div><span style="color:#3b82f6;margin-right:8px">4.</span>Verify, then <strong>Export → InviteFlow</strong> to send invitations</div>
     </div>
     <button class="btn sm pri" onclick="openKeyModal()">⚙ Enter API Key</button>
   </div>`:''}
-  ${filt.length===0&&S.apiKey?`<div style="padding:40px 20px;text-align:center;color:#6e7681;font-size:11px">No officials yet. Use the <strong style="color:#c9d1d9">＋ Scan for New</strong> tab to discover officials,<br>or add them manually with the button below.<br><br><button class="btn sm" onclick="promptAddManual()">+ Add Manually</button></div>`:''}
+  ${filt.length===0&&S.apiKey?`<div style="padding:40px 20px;text-align:center;color:#64748b;font-size:11px">No officials yet. Use the <strong style="color:#1e293b">＋ Scan for New</strong> tab to discover officials,<br>or add them manually with the button below.<br><br><button class="btn sm" onclick="promptAddManual()">+ Add Manually</button></div>`:''}
   ${filt.map(o=>{
     const id=o.name.replace(/[^a-z0-9]/gi,'_');
     const det=o.result?(o.result.error?
-      `<div style="color:#e3b341">Error: ${o.result.error}</div>`:
-      `${o.result.stillInOffice!==undefined?`<div><span style="color:#6e7681">IN OFFICE </span>${o.result.stillInOffice?'<span style="color:#3fb950">Yes</span>':`<span style="color:#f85149">No${o.result.replacedBy?' → '+o.result.replacedBy:''}</span>`}</div>`:''}`+
-      `${o.result.currentTitle?`<div><span style="color:#6e7681">TITLE </span>${o.result.currentTitle}</div>`:''}`+
-      `${o.result.directEmail?`<div><span style="color:#6e7681">DIRECT </span>${o.result.directEmail}</div>`:''}`+
-      `${o.result.officeEmail?`<div><span style="color:#6e7681">OFFICE </span>${o.result.officeEmail}</div>`:''}`+
-      `${o.result.changes&&o.result.changes!=='No changes detected'?`<div style="color:#58a6ff"><span style="color:#6e7681">CHANGES </span>${o.result.changes}</div>`:''}`+
-      `${o.result.flags?`<div style="color:#e3b341"><span style="color:#6e7681">FLAGS </span>${o.result.flags}</div>`:''}`+
-      `<div><span style="color:#6e7681">CONF </span><span style="color:${o.result.confidence==='high'?'#3fb950':o.result.confidence==='medium'?'#e3b341':'#f85149'}">${(o.result.confidence||'').toUpperCase()}</span></div>`
-    ):'<span style="color:#6e7681;font-style:italic">Not yet verified.</span>';
+      `<div style="color:#f59e0b">Error: ${o.result.error}</div>`:
+      `${o.result.stillInOffice!==undefined?`<div><span style="color:#64748b">IN OFFICE </span>${o.result.stillInOffice?'<span style="color:#22c55e">Yes</span>':`<span style="color:#dc2626">No${o.result.replacedBy?' → '+o.result.replacedBy:''}</span>`}</div>`:''}`+
+      `${o.result.currentTitle?`<div><span style="color:#64748b">TITLE </span>${o.result.currentTitle}</div>`:''}`+
+      `${o.result.directEmail?`<div><span style="color:#64748b">DIRECT </span>${o.result.directEmail}</div>`:''}`+
+      `${o.result.officeEmail?`<div><span style="color:#64748b">OFFICE </span>${o.result.officeEmail}</div>`:''}`+
+      `${o.result.changes&&o.result.changes!=='No changes detected'?`<div style="color:#3b82f6"><span style="color:#64748b">CHANGES </span>${o.result.changes}</div>`:''}`+
+      `${o.result.flags?`<div style="color:#f59e0b"><span style="color:#64748b">FLAGS </span>${o.result.flags}</div>`:''}`+
+      `<div><span style="color:#64748b">CONF </span><span style="color:${o.result.confidence==='high'?'#22c55e':o.result.confidence==='medium'?'#f59e0b':'#dc2626'}">${(o.result.confidence||'').toUpperCase()}</span></div>`
+    ):'<span style="color:#64748b;font-style:italic">Not yet verified.</span>';
     return `
-    <div style="border-bottom:1px solid #0d1117">
+    <div style="border-bottom:1px solid #f1f5f9">
       <div class="ritem" style="display:grid;grid-template-columns:20px 1fr 105px 82px 14px;gap:7px;padding:8px 18px" onclick="toggleExpand('${id}')">
         <input type="checkbox" ${S.selected.has(o.name)?'checked':''} onclick="event.stopPropagation();toggleSel('${o.name.replace(/'/g,"\'")}')">
         <div>
-          <div style="font-size:11px;font-weight:500;color:#f0f6fc">${o.name}</div>
-          <div style="font-size:9px;color:#8b949e">${o.title}${o.district?' · D'+o.district:''}${o.county?' · '+o.county:''}</div>
-          <div style="font-size:9px;color:#6e7681;font-style:italic">${o.directEmail||o.officeEmail||'no email'}</div>
+          <div style="font-size:11px;font-weight:500;color:#0f172a">${o.name}</div>
+          <div style="font-size:9px;color:#475569">${o.title}${o.district?' · D'+o.district:''}${o.county?' · '+o.county:''}</div>
+          <div style="font-size:9px;color:#64748b;font-style:italic">${o.directEmail||o.officeEmail||'no email'}</div>
         </div>
-        <div style="font-size:9px;color:#6e7681;padding-top:1px">${o.category}</div>
+        <div style="font-size:9px;color:#64748b;padding-top:1px">${o.category}</div>
         <div><span class="tag${o.status==='checking'?' pulse':''}" style="${ts(o.status)};font-size:8px">${SL[o.status]||'PENDING'}</span></div>
-        <div style="font-size:10px;color:#30363d" id="arr_${id}">▼</div>
+        <div style="font-size:10px;color:#94a3b8" id="arr_${id}">▼</div>
       </div>
       <div id="det_${id}" style="display:none;padding:0 18px 9px 45px">
-        <div style="background:#0d1117;border:1px solid #21262d;border-radius:5px;padding:8px 12px;font-size:10px;line-height:1.8">${det}</div>
+        <div style="background:#ffffff;border:1px solid #e2e8f0;border-radius:5px;padding:8px 12px;font-size:10px;line-height:1.8">${det}</div>
       </div>
     </div>`;
   }).join('')}`;
@@ -460,39 +466,39 @@ function promptAddManual(){
 
 function renderScan(){
   return `<div style="padding:14px 20px">
-    ${needsCustomization()?`<div style="margin-bottom:14px;padding:12px 16px;background:#1a1200;border:1px solid #C8A84B;border-radius:6px;font-size:10px;color:#e3b341;line-height:1.7">
+    ${needsCustomization()?`<div style="margin-bottom:14px;padding:12px 16px;background:#fefce8;border:1px solid #d97706;border-radius:6px;font-size:10px;color:#f59e0b;line-height:1.7">
       <strong>Setup required:</strong> The scan prompts still contain placeholders like <code>[YOUR STATE]</code>, <code>[YOUR COUNTIES]</code>, and <code>[CITY 1]</code>. Edit <code>SCAN_PROMPTS</code> in the source file to set your jurisdiction before scanning.
     </div>`:''}
-    <div style="font-size:11px;color:#8b949e;line-height:1.6;margin-bottom:14px">Each scan searches the live web for all officials in that category. New officials not in your list surface as add candidates. Customize the scan prompts in the source file for your jurisdiction. Run after each election cycle, then <strong style="color:#f0f6fc">Export → InviteFlow</strong> to send the updated list.</div>
+    <div style="font-size:11px;color:#475569;line-height:1.6;margin-bottom:14px">Each scan searches the live web for all officials in that category. New officials not in your list surface as add candidates. Customize the scan prompts in the source file for your jurisdiction. Run after each election cycle, then <strong style="color:#0f172a">Export → InviteFlow</strong> to send the updated list.</div>
     ${SCAN_TARGETS.map(t=>{
       const st=S.scanStatus[t.id],meta=S.scanMeta[t.id];
       const fresh=S.newOfficials.filter(o=>o._scanId===t.id);
       return `
       <div style="margin-bottom:11px">
-        <div style="background:#0d1117;border:1px solid #21262d;border-radius:7px;padding:12px 15px">
+        <div style="background:#ffffff;border:1px solid #e2e8f0;border-radius:7px;padding:12px 15px">
           <div style="display:flex;justify-content:space-between;align-items:center;gap:10px">
             <div style="flex:1">
-              <div style="font-size:12px;color:#f0f6fc;font-weight:500">${t.label}</div>
-              <div style="font-size:10px;color:#6e7681;margin-top:2px">${t.desc}</div>
-              ${meta?`<div style="margin-top:3px;font-size:10px;color:#8b949e">Found ${meta.total} · <span style="color:${meta.confidence==='high'?'#3fb950':meta.confidence==='medium'?'#e3b341':'#f85149'}">${meta.confidence}</span>${meta.notes?` · <span style="color:#e3b341">${meta.notes}</span>`:''}</div>`:''}
+              <div style="font-size:12px;color:#0f172a;font-weight:500">${t.label}</div>
+              <div style="font-size:10px;color:#64748b;margin-top:2px">${t.desc}</div>
+              ${meta?`<div style="margin-top:3px;font-size:10px;color:#475569">Found ${meta.total} · <span style="color:${meta.confidence==='high'?'#22c55e':meta.confidence==='medium'?'#f59e0b':'#dc2626'}">${meta.confidence}</span>${meta.notes?` · <span style="color:#f59e0b">${meta.notes}</span>`:''}</div>`:''}
             </div>
             <div style="display:flex;gap:5px;align-items:center;flex-shrink:0">
               ${st==='scanning'?'<span class="tag pulse" style="border-color:#f59e0b;color:#f59e0b">SCANNING</span>':''}
-              ${st==='done'?'<span class="tag" style="border-color:#238636;color:#3fb950">DONE</span>':''}
-              ${st==='error'?'<span class="tag" style="border-color:#da3633;color:#f85149">ERROR</span>':''}
+              ${st==='done'?'<span class="tag" style="border-color:#16a34a;color:#22c55e">DONE</span>':''}
+              ${st==='error'?'<span class="tag" style="border-color:#ef4444;color:#dc2626">ERROR</span>':''}
               <button class="btn sm pri" onclick="runScan('${t.id}')" ${S.running?'disabled':''}>${st==='done'?'↻ Re-scan':'▶ Scan'}</button>
             </div>
           </div>
         </div>
         ${fresh.length>0?`
-        <div style="margin:3px 0 0 11px;padding-left:11px;border-left:2px solid #1f6feb">
-          <div style="font-size:9px;color:#58a6ff;letter-spacing:.1em;margin:6px 0 4px">NEW (${fresh.length})</div>
+        <div style="margin:3px 0 0 11px;padding-left:11px;border-left:2px solid #2563eb">
+          <div style="font-size:9px;color:#3b82f6;letter-spacing:.03em;margin:6px 0 4px">NEW (${fresh.length})</div>
           ${fresh.map(o=>`
-          <div style="background:#0c1a2e;border:1px solid #1f4f99;border-radius:5px;padding:8px 11px;margin-bottom:4px;display:flex;justify-content:space-between;align-items:center">
+          <div style="background:#eff6ff;border:1px solid #93c5fd;border-radius:5px;padding:8px 11px;margin-bottom:4px;display:flex;justify-content:space-between;align-items:center">
             <div>
-              <div style="font-size:11px;color:#f0f6fc;font-weight:500">${o.name}</div>
-              <div style="font-size:9px;color:#8b949e">${o.title}${o.district?' · D'+o.district:''}${o.county?' · '+o.county:''}</div>
-              ${(o.directEmail||o.officeEmail)?`<div style="font-size:9px;color:#6e7681">${o.directEmail||o.officeEmail}</div>`:''}
+              <div style="font-size:11px;color:#0f172a;font-weight:500">${o.name}</div>
+              <div style="font-size:9px;color:#475569">${o.title}${o.district?' · D'+o.district:''}${o.county?' · '+o.county:''}</div>
+              ${(o.directEmail||o.officeEmail)?`<div style="font-size:9px;color:#64748b">${o.directEmail||o.officeEmail}</div>`:''}
             </div>
             <div style="display:flex;gap:4px;margin-left:8px">
               <button class="btn sm grn" onclick='addNew(${JSON.stringify(o)})'>+ Add</button>
@@ -500,7 +506,7 @@ function renderScan(){
             </div>
           </div>`).join('')}
         </div>`:''}
-        ${st==='done'&&fresh.length===0&&meta?`<div style="margin:3px 0 0 11px;padding:4px 0 4px 11px;border-left:2px solid #238636;font-size:10px;color:#3fb950">✓ All ${meta.total} already in list.</div>`:''}
+        ${st==='done'&&fresh.length===0&&meta?`<div style="margin:3px 0 0 11px;padding:4px 0 4px 11px;border-left:2px solid #16a34a;font-size:10px;color:#22c55e">✓ All ${meta.total} already in list.</div>`:''}
       </div>`;
     }).join('')}
   </div>`;

--- a/index.html
+++ b/index.html
@@ -3,66 +3,75 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Invite Automation Suite</title>
+<title>InviteFlow</title>
 <style>
-@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Syne:wght@700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 *{box-sizing:border-box;margin:0;padding:0}
-body{background:#080c10;color:#c9d1d9;font-family:'DM Mono','Courier New',monospace;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:40px 20px}
-.wrap{max-width:680px;width:100%}
-h1{font-family:'Syne',sans-serif;font-size:26px;font-weight:800;color:#f0f6fc;letter-spacing:-.03em;margin-bottom:6px}
-.sub{font-size:10px;color:#6e7681;letter-spacing:.14em;margin-bottom:48px}
-.cards{display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-bottom:40px}
-@media(max-width:480px){.cards{grid-template-columns:1fr}}
-.card{background:#0d1117;border:1px solid #21262d;border-radius:8px;padding:22px;text-decoration:none;color:inherit;transition:border-color .15s,transform .1s;display:block}
-.card:hover{border-color:#1f6feb;transform:translateY(-2px)}
-.card-name{font-family:'Syne',sans-serif;font-size:16px;font-weight:800;color:#f0f6fc;letter-spacing:-.02em;margin-bottom:4px}
-.card-file{font-size:9px;color:#1f6feb;letter-spacing:.08em;margin-bottom:12px}
-.card-desc{font-size:11px;color:#8b949e;line-height:1.7}
-.flow{display:flex;align-items:center;gap:10px;margin-bottom:40px;padding:14px 18px;background:#0a0e14;border:1px solid #161b22;border-radius:6px;font-size:10px;color:#6e7681;flex-wrap:wrap}
-.flow-step{color:#c9d1d9}.flow-arrow{color:#30363d}
-.footer{font-size:9px;color:#30363d;letter-spacing:.08em;text-align:center}
-.badge{display:inline-block;font-size:8px;padding:2px 6px;border-radius:3px;border:1px solid;letter-spacing:.07em;vertical-align:middle;margin-left:6px}
+body{background:#f0f4f8;color:#1e293b;font-family:'Inter',system-ui,sans-serif;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:40px 20px}
+.wrap{max-width:520px;width:100%}
+.logo{display:flex;align-items:center;gap:12px;margin-bottom:10px}
+.logo-icon{width:40px;height:40px;background:#2563eb;border-radius:10px;display:flex;align-items:center;justify-content:center;flex-shrink:0}
+.logo-icon svg{width:22px;height:22px;fill:#fff}
+h1{font-size:22px;font-weight:700;color:#0f172a;letter-spacing:-.02em}
+.sub{font-size:13px;color:#64748b;margin-bottom:40px;margin-top:4px;padding-left:52px}
+.card{background:#fff;border:1px solid #e2e8f0;border-radius:14px;padding:28px 32px;text-decoration:none;color:inherit;display:block;box-shadow:0 1px 3px rgba(0,0,0,.06);transition:box-shadow .15s,border-color .15s,transform .12s;margin-bottom:32px}
+.card:hover{border-color:#93c5fd;box-shadow:0 4px 16px rgba(37,99,235,.1);transform:translateY(-2px)}
+.card-badge{display:inline-block;font-size:11px;font-weight:600;padding:3px 9px;border-radius:20px;background:#eff6ff;color:#2563eb;border:1px solid #bfdbfe;margin-bottom:14px}
+.card-name{font-size:20px;font-weight:700;color:#0f172a;letter-spacing:-.02em;margin-bottom:6px}
+.card-desc{font-size:14px;color:#475569;line-height:1.7;margin-bottom:20px}
+.card-features{display:flex;flex-direction:column;gap:7px;margin-bottom:24px}
+.feat{display:flex;align-items:flex-start;gap:10px;font-size:13px;color:#334155}
+.feat-dot{width:6px;height:6px;border-radius:50%;background:#2563eb;flex-shrink:0;margin-top:5px}
+.launch-btn{display:inline-flex;align-items:center;gap:8px;background:#2563eb;color:#fff;font-family:inherit;font-size:14px;font-weight:600;padding:11px 22px;border-radius:8px;border:none;cursor:pointer;text-decoration:none;transition:background .15s}
+.launch-btn:hover{background:#1d4ed8}
+.launch-btn svg{width:16px;height:16px;fill:#fff}
+.footer{text-align:center;font-size:12px;color:#94a3b8}
+.admin-link{font-size:11px;color:#cbd5e1;cursor:pointer;background:none;border:none;font-family:inherit;padding:0;margin-top:8px;display:block;text-align:center;transition:color .15s}
+.admin-link:hover{color:#64748b}
 </style>
 </head>
 <body>
 <div class="wrap">
-  <h1>INVITE AUTOMATION SUITE</h1>
-  <div class="sub">CONTACT RESEARCH · INVITE WORKFLOW · RSVP TRACKING</div>
-
-  <div class="flow">
-    <span class="flow-step">1. ContactScout</span>
-    <span class="flow-arrow">→</span>
-    <span style="color:#6e7681">scan &amp; verify officials</span>
-    <span class="flow-arrow">→</span>
-    <span style="color:#6e7681">export JSON</span>
-    <span class="flow-arrow">→</span>
-    <span class="flow-step">2. InviteFlow</span>
-    <span class="flow-arrow">→</span>
-    <span style="color:#6e7681">import · send · track</span>
+  <div class="logo">
+    <div class="logo-icon">
+      <svg viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
+    </div>
+    <h1>InviteFlow</h1>
   </div>
+  <div class="sub">Event invite management · Gmail · Google Sheets</div>
 
-  <div class="cards">
-    <a class="card" href="contactscout.html">
-      <div class="card-name">ContactScout <span class="badge" style="border-color:#1f6feb;color:#58a6ff">CLAUDE API</span></div>
-      <div class="card-file">contactscout.html</div>
-      <div class="card-desc">
-        Research, verify, and discover elected officials using live web search.
-        Scan by category (Congress, state legislature, city councils).
-        Export a verified contact list for InviteFlow.
-      </div>
-    </a>
-    <a class="card" href="inviteflow.html">
-      <div class="card-name">InviteFlow <span class="badge" style="border-color:#238636;color:#3fb950">AUTO-SAVE</span></div>
-      <div class="card-file">inviteflow.html</div>
-      <div class="card-desc">
-        Compose and send personalized invite emails via Gmail.
-        Import from ContactScout JSON or CSV.
-        Track sent / RSVP status. Auto-saves to browser storage.
-      </div>
-    </a>
-  </div>
+  <a class="card" href="inviteflow.html">
+    <div class="card-badge">Web App · No Install Required</div>
+    <div class="card-name">Send &amp; Track Invitations</div>
+    <div class="card-desc">Compose personalized event invitations, send via Gmail, and track RSVPs — all in one place.</div>
+    <div class="card-features">
+      <div class="feat"><div class="feat-dot"></div><span>Import your guest list from Google Sheets or a CSV file</span></div>
+      <div class="feat"><div class="feat-dot"></div><span>Compose rich HTML or plain-text emails with custom templates</span></div>
+      <div class="feat"><div class="feat-dot"></div><span>Send personalized invites in bulk via Gmail with one click</span></div>
+      <div class="feat"><div class="feat-dot"></div><span>Track sent / opened / RSVP status and sync back to Sheets</span></div>
+    </div>
+    <span class="launch-btn">
+      <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+      Open InviteFlow
+    </span>
+  </a>
 
-  <div class="footer">OPEN IN BROWSER · NO INSTALL · NO SERVER REQUIRED</div>
+  <div class="footer">Runs entirely in your browser &mdash; no server, no install</div>
+  <button class="admin-link" onclick="openScout()">Internal tools</button>
 </div>
+<script>
+// ContactScout is an internal research tool (Claude AI + web search).
+// Password: change atob value below to atob(btoa('yournewpassword'))
+const _sc = atob('c2NvdXQyMDI1'); // scout2025
+async function openScout() {
+  const pw = prompt('Internal access code:');
+  if (pw === null) return;
+  if (pw.trim() === _sc) {
+    window.location.href = 'contactscout.html';
+  } else {
+    alert('Incorrect access code.');
+  }
+}
+</script>
 </body>
 </html>

--- a/inviteflow.html
+++ b/inviteflow.html
@@ -220,6 +220,9 @@ function generateAllRsvpLinks() {
 // One token client per scope (cached until page reload)
 const _tokenClients = {};
 let _tokens = {};
+// Queue of [resolve, reject] pairs waiting on the same scope — prevents race where
+// concurrent callers overwrite each other's _res/_rej before the callback fires.
+const _tokenPending = {};
 
 function getGoogleToken(scope) {
   return new Promise((resolve, reject) => {
@@ -228,19 +231,22 @@ function getGoogleToken(scope) {
     if (!window.google) return reject(new Error('Google Identity Services not loaded yet — try again in a moment.'));
     const cached = _tokens[scope];
     if (cached && cached.expires > Date.now()) return resolve(cached.token);
+    if (!_tokenPending[scope]) _tokenPending[scope] = [];
+    _tokenPending[scope].push([resolve, reject]);
+    if (_tokenPending[scope].length > 1) return; // already waiting on this scope
     if (!_tokenClients[scope]) {
       _tokenClients[scope] = window.google.accounts.oauth2.initTokenClient({
         client_id: clientId,
         scope: 'https://www.googleapis.com/auth/' + scope,
         callback: resp => {
-          if (resp.error) { _tokenClients[scope]._rej(new Error(resp.error)); return; }
+          const queue = _tokenPending[scope] || [];
+          _tokenPending[scope] = [];
+          if (resp.error) { queue.forEach(([,rej]) => rej(new Error(resp.error))); return; }
           _tokens[scope] = { token: resp.access_token, expires: Date.now() + (resp.expires_in||3500)*1000 };
-          _tokenClients[scope]._res(resp.access_token);
+          queue.forEach(([res]) => res(resp.access_token));
         },
       });
     }
-    _tokenClients[scope]._res = resolve;
-    _tokenClients[scope]._rej = reject;
     _tokenClients[scope].requestAccessToken({ prompt: '' });
   });
 }
@@ -334,17 +340,18 @@ async function syncToMasterSheet() {
     ];
   })];
   try {
-    // Clear then write
-    await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${sid}/values/A:Z:clear`, {
+    // Clear first — check response before proceeding; a failed clear must not silently destroy data
+    const clearRes = await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${sid}/values/A:Z:clear`, {
       method: 'POST', headers: { Authorization: 'Bearer ' + token, 'Content-Type': 'application/json' },
       body: '{}',
     });
-    const res = await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${sid}/values/A1?valueInputOption=RAW`, {
+    if (!clearRes.ok) throw new Error(`Clear failed (HTTP ${clearRes.status}) — aborting to protect existing sheet data`);
+    const writeRes = await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${sid}/values/A1?valueInputOption=RAW`, {
       method: 'PUT',
       headers: { Authorization: 'Bearer ' + token, 'Content-Type': 'application/json' },
       body: JSON.stringify({ values }),
     });
-    if (!res.ok) throw new Error('HTTP ' + res.status);
+    if (!writeRes.ok) throw new Error('Write failed: HTTP ' + writeRes.status);
     log(`✓ Master Sheet synced — ${S.invitees.length} rows written.`);
   } catch(e) { log('✗ Sync failed: ' + e.message); }
 }
@@ -373,6 +380,7 @@ async function syncRsvpResponses() {
     const rsvpCol  = hdr.findIndex(h => h.includes('rsvp') || h.includes('attend') || h.includes('status'));
     const tsCol    = hdr.findIndex(h => h.includes('timestamp'));
     if (emailCol < 0) { log('✗ No email column found in response sheet.'); return; }
+    if (rsvpCol < 0) { log('✗ No RSVP status column found — headers must contain "rsvp", "attend", or "status".'); return; }
     // Build response map: email → {status, date}
     const map = {};
     rows.slice(1).forEach(row => {
@@ -405,7 +413,12 @@ async function syncRsvpResponses() {
 // ═══════════════════════════════════════════════════════════════════════════════
 function toBase64Url(str) {
   const bytes = new TextEncoder().encode(str);
-  return btoa(String.fromCharCode(...bytes)).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+  // Chunk to avoid call stack overflow when spreading large Uint8Arrays into btoa()
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 8192) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
+  }
+  return btoa(binary).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
 }
 
 function buildMimeRaw(toEmail, toName, subject, body, isHtml) {
@@ -506,7 +519,9 @@ function saveState() {
       schemaNameDraft: S.schemaNameDraft,
       googleClientId: S.googleClientId||'',
     }));
-  } catch(e) {}
+  } catch(e) {
+    if (e.name === 'QuotaExceededError') log('⚠ Auto-save failed: browser storage full. Export a backup to avoid data loss.');
+  }
 }
 
 function loadState() {

--- a/inviteflow.html
+++ b/inviteflow.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
@@ -6,33 +6,43 @@
 <!-- Google Identity Services for OAuth2 (Gmail + Sheets) -->
 <script src="https://accounts.google.com/gsi/client" async defer></script>
 <style>
-@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Syne:wght@700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap');
 *{box-sizing:border-box;margin:0;padding:0}
-body{background:#080c10;color:#c9d1d9;font-family:'DM Mono','Courier New',monospace;height:100vh;overflow:hidden;display:flex;flex-direction:column}
-::-webkit-scrollbar{width:5px}::-webkit-scrollbar-track{background:#0d1117}::-webkit-scrollbar-thumb{background:#21262d;border-radius:3px}
-.btn{border:1px solid #21262d;background:#0d1117;color:#8b949e;padding:6px 13px;border-radius:5px;cursor:pointer;font-family:inherit;font-size:11px;letter-spacing:.05em;transition:all .15s}
-.btn:hover{border-color:#58a6ff;color:#58a6ff}
-.btn.pri{background:#1f6feb;border-color:#1f6feb;color:#fff}.btn.pri:hover{background:#388bfd}
-.btn.grn{background:#238636;border-color:#238636;color:#fff}.btn.grn:hover{background:#2ea043}
-.btn.gold{background:#3d2800;border-color:#C8A84B;color:#C8A84B}.btn.gold:hover{background:#C8A84B;color:#000}
-.btn.sm{padding:4px 9px;font-size:10px}
-.btn.stop{border-color:#da3633;color:#f85149}.btn.stop:hover{background:#da3633;color:#fff}
-.btn:disabled{opacity:.35;cursor:not-allowed}
-.tag{display:inline-block;font-size:9px;padding:2px 6px;border-radius:3px;letter-spacing:.07em;border:1px solid}
-.cat{border:1px solid #21262d;background:transparent;color:#6e7681;padding:4px 10px;border-radius:20px;cursor:pointer;font-family:inherit;font-size:10px;transition:all .15s}
-.cat.on{border-color:#C8A84B;color:#C8A84B;background:#2a1a00}.cat:hover:not(.on){color:#c9d1d9;border-color:#30363d}
-input[type=checkbox]{accent-color:#C8A84B}
-.ifield{background:#0d1117;border:1px solid #21262d;color:#c9d1d9;padding:6px 10px;border-radius:5px;font-family:inherit;font-size:11px;outline:none;width:100%;transition:border-color .15s}
-.ifield:focus{border-color:#C8A84B}
-.ritem{transition:background .1s;cursor:pointer}.ritem:hover{background:#0d1117}
-.card{background:#0d1117;border:1px solid #21262d;border-radius:7px;padding:14px 16px;margin-bottom:10px}
-.sl{font-size:9px;color:#6e7681;letter-spacing:.12em;margin-bottom:7px;margin-top:14px}
-.modal-bg{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.88);z-index:200;display:flex;align-items:center;justify-content:center}
-.modal{background:#0d1117;border:1px solid #21262d;border-radius:8px;width:560px;max-height:82vh;overflow-y:auto;padding:22px 26px}
-.pbar-wrap{height:4px;background:#161b22;border-radius:2px;overflow:hidden;margin-top:8px}
-.pbar{height:100%;background:#C8A84B;border-radius:2px;transition:width .3s}
-/* pie chart pure CSS */
+body{background:#f8fafc;color:#1e293b;font-family:'Inter',system-ui,-apple-system,sans-serif;height:100vh;overflow:hidden;display:flex;flex-direction:column}
+::-webkit-scrollbar{width:5px}::-webkit-scrollbar-track{background:#f1f5f9}::-webkit-scrollbar-thumb{background:#cbd5e1;border-radius:3px}
+.btn{border:1px solid #e2e8f0;background:#ffffff;color:#475569;padding:6px 13px;border-radius:6px;cursor:pointer;font-family:inherit;font-size:12px;font-weight:500;transition:all .15s;box-shadow:0 1px 2px rgba(0,0,0,.05)}
+.btn:hover{border-color:#93c5fd;color:#2563eb;background:#f0f9ff}
+.btn.pri{background:#2563eb;border-color:#2563eb;color:#fff;box-shadow:0 1px 3px rgba(37,99,235,.3)}.btn.pri:hover{background:#1d4ed8;border-color:#1d4ed8}
+.btn.grn{background:#16a34a;border-color:#16a34a;color:#fff;box-shadow:0 1px 3px rgba(22,163,74,.3)}.btn.grn:hover{background:#15803d;border-color:#15803d}
+.btn.gold{background:#fff7ed;border-color:#fdba74;color:#c2410c}.btn.gold:hover{background:#ffedd5;border-color:#f97316}
+.btn.sm{padding:4px 10px;font-size:11px}
+.btn.stop{border-color:#fca5a5;color:#dc2626;background:#fff}.btn.stop:hover{background:#fee2e2;border-color:#ef4444}
+.btn:disabled{opacity:.4;cursor:not-allowed;box-shadow:none}
+.tag{display:inline-flex;align-items:center;font-size:10px;font-weight:600;padding:2px 8px;border-radius:20px;letter-spacing:.03em;border:1px solid}
+.cat{border:1px solid #e2e8f0;background:#ffffff;color:#64748b;padding:4px 12px;border-radius:20px;cursor:pointer;font-family:inherit;font-size:11px;font-weight:500;transition:all .15s}
+.cat.on{border-color:#2563eb;color:#2563eb;background:#eff6ff}.cat:hover:not(.on){color:#1e293b;border-color:#94a3b8;background:#f8fafc}
+input[type=checkbox]{accent-color:#2563eb;width:14px;height:14px}
+.ifield{background:#ffffff;border:1px solid #e2e8f0;color:#1e293b;padding:7px 11px;border-radius:6px;font-family:inherit;font-size:13px;outline:none;width:100%;transition:border-color .15s;box-shadow:0 1px 2px rgba(0,0,0,.04)}
+.ifield:focus{border-color:#2563eb;box-shadow:0 0 0 3px rgba(37,99,235,.1)}
+.ritem{transition:background .1s;cursor:pointer;border-radius:6px}.ritem:hover{background:#f1f5f9}
+.card{background:#ffffff;border:1px solid #e2e8f0;border-radius:10px;padding:16px 18px;margin-bottom:12px;box-shadow:0 1px 3px rgba(0,0,0,.05)}
+.sl{font-size:11px;font-weight:600;color:#94a3b8;letter-spacing:.06em;margin-bottom:8px;margin-top:16px;text-transform:uppercase}
+.modal-bg{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(15,23,42,.6);backdrop-filter:blur(4px);z-index:200;display:flex;align-items:center;justify-content:center;padding:16px}
+.modal{background:#ffffff;border:1px solid #e2e8f0;border-radius:12px;width:560px;max-width:100%;max-height:88vh;overflow-y:auto;padding:24px 28px;box-shadow:0 20px 60px rgba(0,0,0,.15)}
+.pbar-wrap{height:6px;background:#e2e8f0;border-radius:3px;overflow:hidden;margin-top:8px}
+.pbar{height:100%;background:#2563eb;border-radius:3px;transition:width .3s}
 .pie-seg{display:inline-block;width:14px;height:14px;border-radius:50%;vertical-align:middle;margin-right:5px}
+/* ── Responsive ── */
+@media(max-width:768px){
+  body{height:auto!important;overflow:auto!important}
+  #root{height:auto!important;overflow:visible!important;min-height:100vh}
+  /* Log panel stacks below main content on mobile */
+  [style*="grid-template-columns:1fr 200px"],[style*="grid-template-columns:1fr 220px"]{grid-template-columns:1fr!important}
+  /* Compose split stacks */
+  [style*="grid-template-columns:1fr 1fr"]{grid-template-columns:1fr!important}
+  /* Tracker stat row wraps */
+  [style*="grid-template-columns:repeat(5"]{grid-template-columns:repeat(2,1fr)!important}
+}
 </style>
 </head>
 <body>
@@ -67,14 +77,14 @@ function syncImageOverrides() {
 const EMAIL_TEMPLATE = `
 <div style="width:100%;max-width:680px;min-width:280px;margin:0 auto;font-family:Georgia,'Times New Roman',serif;color:#1a1a1a;background:#ffffff">
   <div style="background:#8B1A1A;height:5px"></div>
-  <div style="background:linear-gradient(90deg,#8B1A1A 0%,#C8A84B 50%,#8B1A1A 100%);height:1px"></div>
+  <div style="background:linear-gradient(90deg,#8B1A1A 0%,#d97706 50%,#8B1A1A 100%);height:1px"></div>
   <div style="background:#0d0d0d;padding:32px 44px 26px;text-align:center">
     <img src="__IMG_EMBLEM__" alt="Event Emblem" style="width:180px;max-width:180px;height:auto;display:inline-block;margin-bottom:18px">
-    <div style="color:#C8A84B;font-size:9px;letter-spacing:5px;font-family:Arial,sans-serif;text-transform:uppercase;margin-bottom:10px">{{OrgName}}</div>
-    <div style="background:linear-gradient(90deg,transparent,#C8A84B,transparent);height:1px;margin:0 40px 14px"></div>
+    <div style="color:#d97706;font-size:9px;letter-spacing:5px;font-family:Arial,sans-serif;text-transform:uppercase;margin-bottom:10px">{{OrgName}}</div>
+    <div style="background:linear-gradient(90deg,transparent,#d97706,transparent);height:1px;margin:0 40px 14px"></div>
     <div style="color:#f5ede0;font-size:22px;font-weight:normal;line-height:1.35;letter-spacing:.5px">{{FullTitle}}</div>
-    <div style="color:#C8A84B;font-size:10px;letter-spacing:4px;font-family:Arial,sans-serif;margin-top:10px;text-transform:uppercase">{{EventName}} &nbsp;&middot;&nbsp; {{EventDate}}</div>
-    <div style="background:linear-gradient(90deg,transparent,#C8A84B,transparent);height:1px;margin:14px 40px 0"></div>
+    <div style="color:#d97706;font-size:10px;letter-spacing:4px;font-family:Arial,sans-serif;margin-top:10px;text-transform:uppercase">{{EventName}} &nbsp;&middot;&nbsp; {{EventDate}}</div>
+    <div style="background:linear-gradient(90deg,transparent,#d97706,transparent);height:1px;margin:14px 40px 0"></div>
   </div>
   <div style="background:#8B1A1A;height:3px"></div>
   <div style="padding:40px 48px 32px;background:#fffdf8">
@@ -86,7 +96,7 @@ const EMAIL_TEMPLATE = `
     <p style="font-size:14px;line-height:1.9;margin:0 0 18px;color:#2c2c2c">
       We would be deeply honored to welcome you as our distinguished guest. The VIP program — including the Opening Ceremony and Reception — is scheduled from <strong>{{VIPStart}} until {{VIPEnd}}</strong>, featuring cultural stage performances and community festivities.
     </p>
-    <div style="border-left:2px solid #C8A84B;margin:24px 0;padding:12px 20px;background:#fff8ee">
+    <div style="border-left:2px solid #d97706;margin:24px 0;padding:12px 20px;background:#fff8ee">
       <p style="font-size:13px;color:#8B1A1A;font-style:italic;line-height:1.8;margin:0">
         Dragon boat festivals draw hundreds of thousands of spectators worldwide. The Greater Triangle festival has grown to an estimated attendance of <strong>10,000</strong>, reflecting the region's vibrant and engaged Asian community.
       </p>
@@ -95,32 +105,32 @@ const EMAIL_TEMPLATE = `
       To assist us in preparing the Opening Ceremony, we respectfully request your RSVP at your earliest convenience. Should you be unable to attend in person, you are most welcome to send a representative.
     </p>
     <div style="text-align:center;margin:30px 0 22px">
-      <a href="{{RSVP_Link}}" style="display:inline-block;background:#8B1A1A;color:#f5ede0;text-decoration:none;padding:15px 48px;font-family:Arial,sans-serif;font-size:12px;letter-spacing:3px;text-transform:uppercase;border:1px solid #C8A84B">RSVP &nbsp;&middot;&nbsp; Reserve Your Place</a>
+      <a href="{{RSVP_Link}}" style="display:inline-block;background:#8B1A1A;color:#f5ede0;text-decoration:none;padding:15px 48px;font-family:Arial,sans-serif;font-size:12px;letter-spacing:3px;text-transform:uppercase;border:1px solid #d97706">RSVP &nbsp;&middot;&nbsp; Reserve Your Place</a>
       <div style="margin-top:10px;font-size:11px;color:#aaa;font-family:Arial,sans-serif">or reply directly to this email</div>
     </div>
     <p style="font-size:13px;line-height:1.8;color:#555;font-family:Arial,sans-serif;margin:24px 0 0">
       For inquiries, please contact <strong>{{ContactName}}</strong>, {{ContactTitle}}, at <a href="mailto:{{ContactEmail}}" style="color:#8B1A1A;text-decoration:underline">{{ContactEmail}}</a>.
     </p>
   </div>
-  <div style="background:linear-gradient(90deg,transparent,#C8A84B,transparent);height:1px;margin:0 48px"></div>
+  <div style="background:linear-gradient(90deg,transparent,#d97706,transparent);height:1px;margin:0 48px"></div>
   <div style="padding:28px 48px 32px;background:#fffdf8">
     <p style="font-size:14px;line-height:1.7;margin:0 0 16px;color:#2c2c2c">We look forward to your presence at this important cultural celebration.</p>
     <p style="font-size:14px;margin:0 0 10px;color:#2c2c2c">Respectfully yours,</p>
     <img src="__IMG_LOGO__" alt="Signature" style="width:180px;max-width:180px;height:auto;display:block;margin:8px 0 0">
   </div>
-  <div style="background:linear-gradient(90deg,transparent,#C8A84B,transparent);height:1px"></div>
+  <div style="background:linear-gradient(90deg,transparent,#d97706,transparent);height:1px"></div>
   <div style="background:#0d0d0d;padding:20px 36px">
     <table style="width:100%;border-collapse:collapse"><tr>
       <td style="vertical-align:middle;width:140px;padding:0">
         <img src="__IMG_SIGNATURE__" alt="{{OrgName}}" style="width:120px;height:auto;display:block">
       </td>
       <td style="vertical-align:middle;padding:0 0 0 16px">
-        <div style="color:#C8A84B;font-size:10px;font-family:Arial,sans-serif;letter-spacing:2px;text-transform:uppercase">{{OrgName}}</div>
+        <div style="color:#d97706;font-size:10px;font-family:Arial,sans-serif;letter-spacing:2px;text-transform:uppercase">{{OrgName}}</div>
         <div style="color:#666;font-size:10px;font-family:Arial,sans-serif;margin-top:4px;line-height:1.6">{{OrgLocation}}</div>
       </td>
     </tr></table>
   </div>
-  <div style="background:linear-gradient(90deg,#8B1A1A 0%,#C8A84B 50%,#8B1A1A 100%);height:1px"></div>
+  <div style="background:linear-gradient(90deg,#8B1A1A 0%,#d97706 50%,#8B1A1A 100%);height:1px"></div>
   <div style="background:#8B1A1A;height:4px"></div>
 </div>`;
 
@@ -725,11 +735,11 @@ function testImg(key) {
   el.src = src; log('Testing '+key+'…');
 }
 
-const ITAG = {not_sent:'#30363d:#6e7681',sent:'#238636:#3fb950',skipped:'#bb8009:#e3b341',bounced:'#da3633:#f85149'};
+const ITAG = {not_sent:'#94a3b8:#64748b',sent:'#16a34a:#22c55e',skipped:'#b45309:#f59e0b',bounced:'#ef4444:#dc2626'};
 const IL   = {not_sent:'NOT SENT',sent:'SENT',skipped:'SKIPPED',bounced:'BOUNCED'};
 function its(k) { const[b,c]=(ITAG[k]||ITAG.not_sent).split(':'); return 'border-color:'+b+';color:'+c; }
 
-const RTAG = {confirmed:'#238636:#3fb950',declined:'#da3633:#f85149',pending:'#bb8009:#e3b341',no_response:'#30363d:#6e7681'};
+const RTAG = {confirmed:'#16a34a:#22c55e',declined:'#ef4444:#dc2626',pending:'#b45309:#f59e0b',no_response:'#94a3b8:#64748b'};
 const RL   = {confirmed:'CONFIRMED',declined:'DECLINED',pending:'PENDING',no_response:'NO RESP'};
 function rts(k) { const[b,c]=(RTAG[k]||RTAG.no_response).split(':'); return 'border-color:'+b+';color:'+c; }
 
@@ -745,7 +755,7 @@ function writePreview(html, frameId) {
 // ═══════════════════════════════════════════════════════════════════════════════
 // RENDER ROOT
 // ═══════════════════════════════════════════════════════════════════════════════
-const TABS = ['⬡ Events','⚙ Setup','👥 Invitees','✉ Compose','▶ Send','📊 Tracker','⬡ Sync'];
+const TABS = ['⚙ Setup','👥 Invitees','✉ Compose','▶ Send','📊 Tracker','⬡ Sync','⬡ Configs'];
 
 function render() {
   const sent       = S.invitees.filter(i=>i.inviteStatus==='sent').length;
@@ -754,17 +764,17 @@ function render() {
 
   document.getElementById('root').innerHTML = `
   <!-- HEADER -->
-  <div style="border-bottom:1px solid #21262d;padding:8px 18px;display:flex;justify-content:space-between;align-items:center;flex-shrink:0;background:#080c10">
+  <div style="border-bottom:1px solid #e2e8f0;padding:8px 18px;display:flex;justify-content:space-between;align-items:center;flex-shrink:0;background:#f8fafc">
     <div style="display:flex;align-items:center;gap:10px">
       <div>
-        <div style="font-family:'Syne',sans-serif;font-size:16px;font-weight:800;color:#f0f6fc;letter-spacing:-.02em">VIP MAILER</div>
-        <div style="font-size:9px;color:#6e7681;letter-spacing:.1em">${S.event.profileName||'Untitled'}</div>
+        <div style="font-size:16px;font-weight:700;color:#0f172a;letter-spacing:-.02em">InviteFlow</div>
+        <div style="font-size:9px;color:#64748b;letter-spacing:.03em">${S.event.profileName||'Untitled'}</div>
       </div>
-      ${S.unsaved?'<span style="background:#2a1a00;border:1px solid #C8A84B;border-radius:4px;padding:2px 8px;font-size:9px;color:#C8A84B">● UNSAVED</span>':''}
+      ${S.unsaved?'<span style="background:#fef3c7;border:1px solid #d97706;border-radius:4px;padding:2px 8px;font-size:9px;color:#d97706">● UNSAVED</span>':''}
     </div>
     <div style="display:flex;gap:5px;align-items:center">
-      ${!hasGoogle?'<span style="font-size:9px;padding:2px 7px;border-radius:4px;background:#1a0a00;color:#e3b341;border:1px solid #bb8009">🔒 Add Google OAuth Client ID in Setup</span>':''}
-      <span style="font-size:10px;color:#6e7681">${S.invitees.length} invitees · ${sent} sent · ${confirmed} confirmed</span>
+      ${!hasGoogle?'<span style="font-size:9px;padding:2px 7px;border-radius:4px;background:#fff7ed;color:#f59e0b;border:1px solid #b45309">🔒 Add Google OAuth Client ID in Setup</span>':''}
+      <span style="font-size:10px;color:#64748b">${S.invitees.length} invitees · ${sent} sent · ${confirmed} confirmed</span>
       <button class="btn sm" onclick="exportCSV()">↓ CSV</button>
       <button class="btn sm gold" onclick="exportProfile()">↓ Profile</button>
       <button class="btn sm" onclick="triggerFile(importProfile,'.json')">↑ Load</button>
@@ -773,29 +783,29 @@ function render() {
   </div>
 
   <!-- STAT BAR -->
-  <div style="padding:4px 18px;border-bottom:1px solid #161b22;display:flex;gap:12px;flex-wrap:wrap;align-items:center;flex-shrink:0">
-    ${[['TOTAL',S.invitees.length,'#8b949e'],['SENT',sent,'#3fb950'],['CONFIRMED',confirmed,'#3fb950'],['DECLINED',S.invitees.filter(i=>i.rsvpStatus==='declined').length,'#f85149'],['PENDING',S.invitees.filter(i=>i.rsvpStatus==='pending').length,'#e3b341'],['NO RSVP',S.invitees.filter(i=>i.rsvpStatus==='no_response').length,'#6e7681']].map(([l,n,c])=>`
+  <div style="padding:4px 18px;border-bottom:1px solid #e2e8f0;display:flex;gap:12px;flex-wrap:wrap;align-items:center;flex-shrink:0">
+    ${[['TOTAL',S.invitees.length,'#475569'],['SENT',sent,'#22c55e'],['CONFIRMED',confirmed,'#22c55e'],['DECLINED',S.invitees.filter(i=>i.rsvpStatus==='declined').length,'#dc2626'],['PENDING',S.invitees.filter(i=>i.rsvpStatus==='pending').length,'#f59e0b'],['NO RSVP',S.invitees.filter(i=>i.rsvpStatus==='no_response').length,'#64748b']].map(([l,n,c])=>`
     <div style="display:flex;align-items:center;gap:4px">
       <span style="width:5px;height:5px;border-radius:50%;background:${c};display:inline-block"></span>
-      <span style="font-size:9px;color:#6e7681;letter-spacing:.08em">${l}</span>
+      <span style="font-size:9px;color:#64748b;letter-spacing:.03em">${l}</span>
       <span style="font-size:12px;font-weight:500;color:${c}">${n}</span>
     </div>`).join('')}
   </div>
 
   <!-- TABS -->
-  <div style="border-bottom:1px solid #21262d;display:flex;flex-shrink:0;overflow-x:auto">
-    ${TABS.map((t,i)=>`<button onclick="S.tab=${i};render()" style="background:none;border:none;cursor:pointer;font-family:inherit;font-size:10px;letter-spacing:.04em;padding:7px 13px;white-space:nowrap;color:${S.tab===i?'#f0f6fc':'#6e7681'};border-bottom:${S.tab===i?'2px solid #C8A84B':'2px solid transparent'}">${t}</button>`).join('')}
+  <div style="border-bottom:1px solid #e2e8f0;display:flex;flex-shrink:0;overflow-x:auto">
+    ${TABS.map((t,i)=>`<button onclick="S.tab=${i};render()" style="background:none;border:none;cursor:pointer;font-family:inherit;font-size:10px;letter-spacing:.04em;padding:7px 13px;white-space:nowrap;color:${S.tab===i?'#0f172a':'#64748b'};border-bottom:${S.tab===i?'2px solid #d97706':'2px solid transparent'}">${t}</button>`).join('')}
   </div>
 
   <!-- CONTENT + LOG PANEL -->
   <div style="display:grid;grid-template-columns:1fr 200px;flex:1;overflow:hidden;min-height:0">
     <div style="overflow-y:auto;min-height:0" id="main-content">
-      ${S.tab===0?renderEvents():S.tab===1?renderSetup():S.tab===2?renderInvitees():S.tab===3?renderCompose():S.tab===4?renderSend():S.tab===5?renderTracker():renderSync()}
+      ${S.tab===0?renderSetup():S.tab===1?renderInvitees():S.tab===2?renderCompose():S.tab===3?renderSend():S.tab===4?renderTracker():S.tab===5?renderSync():renderEvents()}
     </div>
-    <div style="overflow-y:auto;padding:10px 11px;background:#050709;border-left:1px solid #161b22;min-height:0" id="logpanel">
-      <div style="font-size:9px;color:#6e7681;letter-spacing:.14em;margin-bottom:6px">ACTIVITY LOG</div>
-      ${S.log.length===0?'<div style="font-size:10px;color:#21262d;font-style:italic">No activity…</div>':''}
-      ${S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#8b949e':'#2d3340'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #C8A84B':'2px solid transparent'};padding-left:6px">${e}</div>`).join('')}
+    <div style="overflow-y:auto;padding:10px 11px;background:#f8fafc;border-left:1px solid #e2e8f0;min-height:0" id="logpanel">
+      <div style="font-size:9px;color:#64748b;letter-spacing:.04em;margin-bottom:6px">ACTIVITY LOG</div>
+      ${S.log.length===0?'<div style="font-size:10px;color:#94a3b8;font-style:italic">No activity…</div>':''}
+      ${S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#475569':'#94a3b8'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #d97706':'2px solid transparent'};padding-left:6px">${e}</div>`).join('')}
     </div>
   </div>
   ${renderModal()}`;
@@ -806,19 +816,19 @@ function render() {
 
 function renderLog() {
   const el = document.getElementById('logpanel'); if (!el) return;
-  el.innerHTML = '<div style="font-size:9px;color:#6e7681;letter-spacing:.14em;margin-bottom:6px">ACTIVITY LOG</div>' +
-    (S.log.length===0?'<div style="font-size:10px;color:#21262d;font-style:italic">No activity…</div>':'') +
-    S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#8b949e':'#2d3340'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #C8A84B':'2px solid transparent'};padding-left:6px">${e}</div>`).join('');
+  el.innerHTML = '<div style="font-size:9px;color:#64748b;letter-spacing:.04em;margin-bottom:6px">ACTIVITY LOG</div>' +
+    (S.log.length===0?'<div style="font-size:10px;color:#94a3b8;font-style:italic">No activity…</div>':'') +
+    S.log.map((e,i)=>`<div style="font-size:10px;color:${i===0?'#475569':'#94a3b8'};margin-bottom:3px;line-height:1.5;border-left:${i===0?'2px solid #d97706':'2px solid transparent'};padding-left:6px">${e}</div>`).join('');
 }
 
 // ─── Tab 0: Events (schema management) ───────────────────────────────────────
 function renderEvents() {
   return `<div style="padding:16px 20px;max-width:640px">
     <div class="card">
-      <div style="font-size:11px;color:#f0f6fc;margin-bottom:10px">Save current config as a named schema</div>
+      <div style="font-size:11px;color:#0f172a;margin-bottom:10px">Save current config as a named schema</div>
       <div style="display:flex;gap:7px;align-items:flex-end;flex-wrap:wrap">
         <div style="flex:1;min-width:160px">
-          <div style="font-size:9px;color:#6e7681;margin-bottom:3px">SCHEMA NAME</div>
+          <div style="font-size:9px;color:#64748b;margin-bottom:3px">SCHEMA NAME</div>
           <input class="ifield" type="text" placeholder="${S.event.profileName||'My Event 2025'}" value="${(S.schemaNameDraft||'').replace(/"/g,'&quot;')}"
             oninput="S.schemaNameDraft=this.value">
         </div>
@@ -826,17 +836,17 @@ function renderEvents() {
         <button class="btn sm" onclick="exportSchema()">↓ Export</button>
         <button class="btn sm" onclick="triggerFile(importSchemaFile,'.json')">↑ Import</button>
       </div>
-      <div style="font-size:9px;color:#6e7681;margin-top:7px;line-height:1.5">Schemas include event config and email templates. They never include invitee data or API keys — safe to share and version-control.</div>
+      <div style="font-size:9px;color:#64748b;margin-top:7px;line-height:1.5">Schemas include event config and email templates. They never include invitee data or API keys — safe to share and version-control.</div>
     </div>
-    ${S.schemas.length===0?`<div style="text-align:center;padding:32px;color:#30363d;font-size:11px">No saved schemas yet — save your current config above.</div>`:''}
+    ${S.schemas.length===0?`<div style="text-align:center;padding:32px;color:#94a3b8;font-size:11px">No saved schemas yet — save your current config above.</div>`:''}
     ${S.schemas.map(sc=>`
     <div class="card" style="display:flex;justify-content:space-between;align-items:center;gap:10px">
       <div>
-        <div style="font-size:12px;color:#f0f6fc;font-weight:500;display:flex;align-items:center;gap:6px">
-          ${esc(sc.name)} ${sc.id===S.activeSchemaId?'<span style="font-size:9px;background:#0c2d0c;border:1px solid #238636;color:#3fb950;border-radius:3px;padding:1px 5px">active</span>':''}
+        <div style="font-size:12px;color:#0f172a;font-weight:500;display:flex;align-items:center;gap:6px">
+          ${esc(sc.name)} ${sc.id===S.activeSchemaId?'<span style="font-size:9px;background:#dcfce7;border:1px solid #86efac;color:#166534;border-radius:3px;padding:1px 5px">active</span>':''}
         </div>
-        <div style="font-size:9px;color:#6e7681;margin-top:3px">${sc.event?.eventDate||''} · ${sc.event?.venue||''}</div>
-        <div style="font-size:9px;color:#6e7681">Saved ${new Date(sc.savedAt).toLocaleString()}</div>
+        <div style="font-size:9px;color:#64748b;margin-top:3px">${sc.event?.eventDate||''} · ${sc.event?.venue||''}</div>
+        <div style="font-size:9px;color:#64748b">Saved ${new Date(sc.savedAt).toLocaleString()}</div>
       </div>
       <div style="display:flex;gap:5px;flex-shrink:0">
         <button class="btn sm pri" onclick="loadSchema(${JSON.stringify(sc).replace(/"/g,'&quot;')})">Load</button>
@@ -853,13 +863,33 @@ function renderSetup() {
   const e = S.event;
   const ml = {embedded:'Embedded',gdrive:'Google Drive ID',url:'Direct URL'};
   const imgDefs = [{key:'Emblem',label:'Header Emblem',hint:'Main event image'},{key:'Logo',label:'Signature',hint:'Small signature image'},{key:'Sig',label:'Footer Logo',hint:'Org footer/letterhead'}];
+  const isNew = !S.googleClientId && !S.event.eventName && S.invitees.length === 0;
   return `<div style="padding:16px 20px;max-width:600px">
+
+    ${isNew ? `<div style="margin-bottom:20px;padding:20px 24px;background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px">
+      <div style="font-size:15px;font-weight:700;color:#1e40af;margin-bottom:6px">Welcome to InviteFlow</div>
+      <div style="font-size:13px;color:#1e3a8a;margin-bottom:16px;line-height:1.6">Complete these three steps to get started:</div>
+      <div style="display:flex;flex-direction:column;gap:10px">
+        <div style="display:flex;align-items:flex-start;gap:12px">
+          <div style="width:24px;height:24px;border-radius:50%;background:${S.event.eventName?'#2563eb':'#bfdbfe'};color:${S.event.eventName?'#fff':'#1e40af'};display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;flex-shrink:0">${S.event.eventName?'✓':'1'}</div>
+          <div><div style="font-size:13px;font-weight:600;color:#1e293b">Fill in event details</div><div style="font-size:12px;color:#64748b">Name, date, venue, and contact information below</div></div>
+        </div>
+        <div style="display:flex;align-items:flex-start;gap:12px">
+          <div style="width:24px;height:24px;border-radius:50%;background:${S.googleClientId?'#2563eb':'#bfdbfe'};color:${S.googleClientId?'#fff':'#1e40af'};display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;flex-shrink:0">${S.googleClientId?'✓':'2'}</div>
+          <div><div style="font-size:13px;font-weight:600;color:#1e293b">Connect Google OAuth</div><div style="font-size:12px;color:#64748b">Enables Gmail sending and Google Sheets sync</div></div>
+        </div>
+        <div style="display:flex;align-items:flex-start;gap:12px">
+          <div style="width:24px;height:24px;border-radius:50%;background:${S.invitees.length?'#2563eb':'#bfdbfe'};color:${S.invitees.length?'#fff':'#1e40af'};display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;flex-shrink:0">${S.invitees.length?'✓':'3'}</div>
+          <div><div style="font-size:13px;font-weight:600;color:#1e293b">Import your guest list</div><div style="font-size:12px;color:#64748b">Go to Invitees → import from Google Sheets or CSV</div></div>
+        </div>
+      </div>
+    </div>` : ''}
 
     <div class="sl">EVENT DETAILS</div>
     <div class="card">
       ${[['Profile Name','profileName'],['Event Display Name','eventName'],['Full Title','fullTitle'],['Date','eventDate'],['Venue','venue'],['VIP Start','vipStart'],['VIP End','vipEnd']].map(([lbl,key])=>`
       <div style="margin-bottom:8px">
-        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">${lbl}</div>
+        <div style="font-size:9px;color:#64748b;margin-bottom:3px">${lbl}</div>
         <input class="ifield" type="text" value="${(e[key]||'').replace(/"/g,'&quot;')}" oninput="S.event['${key}']=this.value;S.unsaved=true">
       </div>`).join('')}
     </div>
@@ -868,24 +898,24 @@ function renderSetup() {
     <div class="card">
       ${[['Email Subject','emailSubject'],['Org Name','org'],['Contact Name','contactName'],['Contact Title','contactTitle'],['Contact Email','contactEmail'],['Date Shown in Letter','sentDate'],['Org Location','orgLocation']].map(([lbl,key])=>`
       <div style="margin-bottom:8px">
-        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">${lbl}</div>
+        <div style="font-size:9px;color:#64748b;margin-bottom:3px">${lbl}</div>
         <input class="ifield" type="text" value="${(e[key]||'').replace(/"/g,'&quot;')}" oninput="S.event['${key}']=this.value;S.unsaved=true">
       </div>`).join('')}
     </div>
 
     <div class="sl">GOOGLE OAUTH CLIENT ID</div>
-    <div class="card" style="background:#0a1a0a;border-color:#238636">
-      <div style="font-size:10px;color:#3fb950;margin-bottom:8px;line-height:1.6">
+    <div class="card" style="background:#f0fdf4;border-color:#86efac">
+      <div style="font-size:13px;color:#166534;margin-bottom:8px;line-height:1.6">
         Required for "Import from Sheets", "Sync to Sheet", "Sync RSVPs", and "Send via Gmail".<br>
-        <a href="https://console.cloud.google.com/apis/credentials" target="_blank" style="color:#58a6ff">console.cloud.google.com → Credentials → Create OAuth 2.0 Client ID (Web)</a><br>
-        Add <code style="color:#C8A84B">https://lychan110.github.io</code> and <code style="color:#C8A84B">http://localhost</code> as authorized JavaScript origins. Enable Gmail API + Sheets API.
+        <a href="https://console.cloud.google.com/apis/credentials" target="_blank" style="color:#3b82f6">console.cloud.google.com → Credentials → Create OAuth 2.0 Client ID (Web)</a><br>
+        Add <code style="color:#d97706">https://lychan110.github.io</code> and <code style="color:#d97706">http://localhost</code> as authorized JavaScript origins. Enable Gmail API + Sheets API.
       </div>
-      <div style="font-size:9px;color:#6e7681;margin-bottom:3px">CLIENT ID</div>
+      <div style="font-size:9px;color:#64748b;margin-bottom:3px">CLIENT ID</div>
       <input class="ifield" type="text" placeholder="123456789-abc.apps.googleusercontent.com"
         value="${(S.googleClientId||'').replace(/"/g,'&quot;')}"
         oninput="S.googleClientId=this.value;S.unsaved=true"
-        style="border-color:${S.googleClientId?'#238636':'#21262d'}">
-      ${S.googleClientId?'<div style="font-size:9px;color:#3fb950;margin-top:4px">✓ Google OAuth configured</div>':''}
+        style="border-color:${S.googleClientId?'#16a34a':'#e2e8f0'}">
+      ${S.googleClientId?'<div style="font-size:9px;color:#22c55e;margin-top:4px">✓ Google OAuth configured</div>':''}
     </div>
 
     <div class="sl">GOOGLE SHEETS URLS</div>
@@ -894,22 +924,22 @@ function renderSetup() {
          ['Master Sheet URL (sync tracking to)','masterSheetUrl','https://docs.google.com/spreadsheets/d/...'],
          ['RSVP Form Response Sheet URL','rsvpResponseUrl','https://docs.google.com/spreadsheets/d/...']].map(([lbl,key,ph])=>`
       <div style="margin-bottom:8px">
-        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">${lbl}</div>
+        <div style="font-size:9px;color:#64748b;margin-bottom:3px">${lbl}</div>
         <input class="ifield" type="text" placeholder="${ph}" value="${(e[key]||'').replace(/"/g,'&quot;')}" oninput="S.event['${key}']=this.value;S.unsaved=true">
       </div>`).join('')}
     </div>
 
     <div class="sl">RSVP FORM PREFILL</div>
     <div class="card">
-      <div style="font-size:9px;color:#8b949e;margin-bottom:8px;line-height:1.6">In Google Forms, click ⋮ → "Get pre-filled link" → fill sample data → copy the URL. The entry IDs look like <code style="color:#C8A84B">entry.123456789</code>.</div>
+      <div style="font-size:9px;color:#475569;margin-bottom:8px;line-height:1.6">In Google Forms, click ⋮ → "Get pre-filled link" → fill sample data → copy the URL. The entry IDs look like <code style="color:#d97706">entry.123456789</code>.</div>
       ${[['Google Form Base URL','formUrl','https://docs.google.com/forms/d/e/FORM_ID/viewform'],
          ['Name Entry ID (digits only)','entryName','e.g. 123456789'],
          ['Email Entry ID (digits only)','entryEmail','e.g. 987654321']].map(([lbl,key,ph])=>`
       <div style="margin-bottom:8px">
-        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">${lbl}</div>
+        <div style="font-size:9px;color:#64748b;margin-bottom:3px">${lbl}</div>
         <input class="ifield" type="text" placeholder="${ph}" value="${(e[key]||'').replace(/"/g,'&quot;')}" oninput="S.event['${key}']=this.value;S.unsaved=true">
       </div>`).join('')}
-      ${e.formUrl?`<div style="margin-top:6px;padding:6px 8px;background:#161b22;border-radius:4px;font-size:9px;color:#6e7681;word-break:break-all">Preview: ${buildRsvpLink({name:'Sample Official',email:'sample@example.gov'})}</div>`:''}
+      ${e.formUrl?`<div style="margin-top:6px;padding:6px 8px;background:#e2e8f0;border-radius:4px;font-size:9px;color:#64748b;word-break:break-all">Preview: ${buildRsvpLink({name:'Sample Official',email:'sample@example.gov'})}</div>`:''}
     </div>
 
     <div class="sl">IMAGES</div>
@@ -918,21 +948,21 @@ function renderSetup() {
       const mode=e[modeKey]||'embedded', url=e[urlKey]||'';
       return `<div class="card">
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:7px">
-          <div><span style="font-size:11px;color:#f0f6fc">${label}</span> <span style="font-size:9px;color:#6e7681">${hint}</span></div>
+          <div><span style="font-size:11px;color:#0f172a">${label}</span> <span style="font-size:9px;color:#64748b">${hint}</span></div>
           <button class="btn sm" onclick="syncImageOverrides();testImg('${key.toUpperCase()}')">Test</button>
         </div>
         <div style="display:flex;gap:4px;margin-bottom:6px">
           ${['embedded','gdrive','url'].map(m=>`<button class="cat${mode===m?' on':''}" onclick="S.event['${modeKey}']='${m}';S.unsaved=true;syncImageOverrides();render()">${ml[m]}</button>`).join('')}
         </div>
-        ${mode==='embedded'?`<div style="font-size:9px;color:#6e7681">Embedded base64 — token: <code style="color:#C8A84B">__IMG_${key.toUpperCase()}__</code></div>`
+        ${mode==='embedded'?`<div style="font-size:9px;color:#64748b">Embedded base64 — token: <code style="color:#d97706">__IMG_${key.toUpperCase()}__</code></div>`
           :mode==='gdrive'?`<input class="ifield" type="text" placeholder="Paste Google Drive file ID" value="${url.replace(/"/g,'&quot;')}" oninput="S.event['${urlKey}']=this.value;S.unsaved=true;syncImageOverrides()">
-             ${url?`<div style="font-size:9px;color:#6e7681;margin-top:3px">→ drive.google.com/uc?export=view&id=${url}</div>`:''}`
+             ${url?`<div style="font-size:9px;color:#64748b;margin-top:3px">→ drive.google.com/uc?export=view&id=${url}</div>`:''}`
           :`<input class="ifield" type="text" placeholder="https://example.org/image.png" value="${url.replace(/"/g,'&quot;')}" oninput="S.event['${urlKey}']=this.value;S.unsaved=true;syncImageOverrides()">`}
       </div>`;
     }).join('')}
 
-    <div style="margin-top:14px;padding-top:12px;border-top:1px solid #161b22">
-      <div style="font-size:9px;color:#6e7681;letter-spacing:.1em;margin-bottom:7px">DATA MANAGEMENT</div>
+    <div style="margin-top:14px;padding-top:12px;border-top:1px solid #e2e8f0">
+      <div style="font-size:9px;color:#64748b;letter-spacing:.03em;margin-bottom:7px">DATA MANAGEMENT</div>
       <div style="display:flex;gap:6px;flex-wrap:wrap">
         <button class="btn sm gold" onclick="exportProfile()">↓ Export Profile JSON</button>
         <button class="btn sm stop" onclick="if(confirm('Clear all saved data?'))clearSavedState()">✕ Clear All</button>
@@ -945,7 +975,7 @@ function renderSetup() {
 function renderInvitees() {
   return `<div style="padding:14px 18px">
     <div style="display:flex;gap:5px;align-items:center;margin-bottom:10px;flex-wrap:wrap">
-      <span style="font-size:11px;color:#f0f6fc">${S.invitees.length} invitees</span>
+      <span style="font-size:11px;color:#0f172a">${S.invitees.length} invitees</span>
       <div style="display:flex;gap:5px;margin-left:auto;flex-wrap:wrap">
         <button class="btn sm pri" onclick="importFromSheet()" ${!S.googleClientId?'disabled title="Add Google OAuth Client ID in Setup"':''}>⬡ Import from Sheet</button>
         <button class="btn sm gold" onclick="generateAllRsvpLinks()" ${!S.event.formUrl?'disabled title="Set Form URL in Setup first"':''}>🔗 Generate RSVP Links</button>
@@ -955,12 +985,12 @@ function renderInvitees() {
         <button class="btn sm stop" onclick="if(confirm('Clear ALL invitees?')){S.invitees=[];S.unsaved=true;render();}">Clear</button>
       </div>
     </div>
-    ${S.invitees.length===0?`<div style="text-align:center;padding:40px;color:#30363d"><div style="font-size:24px;margin-bottom:8px">📋</div><div style="font-size:11px">No invitees yet — import from Google Sheets, upload CSV, or add manually.</div></div>`:''}
+    ${S.invitees.length===0?`<div style="text-align:center;padding:40px;color:#94a3b8"><div style="font-size:24px;margin-bottom:8px">📋</div><div style="font-size:11px">No invitees yet — import from Google Sheets, upload CSV, or add manually.</div></div>`:''}
     ${S.invitees.map((inv,idx) => `
-    <div style="display:grid;grid-template-columns:1fr 130px 70px 70px 20px;gap:5px;padding:6px 0;border-bottom:1px solid #0d1117;align-items:center">
+    <div style="display:grid;grid-template-columns:1fr 130px 70px 70px 20px;gap:5px;padding:6px 0;border-bottom:1px solid #f1f5f9;align-items:center">
       <div>
-        <div style="font-size:11px;color:#f0f6fc">${esc(inv.name)}</div>
-        <div style="font-size:9px;color:#6e7681">${inv.title?esc(inv.title)+' · ':''} ${inv.category||''}</div>
+        <div style="font-size:11px;color:#0f172a">${esc(inv.name)}</div>
+        <div style="font-size:9px;color:#64748b">${inv.title?esc(inv.title)+' · ':''} ${inv.category||''}</div>
       </div>
       <input class="ifield" type="text" value="${(inv.email||'').replace(/"/g,'&quot;')}" placeholder="email"
         oninput="S.invitees[${idx}].email=this.value;S.unsaved=true" style="font-size:9px;padding:3px 7px">
@@ -969,7 +999,7 @@ function renderInvitees() {
       <button class="btn sm stop" onclick="S.invitees.splice(${idx},1);S.unsaved=true;render()" style="padding:2px 5px">✕</button>
     </div>`).join('')}
     ${S.invitees.length>0?`
-    <div style="padding:8px 0;font-size:9px;color:#6e7681">
+    <div style="padding:8px 0;font-size:9px;color:#64748b">
       ${S.invitees.filter(i=>!i.email).length} missing email ·
       ${S.invitees.filter(i=>i.rsvpLink).length} with RSVP links ·
       ${S.invitees.filter(i=>i.inviteStatus==='sent').length} sent
@@ -984,7 +1014,7 @@ function renderCompose() {
   const prevLast  = prevInv ? prevInv.name.split(' ').slice(1).join(' ') : 'Official';
   return `<div style="display:grid;grid-template-columns:1fr 1fr;height:100%;overflow:hidden">
     <!-- Left: editor -->
-    <div style="overflow-y:auto;padding:14px 16px;border-right:1px solid #21262d">
+    <div style="overflow-y:auto;padding:14px 16px;border-right:1px solid #e2e8f0">
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px">
         <div style="display:flex;gap:3px">
           ${['html','text'].map(m=>`<button class="cat${S.tplMode===m?' on':''}" onclick="S.tplMode='${m}';render()">${m.toUpperCase()}</button>`).join('')}
@@ -993,35 +1023,35 @@ function renderCompose() {
       </div>
 
       ${S.tplMode==='html'?`
-      <div style="font-size:9px;color:#6e7681;margin-bottom:4px">HTML EMAIL TEMPLATE</div>
-      <textarea style="background:#0d1117;border:1px solid #21262d;color:#c9d1d9;padding:8px 10px;border-radius:5px;font-family:'DM Mono',monospace;font-size:10px;width:100%;min-height:300px;outline:none;resize:vertical;line-height:1.5"
+      <div style="font-size:9px;color:#64748b;margin-bottom:4px">HTML EMAIL TEMPLATE</div>
+      <textarea style="background:#ffffff;border:1px solid #e2e8f0;color:#1e293b;padding:8px 10px;border-radius:5px;font-family:'Inter',system-ui,sans-serif;font-size:10px;width:100%;min-height:300px;outline:none;resize:vertical;line-height:1.5"
         oninput="S.htmlBody=this.value;S.unsaved=true;requestAnimationFrame(refreshComposePreview)">${esc(S.htmlBody||EMAIL_TEMPLATE.trim())}</textarea>
       <button class="btn sm" style="margin-top:5px" onclick="S.htmlBody='';S.unsaved=true;render()">↺ Reset to default</button>
       `:
       `<div style="margin-bottom:8px">
-        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">SUBJECT</div>
+        <div style="font-size:9px;color:#64748b;margin-bottom:3px">SUBJECT</div>
         <input class="ifield" type="text" value="${(S.textSubject||'').replace(/"/g,'&quot;')}" oninput="S.textSubject=this.value;S.unsaved=true;requestAnimationFrame(refreshComposePreview)">
       </div>
       <div>
-        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">BODY</div>
-        <textarea style="background:#0d1117;border:1px solid #21262d;color:#c9d1d9;padding:8px 10px;border-radius:5px;font-family:'DM Mono',monospace;font-size:11px;width:100%;min-height:260px;outline:none;resize:vertical;line-height:1.7"
+        <div style="font-size:9px;color:#64748b;margin-bottom:3px">BODY</div>
+        <textarea style="background:#ffffff;border:1px solid #e2e8f0;color:#1e293b;padding:8px 10px;border-radius:5px;font-family:'Inter',system-ui,sans-serif;font-size:11px;width:100%;min-height:260px;outline:none;resize:vertical;line-height:1.7"
           oninput="S.textBody=this.value;S.unsaved=true">${esc(S.textBody)}</textarea>
       </div>`}
 
-      <div style="margin-top:10px;padding:8px 10px;background:#0d1117;border:1px solid #21262d;border-radius:5px">
-        <div style="font-size:9px;color:#6e7681;margin-bottom:5px;letter-spacing:.1em">TOKENS — click to copy</div>
+      <div style="margin-top:10px;padding:8px 10px;background:#ffffff;border:1px solid #e2e8f0;border-radius:5px">
+        <div style="font-size:9px;color:#64748b;margin-bottom:5px;letter-spacing:.03em">TOKENS — click to copy</div>
         <div style="display:flex;flex-wrap:wrap;gap:4px">
           ${['{{FirstName}}','{{LastName}}','{{FullTitle}}','{{EventName}}','{{EventDate}}','{{Venue}}','{{RSVP_Link}}','{{OrgName}}','{{ContactName}}','{{ContactEmail}}','{{VIPStart}}','{{VIPEnd}}','{{Date_Sent}}'].map(v=>`
-          <code style="font-size:10px;padding:2px 6px;background:#161b22;border:1px solid #21262d;border-radius:3px;cursor:pointer;color:#C8A84B" onclick="navigator.clipboard.writeText('${v}');log('Copied ${v}')">${v}</code>`).join('')}
+          <code style="font-size:10px;padding:2px 6px;background:#e2e8f0;border:1px solid #e2e8f0;border-radius:3px;cursor:pointer;color:#d97706" onclick="navigator.clipboard.writeText('${v}');log('Copied ${v}')">${v}</code>`).join('')}
         </div>
       </div>
     </div>
 
     <!-- Right: preview -->
     <div style="display:flex;flex-direction:column;overflow:hidden">
-      <div style="padding:8px 12px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:8px;flex-shrink:0">
-        <div style="font-size:9px;color:#6e7681">PREVIEW FOR</div>
-        <select style="background:#0d1117;border:1px solid #21262d;color:#c9d1d9;padding:3px 6px;border-radius:4px;font-family:inherit;font-size:10px;outline:none" onchange="S.previewName=this.value;render()">
+      <div style="padding:8px 12px;border-bottom:1px solid #e2e8f0;display:flex;align-items:center;gap:8px;flex-shrink:0">
+        <div style="font-size:9px;color:#64748b">PREVIEW FOR</div>
+        <select style="background:#ffffff;border:1px solid #e2e8f0;color:#1e293b;padding:3px 6px;border-radius:4px;font-family:inherit;font-size:10px;outline:none" onchange="S.previewName=this.value;render()">
           ${S.invitees.length===0?'<option>Sample Official</option>':''}
           ${S.invitees.map(inv=>`<option value="${inv.name.replace(/"/g,'&quot;')}" ${S.previewName===inv.name?'selected':''}>${esc(inv.name)}</option>`).join('')}
         </select>
@@ -1049,21 +1079,21 @@ function renderSend() {
   const pct = S.sendProgress.total>0 ? Math.round(((S.sendProgress.sent+S.sendProgress.failed)/S.sendProgress.total)*100) : 0;
   const hasOAuth = !!S.googleClientId;
   return `<div style="padding:16px 20px;max-width:580px">
-    ${!hasOAuth?`<div style="background:#1a0e00;border:1px solid #bb8009;border-radius:6px;padding:10px 14px;margin-bottom:12px;font-size:11px;color:#e3b341">
-      Gmail OAuth not configured. <button class="btn sm gold" onclick="S.tab=1;render()">Go to Setup</button>
-      <span style="font-size:10px;color:#8b949e;display:block;margin-top:4px">Or use the manual Gmail fallback below.</span>
+    ${!hasOAuth?`<div style="background:#1a0e00;border:1px solid #b45309;border-radius:6px;padding:10px 14px;margin-bottom:12px;font-size:11px;color:#f59e0b">
+      Gmail OAuth not configured. <button class="btn sm gold" onclick="S.tab=0;render()">Go to Setup</button>
+      <span style="font-size:10px;color:#475569;display:block;margin-top:4px">Or use the manual Gmail fallback below.</span>
     </div>`:''}
 
     <div class="card">
-      <div style="font-size:12px;color:#f0f6fc;margin-bottom:12px">Send via Gmail API</div>
+      <div style="font-size:12px;color:#0f172a;margin-bottom:12px">Send via Gmail API</div>
       <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:14px">
-        <div style="background:#161b22;border-radius:6px;padding:11px 13px">
-          <div style="font-size:20px;font-weight:500;color:#f0f6fc">${unsent.length}</div>
-          <div style="font-size:9px;color:#6e7681;margin-top:2px">Unsent invitees</div>
+        <div style="background:#e2e8f0;border-radius:6px;padding:11px 13px">
+          <div style="font-size:20px;font-weight:500;color:#0f172a">${unsent.length}</div>
+          <div style="font-size:9px;color:#64748b;margin-top:2px">Unsent invitees</div>
         </div>
-        <div style="background:#0c1a0c;border-radius:6px;padding:11px 13px">
-          <div style="font-size:20px;font-weight:500;color:#3fb950">${S.invitees.filter(i=>i.inviteStatus==='sent').length}</div>
-          <div style="font-size:9px;color:#3fb950;margin-top:2px">Already sent</div>
+        <div style="background:#f0fdf4;border-radius:6px;padding:11px 13px">
+          <div style="font-size:20px;font-weight:500;color:#22c55e">${S.invitees.filter(i=>i.inviteStatus==='sent').length}</div>
+          <div style="font-size:9px;color:#22c55e;margin-top:2px">Already sent</div>
         </div>
       </div>
       <div style="display:flex;gap:7px;flex-wrap:wrap">
@@ -1077,7 +1107,7 @@ function renderSend() {
       </div>
       ${(S.sending||S.sendProgress.total>0)?`
       <div style="margin-top:10px">
-        <div style="display:flex;justify-content:space-between;font-size:9px;color:#6e7681;margin-bottom:4px">
+        <div style="display:flex;justify-content:space-between;font-size:9px;color:#64748b;margin-bottom:4px">
           <span>${S.sending?'Sending to '+S.sendProgress.current+'…':'Done'}</span>
           <span>${S.sendProgress.sent} sent · ${S.sendProgress.failed} failed · ${pct}%</span>
         </div>
@@ -1087,27 +1117,27 @@ function renderSend() {
 
     ${S.sendLog.length>0?`
     <div class="card">
-      <div style="font-size:11px;color:#f0f6fc;margin-bottom:10px">Send Log</div>
+      <div style="font-size:11px;color:#0f172a;margin-bottom:10px">Send Log</div>
       <div style="max-height:240px;overflow-y:auto">
         ${S.sendLog.map(entry=>`
-        <div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #161b22;font-size:11px">
-          <span style="color:#f0f6fc;font-weight:500">${esc(entry.name)}</span>
+        <div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #e2e8f0;font-size:11px">
+          <span style="color:#0f172a;font-weight:500">${esc(entry.name)}</span>
           <div style="display:flex;gap:10px;align-items:center">
-            <span style="font-size:9px;color:#6e7681">${entry.email}</span>
-            <span style="font-size:10px;font-weight:500;color:${entry.status==='sent'?'#3fb950':'#f85149'}">${entry.status==='sent'?'✓ Sent':'✗ '+entry.status}</span>
-            <span style="font-size:9px;color:#6e7681">${entry.ts}</span>
+            <span style="font-size:9px;color:#64748b">${entry.email}</span>
+            <span style="font-size:10px;font-weight:500;color:${entry.status==='sent'?'#22c55e':'#dc2626'}">${entry.status==='sent'?'✓ Sent':'✗ '+entry.status}</span>
+            <span style="font-size:9px;color:#64748b">${entry.ts}</span>
           </div>
         </div>`).join('')}
       </div>
     </div>`:''}
 
-    <div class="card" style="background:#0a0d14;border-color:#1f6feb">
-      <div style="font-size:10px;color:#58a6ff;margin-bottom:5px;font-weight:500">Manual fallback — Gmail compose</div>
-      <div style="font-size:9px;color:#8b949e;margin-bottom:8px;line-height:1.5">Opens Gmail in browser tab. HTML downloads for manual paste. Use if OAuth isn't configured.</div>
+    <div class="card" style="background:#eff6ff;border-color:#bfdbfe">
+      <div style="font-size:10px;color:#3b82f6;margin-bottom:5px;font-weight:500">Manual fallback — Gmail compose</div>
+      <div style="font-size:9px;color:#475569;margin-bottom:8px;line-height:1.5">Opens Gmail in browser tab. HTML downloads for manual paste. Use if OAuth isn't configured.</div>
       <div style="display:flex;gap:5px;flex-wrap:wrap">
         ${S.invitees.filter(i=>i.email&&i.inviteStatus!=='sent').slice(0,5).map(inv=>`
         <button class="btn sm" onclick='openGmailFallback(${JSON.stringify(inv).replace(/"/g,"&quot;")})' style="font-size:9px">✉ ${esc(inv.name.split(' ')[0])}</button>`).join('')}
-        ${S.invitees.filter(i=>i.email&&i.inviteStatus!=='sent').length>5?`<span style="font-size:9px;color:#6e7681;padding:4px 0">+${S.invitees.filter(i=>i.email&&i.inviteStatus!=='sent').length-5} more</span>`:''}
+        ${S.invitees.filter(i=>i.email&&i.inviteStatus!=='sent').length>5?`<span style="font-size:9px;color:#64748b;padding:4px 0">+${S.invitees.filter(i=>i.email&&i.inviteStatus!=='sent').length-5} more</span>`:''}
       </div>
     </div>
   </div>`;
@@ -1121,33 +1151,33 @@ function renderTracker() {
   const noResp    = S.invitees.filter(i=>i.rsvpStatus==='no_response');
   const total     = S.invitees.length || 1;
   // Simple visual bar chart (pure CSS, no recharts)
-  const bars = [['Confirmed',confirmed.length,'#3fb950'],['Declined',declined.length,'#f85149'],['Pending',pending.length,'#e3b341'],['No RSVP',noResp.length,'#6e7681']];
+  const bars = [['Confirmed',confirmed.length,'#22c55e'],['Declined',declined.length,'#dc2626'],['Pending',pending.length,'#f59e0b'],['No RSVP',noResp.length,'#64748b']];
   return `<div style="padding:16px 20px">
     <!-- Stat cards -->
     <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:8px;margin-bottom:14px">
-      ${[['Total',S.invitees.length,'',''],['Confirmed',confirmed.length,'#0c1a0c','#3fb950'],['Declined',declined.length,'#1a0a0a','#f85149'],['Pending',pending.length,'#1a1400','#e3b341'],['No RSVP',noResp.length,'','#6e7681']].map(([l,v,bg,tc])=>`
-      <div style="background:${bg||'#161b22'};border:1px solid #21262d;border-radius:6px;padding:11px 12px">
-        <div style="font-size:22px;font-weight:500;color:${tc||'#f0f6fc'}">${v}</div>
-        <div style="font-size:9px;color:${tc||'#6e7681'};margin-top:2px;letter-spacing:.06em">${l}</div>
+      ${[['Total',S.invitees.length,'',''],['Confirmed',confirmed.length,'#0c1a0c','#22c55e'],['Declined',declined.length,'#1a0a0a','#dc2626'],['Pending',pending.length,'#1a1400','#f59e0b'],['No RSVP',noResp.length,'','#64748b']].map(([l,v,bg,tc])=>`
+      <div style="background:${bg||'#e2e8f0'};border:1px solid #e2e8f0;border-radius:6px;padding:11px 12px">
+        <div style="font-size:22px;font-weight:500;color:${tc||'#0f172a'}">${v}</div>
+        <div style="font-size:9px;color:${tc||'#64748b'};margin-top:2px;letter-spacing:.06em">${l}</div>
       </div>`).join('')}
     </div>
 
     <!-- Sync bar -->
-    <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;padding:7px 11px;background:#0d1117;border:1px solid #21262d;border-radius:6px">
+    <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;padding:7px 11px;background:#ffffff;border:1px solid #e2e8f0;border-radius:6px">
       <button class="btn sm pri" onclick="syncRsvpResponses()" ${!S.googleClientId?'disabled title="Add Google OAuth Client ID in Setup"':''}>↻ Sync RSVP Responses</button>
-      <span style="font-size:10px;color:#6e7681">Reads your Google Form response sheet and matches by email.</span>
-      ${!S.googleClientId?'<span style="font-size:9px;color:#e3b341">🔒 OAuth needed</span>':''}
+      <span style="font-size:10px;color:#64748b">Reads your Google Form response sheet and matches by email.</span>
+      ${!S.googleClientId?'<span style="font-size:9px;color:#f59e0b">🔒 OAuth needed</span>':''}
     </div>
 
     <!-- Bar chart -->
     <div class="card" style="margin-bottom:12px">
-      <div style="font-size:10px;color:#f0f6fc;margin-bottom:12px">Response Breakdown</div>
+      <div style="font-size:10px;color:#0f172a;margin-bottom:12px">Response Breakdown</div>
       ${bars.map(([label,count,color])=>`
       <div style="margin-bottom:8px">
-        <div style="display:flex;justify-content:space-between;font-size:9px;color:#6e7681;margin-bottom:3px">
+        <div style="display:flex;justify-content:space-between;font-size:9px;color:#64748b;margin-bottom:3px">
           <span>${label}</span><span style="color:${color}">${count} (${Math.round(count/total*100)}%)</span>
         </div>
-        <div style="height:8px;background:#161b22;border-radius:4px;overflow:hidden">
+        <div style="height:8px;background:#e2e8f0;border-radius:4px;overflow:hidden">
           <div style="height:100%;width:${Math.round(count/total*100)}%;background:${color};border-radius:4px;transition:width .4s"></div>
         </div>
       </div>`).join('')}
@@ -1156,22 +1186,22 @@ function renderTracker() {
     <!-- Confirmed addresses -->
     <div class="card">
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px">
-        <div style="font-size:10px;color:#f0f6fc">Confirmed — Recent RSVPs</div>
+        <div style="font-size:10px;color:#0f172a">Confirmed — Recent RSVPs</div>
         <button class="btn sm" onclick="navigator.clipboard.writeText('${confirmed.map(i=>i.name+' <'+i.email+'>').join(', ')}');log('${confirmed.length} confirmed emails copied')">Copy emails</button>
       </div>
-      ${confirmed.length===0?'<div style="font-size:10px;color:#6e7681">No confirmed attendees yet.</div>':''}
+      ${confirmed.length===0?'<div style="font-size:10px;color:#64748b">No confirmed attendees yet.</div>':''}
       ${confirmed.slice(0,20).map(inv=>`
-      <div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #161b22;font-size:11px">
+      <div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #e2e8f0;font-size:11px">
         <div>
-          <span style="color:#f0f6fc;font-weight:500">${esc(inv.name)}</span>
-          <span style="color:#6e7681;font-size:9px;margin-left:8px">${esc(inv.title||'')}</span>
+          <span style="color:#0f172a;font-weight:500">${esc(inv.name)}</span>
+          <span style="color:#64748b;font-size:9px;margin-left:8px">${esc(inv.title||'')}</span>
         </div>
-        <div style="text-align:right;font-size:9px;color:#6e7681">
-          ${inv.rsvpDate?'<span style="color:#3fb950">'+inv.rsvpDate+'</span>':''}
+        <div style="text-align:right;font-size:9px;color:#64748b">
+          ${inv.rsvpDate?'<span style="color:#22c55e">'+inv.rsvpDate+'</span>':''}
           <div>${esc(inv.email)}</div>
         </div>
       </div>`).join('')}
-      ${confirmed.length>20?`<div style="font-size:9px;color:#6e7681;padding-top:6px">+ ${confirmed.length-20} more</div>`:''}
+      ${confirmed.length>20?`<div style="font-size:9px;color:#64748b;padding-top:6px">+ ${confirmed.length-20} more</div>`:''}
     </div>
   </div>`;
 }
@@ -1181,14 +1211,14 @@ function renderSync() {
   const hasMaster = !!S.event.masterSheetUrl;
   const hasOAuth  = !!S.googleClientId;
   return `<div style="padding:16px 20px;max-width:560px">
-    <div class="card" style="background:#0a0f1a;border-color:#1f6feb">
-      <div style="font-size:12px;color:#58a6ff;margin-bottom:8px;font-weight:500">⬡ Sync to Master Google Sheet</div>
-      <div style="font-size:10px;color:#8b949e;line-height:1.6;margin-bottom:12px">
+    <div class="card" style="background:#eff6ff;border-color:#bfdbfe">
+      <div style="font-size:12px;color:#3b82f6;margin-bottom:8px;font-weight:500">⬡ Sync to Master Google Sheet</div>
+      <div style="font-size:10px;color:#475569;line-height:1.6;margin-bottom:12px">
         Writes all ${S.invitees.length} invitees with current invite + RSVP status to your master sheet.<br>
         Columns: FirstName, LastName, Title, Category, Email, RSVP_Link, InviteSent, InviteSentDate, RSVP_Status, RSVP_Date, Notes
       </div>
       <div style="margin-bottom:10px">
-        <div style="font-size:9px;color:#6e7681;margin-bottom:3px">MASTER SHEET URL</div>
+        <div style="font-size:9px;color:#64748b;margin-bottom:3px">MASTER SHEET URL</div>
         <input class="ifield" type="text" placeholder="https://docs.google.com/spreadsheets/d/..."
           value="${(S.event.masterSheetUrl||'').replace(/"/g,'&quot;')}"
           oninput="S.event.masterSheetUrl=this.value;S.unsaved=true">
@@ -1196,35 +1226,35 @@ function renderSync() {
       <div style="display:flex;gap:7px;flex-wrap:wrap;align-items:center">
         <button class="btn pri" onclick="syncToMasterSheet()" ${!hasOAuth||!hasMaster?'disabled':''}>⬡ Sync to Sheet</button>
         ${hasMaster?`<button class="btn sm" onclick="window.open('${S.event.masterSheetUrl}','_blank')">Open Sheet ↗</button>`:''}
-        ${!hasOAuth?'<span style="font-size:9px;color:#e3b341">🔒 OAuth needed — go to Setup</span>':''}
-        ${!hasMaster&&hasOAuth?'<span style="font-size:9px;color:#6e7681">Enter Sheet URL above</span>':''}
+        ${!hasOAuth?'<span style="font-size:9px;color:#f59e0b">🔒 OAuth needed — go to Setup</span>':''}
+        ${!hasMaster&&hasOAuth?'<span style="font-size:9px;color:#64748b">Enter Sheet URL above</span>':''}
       </div>
     </div>
 
     <div class="card">
-      <div style="font-size:11px;color:#f0f6fc;margin-bottom:8px">CSV Export (no OAuth needed)</div>
-      <div style="font-size:10px;color:#8b949e;margin-bottom:10px">Download all ${S.invitees.length} invitees as a CSV with all 10 tracking columns. Import into any spreadsheet.</div>
+      <div style="font-size:11px;color:#0f172a;margin-bottom:8px">CSV Export (no OAuth needed)</div>
+      <div style="font-size:10px;color:#475569;margin-bottom:10px">Download all ${S.invitees.length} invitees as a CSV with all 10 tracking columns. Import into any spreadsheet.</div>
       <button class="btn grn" onclick="exportCSV()">↓ Export Master CSV</button>
     </div>
 
-    <div class="card" style="background:#0a0a0a">
-      <div style="font-size:10px;color:#6e7681;margin-bottom:8px">Google Apps Script (optional power tool)</div>
-      <div style="font-size:9px;color:#6e7681;line-height:1.6">
-        The <code style="color:#C8A84B">scripts/general_user_workflow.gs</code> file in this repo provides in-sheet menu actions:
+    <div class="card" style="background:#f8fafc">
+      <div style="font-size:10px;color:#64748b;margin-bottom:8px">Google Apps Script (optional power tool)</div>
+      <div style="font-size:9px;color:#64748b;line-height:1.6">
+        The <code style="color:#d97706">scripts/general_user_workflow.gs</code> file in this repo provides in-sheet menu actions:
         Generate RSVP Links, Send Invites, Sync RSVPs — all runnable from within Google Sheets.<br>
         Use this if you prefer managing the workflow from the spreadsheet side.
       </div>
     </div>
 
-    <div class="card" style="background:#0a1a0a;border-color:#238636">
-      <div style="font-size:10px;color:#3fb950;margin-bottom:8px">Workflow Summary</div>
-      <div style="font-size:10px;color:#8b949e;line-height:1.8">
-        1. <strong style="color:#f0f6fc">Invitees tab</strong> → Import from Sheet (or CSV)<br>
-        2. <strong style="color:#f0f6fc">Invitees tab</strong> → Generate RSVP Links<br>
-        3. <strong style="color:#f0f6fc">Compose tab</strong> → Review/customize email template<br>
-        4. <strong style="color:#f0f6fc">Send tab</strong> → Send new only (Gmail OAuth)<br>
-        5. <strong style="color:#f0f6fc">Tracker tab</strong> → Sync RSVP Responses from Form<br>
-        6. <strong style="color:#f0f6fc">Sync tab</strong> → Sync to Master Sheet
+    <div class="card" style="background:#f0fdf4;border-color:#86efac">
+      <div style="font-size:10px;color:#22c55e;margin-bottom:8px">Workflow Summary</div>
+      <div style="font-size:10px;color:#475569;line-height:1.8">
+        1. <strong style="color:#0f172a">Invitees tab</strong> → Import from Sheet (or CSV)<br>
+        2. <strong style="color:#0f172a">Invitees tab</strong> → Generate RSVP Links<br>
+        3. <strong style="color:#0f172a">Compose tab</strong> → Review/customize email template<br>
+        4. <strong style="color:#0f172a">Send tab</strong> → Send new only (Gmail OAuth)<br>
+        5. <strong style="color:#0f172a">Tracker tab</strong> → Sync RSVP Responses from Form<br>
+        6. <strong style="color:#0f172a">Sync tab</strong> → Sync to Master Sheet
       </div>
     </div>
   </div>`;
@@ -1247,8 +1277,8 @@ function renderModal() {
 
   if (S.modal==='new') return `
   <div class="modal-bg" onclick="S.modal=null;render()"><div class="modal" onclick="event.stopPropagation()">
-    <div style="font-size:13px;color:#f0f6fc;margin-bottom:10px">Start New Event</div>
-    <p style="font-size:11px;color:#8b949e;line-height:1.6;margin-bottom:14px">This resets the current session. <strong style="color:#e3b341">Save your current profile first if you have unsaved work.</strong></p>
+    <div style="font-size:13px;color:#0f172a;margin-bottom:10px">Start New Event</div>
+    <p style="font-size:11px;color:#475569;line-height:1.6;margin-bottom:14px">This resets the current session. <strong style="color:#f59e0b">Save your current profile first if you have unsaved work.</strong></p>
     <button class="btn gold" onclick="exportProfile()">↓ Save Current Profile</button>
     <button class="btn stop" style="margin-left:8px" onclick="S.event={...DEFAULT_EVENT};S.invitees=[];syncImageOverrides();S.unsaved=false;S.modal=null;log('New event started.');render()">Reset & Start Fresh</button>
     <button class="btn sm" style="margin-left:8px" onclick="S.modal=null;render()">Cancel</button>
@@ -1256,10 +1286,10 @@ function renderModal() {
 
   if (S.modal==='researcher') return `
   <div class="modal-bg" onclick="S.modal=null;render()"><div class="modal" onclick="event.stopPropagation()">
-    <div style="font-size:13px;color:#f0f6fc;margin-bottom:10px">⬡ Import from VIP Researcher</div>
-    <p style="font-size:11px;color:#8b949e;line-height:1.7;margin-bottom:14px">
-      In VIP Researcher, click <strong style="color:#3fb950">⬡ Export → Mailer</strong> after verifying officials, then load that JSON file here.<br><br>
-      <strong style="color:#f0f6fc">Merge rules:</strong> New officials added as NOT SENT · Existing names get email refreshed, invite status preserved · Left-office excluded.
+    <div style="font-size:13px;color:#0f172a;margin-bottom:10px">⬡ Import from VIP Researcher</div>
+    <p style="font-size:11px;color:#475569;line-height:1.7;margin-bottom:14px">
+      In VIP Researcher, click <strong style="color:#22c55e">⬡ Export → Mailer</strong> after verifying officials, then load that JSON file here.<br><br>
+      <strong style="color:#0f172a">Merge rules:</strong> New officials added as NOT SENT · Existing names get email refreshed, invite status preserved · Left-office excluded.
     </p>
     <button class="btn pri" onclick="triggerFile(importResearcher,'.json')">↑ Choose File</button>
     <button class="btn sm" style="margin-left:8px" onclick="S.modal=null;render()">Cancel</button>
@@ -1267,9 +1297,9 @@ function renderModal() {
 
   if (S.modal==='add') return `
   <div class="modal-bg" onclick="S.modal=null;render()"><div class="modal" onclick="event.stopPropagation()">
-    <div style="font-size:13px;color:#f0f6fc;margin-bottom:14px">Add Invitee Manually</div>
+    <div style="font-size:13px;color:#0f172a;margin-bottom:14px">Add Invitee Manually</div>
     ${[['Full Name *','m_name','Firstname Lastname'],['Title','m_title','e.g. US Representative'],['Email','m_email','scheduler@example.gov'],['Category','m_cat','e.g. US House']].map(([l,id,ph])=>`
-    <div style="margin-bottom:9px"><div style="font-size:9px;color:#6e7681;margin-bottom:3px">${l}</div><input id="${id}" class="ifield" type="text" placeholder="${ph}"></div>`).join('')}
+    <div style="margin-bottom:9px"><div style="font-size:9px;color:#64748b;margin-bottom:3px">${l}</div><input id="${id}" class="ifield" type="text" placeholder="${ph}"></div>`).join('')}
     <button class="btn pri" onclick="
       const n=document.getElementById('m_name').value.trim();
       if(!n){alert('Name required');return;}
@@ -1283,9 +1313,9 @@ function renderModal() {
 
   if (S.modal==='fullpreview') return `
   <div class="modal-bg" style="padding:0;align-items:stretch" onclick="S.modal=null;render()">
-  <div style="display:flex;flex-direction:column;width:100%;max-width:780px;margin:0 auto;background:#0d1117;height:100vh" onclick="event.stopPropagation()">
-    <div style="background:#080c10;padding:8px 15px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:10px;flex-shrink:0">
-      <span style="font-size:11px;color:#f0f6fc">Full Preview</span>
+  <div style="display:flex;flex-direction:column;width:100%;max-width:780px;margin:0 auto;background:#ffffff;height:100vh" onclick="event.stopPropagation()">
+    <div style="background:#f8fafc;padding:8px 15px;border-bottom:1px solid #e2e8f0;display:flex;align-items:center;gap:10px;flex-shrink:0">
+      <span style="font-size:11px;color:#0f172a">Full Preview</span>
       <button class="btn sm" style="margin-left:auto" onclick="S.modal=null;render()">✕ Close</button>
     </div>
     <iframe id="full-preview-frame" style="flex:1;border:none;background:#fff"></iframe>


### PR DESCRIPTION
## Summary

- **Backend #1**: Upgrade contactscout.html to `claude-sonnet-4-6` with extended thinking (budget: 8000 tokens); improved API key onboarding (welcome card, setup notice for placeholder prompts, link to console.anthropic.com)
- **Backend #2**: Harden Google Sheets sync — atomic clear+write with error check, concurrent OAuth token queue, `syncRsvpResponses` rsvpCol guard, chunked `toBase64Url` to prevent V8 stack overflow, surfaced `QuotaExceededError` in activity log
- **Frontend #1**: `index.html` redesigned — InviteFlow as sole hero, ContactScout hidden behind "Internal tools" password prompt (password: `scout2025`)
- **Full theming overhaul**: Dark → light theme (30-color swap), DM Mono/Syne → Inter, polished buttons/modals/inputs, backdrop-blur overlays
- **Mobile-first**: `@media(max-width:768px)` in both apps — body scrolls, main grid stacks, compose/tracker columns responsive
- **InviteFlow UX**: Setup moved to tab 0, welcome card with 3-step checklist, `Go to Setup` deeplink fixed, header renamed to "InviteFlow", OAuth card light-themed
- **ContactScout UX**: Header sentence-cased, invisible text/border contrast fixed

## Test plan

- [ ] Open `index.html` — only InviteFlow card visible; "Internal tools" → password `scout2025` → redirects to ContactScout
- [ ] Open `inviteflow.html` — lands on Setup tab with welcome card; Inter font, light background
- [ ] Resize to mobile — layout stacks, no horizontal overflow
- [ ] Open `contactscout.html` — "ContactScout" header, Inter font, light background; welcome banner visible when no key set
- [ ] Click ⚙ Key in ContactScout — modal shows link to console.anthropic.com
- [ ] Scan tab with placeholder prompts → yellow setup notice appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)