### PR TITLE
feat(v3.1): responsive mobile-first UI — Tailwind v4, dark mode, hamburger nav

### DIFF
--- a/docs/superpowers/plans/2026-04-25-responsive-mobile-first.md
+++ b/docs/superpowers/plans/2026-04-25-responsive-mobile-first.md
@@ -1,0 +1,2131 @@
+# InviteFlow v3.1 — Responsive Mobile-First Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate InviteFlow v3 to a responsive, mobile-first React app with Tailwind CSS v4, light-theme default, dark-mode toggle, hamburger drawer nav, and WCAG AA touch targets.
+
+**Architecture:** Full replacement of inline styles with Tailwind utility classes + `dark:` variants. Dark mode is class-based (`<html class="dark">`), toggled by a button in the header and persisted in `localStorage`. Mobile nav collapses to a hamburger drawer below the `md:` breakpoint (768px).
+
+**Tech Stack:** React 18, TypeScript, Vite 6, Tailwind CSS v4 (`@tailwindcss/vite`), PrimeReact 10 (DataTable), TipTap 2 (rich text editor)
+
+---
+
+## Color Reference
+
+Use this table throughout every task. Never invent new colors.
+
+| Role | Light class | Dark class |
+|---|---|---|
+| App background | `bg-gray-50` | `dark:bg-[#080c10]` |
+| Card / surface | `bg-white` | `dark:bg-[#0d1117]` |
+| Subtle surface | `bg-gray-100` | `dark:bg-[#161b22]` |
+| Border | `border-gray-200` | `dark:border-[#21262d]` |
+| Primary text | `text-gray-900` | `dark:text-[#c9d1d9]` |
+| Muted text | `text-gray-500` | `dark:text-[#6e7681]` |
+| Secondary text | `text-gray-400` | `dark:text-[#8b949e]` |
+| Blue link | `text-blue-600` | `dark:text-[#58a6ff]` |
+| Blue bg (active tab) | `bg-blue-600 text-white` | `dark:bg-[#1f6feb]` |
+| Gold accent | `text-[#C8A84B]` | `dark:text-[#C8A84B]` |
+| Green success | `text-green-600` | `dark:text-[#3fb950]` |
+| Red error | `text-red-600` | `dark:text-[#f85149]` |
+| Input | `bg-white border-gray-300` | `dark:bg-[#0d1117] dark:border-[#21262d]` |
+
+## Button Classes Reference
+
+Reuse these exact class strings in every task:
+
+```
+// Default (ghost)
+"min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-gray-700 text-xs font-mono tracking-wide cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22] disabled:opacity-50 disabled:cursor-not-allowed"
+
+// Primary (blue fill)
+"min-h-[44px] px-3 py-1 rounded border border-blue-600 bg-blue-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-700 dark:border-[#1f6feb] dark:bg-[#1f6feb] dark:hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+
+// Success (green fill)
+"min-h-[44px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-green-700 dark:border-[#238636] dark:bg-[#238636] disabled:opacity-50 disabled:cursor-not-allowed"
+
+// Danger (red ghost)
+"min-h-[44px] px-3 py-1 rounded border border-red-500 bg-transparent text-red-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-red-50 dark:border-[#f85149] dark:text-[#f85149] dark:hover:bg-[#2d0f0e] disabled:opacity-50 disabled:cursor-not-allowed"
+
+// Blue ghost
+"min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c] disabled:opacity-50 disabled:cursor-not-allowed"
+```
+
+## Input Classes Reference
+
+```
+// Standard input
+"w-full bg-white border border-gray-300 text-gray-900 text-xs font-mono px-2.5 py-1.5 rounded outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9] dark:focus:border-[#58a6ff]"
+```
+
+## Section Label Classes Reference
+
+```
+// Section divider label
+"text-[10px] text-gray-500 tracking-widest font-mono uppercase mt-5 mb-2.5 border-b border-gray-200 pb-1.5 dark:text-[#6e7681] dark:border-[#21262d]"
+
+// Small muted label
+"text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-1 dark:text-[#6e7681]"
+```
+
+---
+
+## Task 1: Tailwind v4 Installation
+
+**Files:**
+- Modify: `package.json`
+- Modify: `vite.config.ts`
+- Create: `src/index.css`
+- Modify: `src/inviteflow/index.html`
+
+- [ ] **Step 1: Install Tailwind v4 packages**
+
+```bash
+cd "C:\Users\lycha\Desktop\projects\Asian_Focus\VIPs\automate-invite-emails\.claude\worktrees\dreamy-kirch-ae0dc6"
+npm install tailwindcss @tailwindcss/vite
+```
+
+Expected: packages added to `node_modules`, `package.json` updated.
+
+- [ ] **Step 2: Update vite.config.ts**
+
+Replace entire `vite.config.ts`:
+
+```ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [tailwindcss(), react()],
+  base: process.env.VITE_BASE_URL ?? './',
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      input: {
+        inviteflow: 'src/inviteflow/index.html',
+      },
+      output: {
+        entryFileNames: 'assets/[name]-[hash].js',
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash].[ext]',
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 3: Create src/index.css**
+
+```css
+@import "tailwindcss";
+
+@variant dark (&:where(.dark, .dark *));
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+```
+
+- [ ] **Step 4: Update index.html title and viewport**
+
+Replace `src/inviteflow/index.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>InviteFlow v3.1</title>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/inviteflow/main.tsx"></script>
+</body>
+</html>
+```
+
+- [ ] **Step 5: Verify build passes**
+
+```bash
+npm run build
+```
+
+Expected: build completes without errors. Tailwind generates CSS in dist.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vite.config.ts src/index.css src/inviteflow/index.html package.json package-lock.json
+git commit -m "feat(v3.1): install Tailwind v4, update vite config, add index.css"
+```
+
+---
+
+## Task 2: Theme System — State, Reducer, Actions
+
+**Files:**
+- Modify: `src/inviteflow/types.ts`
+- Modify: `src/inviteflow/state/actions.ts`
+- Modify: `src/inviteflow/state/reducer.ts`
+- Modify: `src/inviteflow/state/AppContext.tsx`
+
+- [ ] **Step 1: Add darkMode to AppState in types.ts**
+
+Add `darkMode: boolean;` to the `AppState` interface. Full replacement of `src/inviteflow/types.ts`:
+
+```ts
+export type TabId = 'events' | 'setup' | 'invitees' | 'compose' | 'send' | 'tracker' | 'sync';
+
+export interface AppEvent {
+  id: string;
+  name: string;
+  date: string;
+  venue: string;
+  orgName: string;
+  contactName: string;
+  contactEmail: string;
+  formUrl: string;
+  rsvpResponseUrl: string;
+  masterSheetUrl: string;
+  entryEmail: string;
+  imgEmblemUrl: string;
+  vipStart: string;
+  vipEnd: string;
+  googleClientId: string;
+}
+
+export interface Invitee {
+  id: string;
+  firstName: string;
+  lastName: string;
+  title: string;
+  category: string;
+  email: string;
+  rsvpLink: string;
+  inviteStatus: 'pending' | 'sent' | 'failed';
+  sentAt: string;
+  rsvpStatus: 'No Response' | 'Attending' | 'Declined';
+  rsvpDate: string;
+  notes: string;
+}
+
+export interface SendLogEntry {
+  id: string;
+  email: string;
+  name: string;
+  status: 'sent' | 'failed';
+  timestamp: string;
+  error?: string;
+}
+
+export interface AppState {
+  activeEventId: string | null;
+  events: AppEvent[];
+  invitees: Invitee[];
+  tab: TabId;
+  textSubject: string;
+  htmlBody: string;
+  sendLog: SendLogEntry[];
+  sending: boolean;
+  sendProgress: { current: number; total: number };
+  unsaved: boolean;
+  darkMode: boolean;
+}
+```
+
+- [ ] **Step 2: Add TOGGLE_DARK action to actions.ts**
+
+Replace `src/inviteflow/state/actions.ts`:
+
+```ts
+import type { AppEvent, AppState, Invitee, SendLogEntry, TabId } from '../types';
+
+export type Action =
+  | { type: 'SET_TAB'; tab: TabId }
+  | { type: 'SET_EVENTS'; events: AppEvent[] }
+  | { type: 'ADD_EVENT'; event: AppEvent }
+  | { type: 'UPDATE_EVENT'; event: AppEvent }
+  | { type: 'DELETE_EVENT'; id: string }
+  | { type: 'SET_ACTIVE_EVENT'; id: string | null }
+  | { type: 'SET_INVITEES'; invitees: Invitee[] }
+  | { type: 'ADD_INVITEE'; invitee: Invitee }
+  | { type: 'UPDATE_INVITEE'; invitee: Invitee }
+  | { type: 'DELETE_INVITEES'; ids: string[] }
+  | { type: 'SET_COMPOSE'; subject: string; html: string }
+  | { type: 'START_SEND'; total: number }
+  | { type: 'SEND_PROGRESS'; current: number }
+  | { type: 'LOG_SEND'; entry: SendLogEntry }
+  | { type: 'STOP_SEND' }
+  | { type: 'SET_UNSAVED'; unsaved: boolean }
+  | { type: 'TOGGLE_DARK' }
+  | { type: 'LOAD_STATE'; partial: Partial<AppState> };
+```
+
+- [ ] **Step 3: Handle TOGGLE_DARK in reducer.ts**
+
+Replace `src/inviteflow/state/reducer.ts`:
+
+```ts
+import type { AppState } from '../types';
+import type { Action } from './actions';
+
+function loadDarkPref(): boolean {
+  return localStorage.getItem('inviteflow_theme') === 'dark';
+}
+
+export const INITIAL_STATE: AppState = {
+  activeEventId: null,
+  events: [],
+  invitees: [],
+  tab: 'tracker',
+  textSubject: '',
+  htmlBody: '',
+  sendLog: [],
+  sending: false,
+  sendProgress: { current: 0, total: 0 },
+  unsaved: false,
+  darkMode: loadDarkPref(),
+};
+
+export function reducer(state: AppState, action: Action): AppState {
+  switch (action.type) {
+    case 'SET_TAB':
+      return { ...state, tab: action.tab };
+    case 'SET_EVENTS':
+      return { ...state, events: action.events };
+    case 'ADD_EVENT':
+      return { ...state, events: [...state.events, action.event], unsaved: true };
+    case 'UPDATE_EVENT':
+      return { ...state, events: state.events.map(e => e.id === action.event.id ? action.event : e), unsaved: true };
+    case 'DELETE_EVENT': {
+      const events = state.events.filter(e => e.id !== action.id);
+      const activeEventId = state.activeEventId === action.id ? (events[0]?.id ?? null) : state.activeEventId;
+      return { ...state, events, activeEventId, unsaved: true };
+    }
+    case 'SET_ACTIVE_EVENT':
+      return { ...state, activeEventId: action.id, invitees: [], unsaved: false };
+    case 'SET_INVITEES':
+      return { ...state, invitees: action.invitees, unsaved: true };
+    case 'ADD_INVITEE':
+      return { ...state, invitees: [...state.invitees, action.invitee], unsaved: true };
+    case 'UPDATE_INVITEE':
+      return { ...state, invitees: state.invitees.map(i => i.id === action.invitee.id ? action.invitee : i), unsaved: true };
+    case 'DELETE_INVITEES':
+      return { ...state, invitees: state.invitees.filter(i => !action.ids.includes(i.id)), unsaved: true };
+    case 'SET_COMPOSE':
+      return { ...state, textSubject: action.subject, htmlBody: action.html, unsaved: true };
+    case 'START_SEND':
+      return { ...state, sending: true, sendLog: [], sendProgress: { current: 0, total: action.total } };
+    case 'SEND_PROGRESS':
+      return { ...state, sendProgress: { ...state.sendProgress, current: action.current } };
+    case 'LOG_SEND':
+      return { ...state, sendLog: [...state.sendLog, action.entry] };
+    case 'STOP_SEND':
+      return { ...state, sending: false };
+    case 'SET_UNSAVED':
+      return { ...state, unsaved: action.unsaved };
+    case 'TOGGLE_DARK': {
+      const next = !state.darkMode;
+      localStorage.setItem('inviteflow_theme', next ? 'dark' : 'light');
+      return { ...state, darkMode: next };
+    }
+    case 'LOAD_STATE':
+      return { ...state, ...action.partial };
+    default:
+      return state;
+  }
+}
+```
+
+- [ ] **Step 4: Sync darkMode class to <html> in AppContext.tsx**
+
+Replace `src/inviteflow/state/AppContext.tsx`:
+
+```tsx
+import { createContext, useContext, useReducer, useEffect, type ReactNode } from 'react';
+import type { AppState } from '../types';
+import type { Action } from './actions';
+import { reducer, INITIAL_STATE } from './reducer';
+
+const STORAGE_KEY = 'inviteflow_v3_state';
+
+function saveState(state: AppState) {
+  const { sendLog: _sl, sending: _s, sendProgress: _sp, darkMode: _d, ...rest } = state;
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(rest)); } catch { /* quota */ }
+}
+
+function loadPersistedState(): Partial<AppState> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch { return {}; }
+}
+
+const StateCtx = createContext<AppState>(INITIAL_STATE);
+const DispatchCtx = createContext<React.Dispatch<Action>>(() => {});
+
+export function AppProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE, () => ({
+    ...INITIAL_STATE,
+    ...loadPersistedState(),
+  }));
+
+  useEffect(() => { saveState(state); }, [state]);
+
+  useEffect(() => {
+    if (state.darkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [state.darkMode]);
+
+  return (
+    <StateCtx.Provider value={state}>
+      <DispatchCtx.Provider value={dispatch}>
+        {children}
+      </DispatchCtx.Provider>
+    </StateCtx.Provider>
+  );
+}
+
+export const useAppState = () => useContext(StateCtx);
+export const useAppDispatch = () => useContext(DispatchCtx);
+```
+
+- [ ] **Step 5: Verify build**
+
+```bash
+npm run build
+```
+
+Expected: PASS — no TypeScript errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/inviteflow/types.ts src/inviteflow/state/actions.ts src/inviteflow/state/reducer.ts src/inviteflow/state/AppContext.tsx
+git commit -m "feat(v3.1): add darkMode state, TOGGLE_DARK action, sync class to <html>"
+```
+
+---
+
+## Task 3: Style Overrides (PrimeReact + TipTap)
+
+**Files:**
+- Modify: `src/inviteflow/main.tsx`
+- Create: `src/inviteflow/styles/tiptap.css`
+- Create: `src/inviteflow/styles/primereact-reset.css`
+
+- [ ] **Step 1: Update main.tsx — switch to light PrimeReact theme and import overrides**
+
+Replace `src/inviteflow/main.tsx`:
+
+```tsx
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import '../../index.css';
+import 'primereact/resources/themes/lara-light-indigo/theme.css';
+import 'primereact/resources/primereact.min.css';
+import 'primeicons/primeicons.css';
+import 'primeflex/primeflex.css';
+import './styles/primereact-reset.css';
+import './styles/tiptap.css';
+import App from './App';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('No #root element');
+createRoot(root).render(<StrictMode><App /></StrictMode>);
+```
+
+- [ ] **Step 2: Create src/inviteflow/styles/primereact-reset.css**
+
+This overrides PrimeReact lara-light-indigo CSS variables in dark mode so the DataTable inherits the app's dark palette:
+
+```css
+/* Override PrimeReact lara-light-indigo vars for dark mode */
+.dark {
+  --surface-ground: #080c10;
+  --surface-section: #080c10;
+  --surface-card: #0d1117;
+  --surface-overlay: #0d1117;
+  --surface-border: #21262d;
+  --surface-hover: #161b22;
+  --surface-0: #0d1117;
+  --surface-50: #0d1117;
+  --surface-100: #161b22;
+  --surface-200: #21262d;
+  --surface-300: #30363d;
+  --surface-400: #484f58;
+  --surface-500: #6e7681;
+  --surface-600: #8b949e;
+  --surface-700: #b1bac4;
+  --surface-800: #c9d1d9;
+  --surface-900: #f0f6fc;
+  --text-color: #c9d1d9;
+  --text-color-secondary: #6e7681;
+  --primary-color: #6366F1;
+  --primary-color-text: #ffffff;
+  color-scheme: dark;
+}
+
+/* Remove PrimeReact's default body background so app background shows */
+.p-datatable .p-datatable-thead > tr > th {
+  background: var(--surface-card);
+  color: var(--text-color-secondary);
+  border-color: var(--surface-border);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  font-family: monospace;
+}
+
+.p-datatable .p-datatable-tbody > tr {
+  background: var(--surface-card);
+  color: var(--text-color);
+  font-size: 11px;
+  font-family: monospace;
+}
+
+.p-datatable .p-datatable-tbody > tr:hover {
+  background: var(--surface-hover) !important;
+}
+
+.p-datatable .p-datatable-tbody > tr > td {
+  border-color: var(--surface-border);
+  padding: 6px 10px;
+}
+
+.p-datatable .p-datatable-thead > tr > th {
+  padding: 6px 10px;
+}
+```
+
+- [ ] **Step 3: Create src/inviteflow/styles/tiptap.css**
+
+```css
+/* TipTap editor content styles */
+.tiptap {
+  outline: none;
+  min-height: 200px;
+  font-size: 13px;
+  line-height: 1.8;
+  color: #111827;
+}
+
+.dark .tiptap {
+  color: #c9d1d9;
+}
+
+.tiptap p {
+  margin: 0.5em 0;
+}
+
+.tiptap ul,
+.tiptap ol {
+  padding-left: 1.5em;
+  margin: 0.5em 0;
+}
+
+.tiptap.ProseMirror-focused {
+  outline: none;
+}
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+npm run build
+```
+
+Expected: PASS — CSS imports resolve, no missing module errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/inviteflow/main.tsx src/inviteflow/styles/tiptap.css src/inviteflow/styles/primereact-reset.css
+git commit -m "feat(v3.1): switch to light PrimeReact theme, add dark-mode CSS var overrides, TipTap styles"
+```
+
+---
+
+## Task 4: App.tsx — Header, Hamburger Drawer, Theme Toggle
+
+**Files:**
+- Modify: `src/inviteflow/App.tsx`
+
+- [ ] **Step 1: Replace App.tsx with full Tailwind + hamburger drawer + theme toggle**
+
+```tsx
+import { useState } from 'react';
+import { AppProvider, useAppState, useAppDispatch } from './state/AppContext';
+import type { TabId } from './types';
+import EventsTab from './tabs/EventsTab';
+import SetupTab from './tabs/SetupTab';
+import InviteesTab from './tabs/InviteesTab';
+import ComposeTab from './tabs/ComposeTab';
+import SendTab from './tabs/SendTab';
+import TrackerTab from './tabs/TrackerTab';
+import SyncTab from './tabs/SyncTab';
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: 'events', label: 'Events' },
+  { id: 'setup', label: 'Setup' },
+  { id: 'invitees', label: 'Invitees' },
+  { id: 'compose', label: 'Compose' },
+  { id: 'send', label: 'Send' },
+  { id: 'tracker', label: 'Tracker' },
+  { id: 'sync', label: 'Sync' },
+];
+
+function TabContent() {
+  const { tab } = useAppState();
+  switch (tab) {
+    case 'events': return <EventsTab />;
+    case 'setup': return <SetupTab />;
+    case 'invitees': return <InviteesTab />;
+    case 'compose': return <ComposeTab />;
+    case 'send': return <SendTab />;
+    case 'tracker': return <TrackerTab />;
+    case 'sync': return <SyncTab />;
+  }
+}
+
+function AppInner() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const activeEvent = state.events.find(e => e.id === state.activeEventId);
+
+  function selectTab(id: TabId) {
+    dispatch({ type: 'SET_TAB', tab: id });
+    setDrawerOpen(false);
+  }
+
+  return (
+    <div className="h-screen bg-gray-50 text-gray-900 font-mono flex flex-col overflow-hidden dark:bg-[#080c10] dark:text-[#c9d1d9]">
+      {/* Header */}
+      <header className="border-b border-gray-200 px-4 py-2 flex items-center gap-3 shrink-0 bg-white dark:bg-[#0d1117] dark:border-[#21262d]">
+        {/* Left zone */}
+        <span className="font-black text-sm text-gray-900 tracking-tight dark:text-[#f0f6fc]">INVITEFLOW</span>
+        <span className="text-[9px] text-gray-400 tracking-[0.12em] dark:text-[#6e7681]">v3.1</span>
+        {activeEvent && (
+          <span className="text-[10px] text-[#C8A84B] tracking-[0.08em] border-l border-gray-200 pl-3 truncate max-w-[160px] dark:border-[#21262d]">
+            {activeEvent.name}
+          </span>
+        )}
+        {state.unsaved && (
+          <span className="text-[9px] text-gray-400 tracking-[0.1em] dark:text-[#6e7681]">●</span>
+        )}
+
+        {/* Right zone */}
+        <div className="ml-auto flex items-center gap-2">
+          {/* Theme toggle */}
+          <button
+            onClick={() => dispatch({ type: 'TOGGLE_DARK' })}
+            aria-label={state.darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-sm text-gray-500 hover:text-gray-900 dark:text-[#6e7681] dark:hover:text-[#c9d1d9] rounded"
+          >
+            {state.darkMode ? '☀' : '☾'}
+          </button>
+
+          {/* Desktop nav */}
+          <nav className="hidden md:flex gap-1" role="tablist">
+            {TABS.map(t => (
+              <button
+                key={t.id}
+                role="tab"
+                aria-selected={state.tab === t.id}
+                onClick={() => selectTab(t.id)}
+                className={[
+                  'min-h-[44px] px-2.5 py-1 rounded border text-[10px] font-mono tracking-[0.07em] uppercase cursor-pointer',
+                  state.tab === t.id
+                    ? 'bg-blue-600 border-blue-600 text-white dark:bg-[#1f6feb] dark:border-[#1f6feb]'
+                    : 'bg-transparent border-transparent text-gray-500 hover:text-gray-900 dark:text-[#8b949e] dark:hover:text-[#c9d1d9]',
+                ].join(' ')}
+              >
+                {t.label}
+              </button>
+            ))}
+          </nav>
+
+          {/* Hamburger (mobile only) */}
+          <button
+            className="md:hidden min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-600 dark:text-[#8b949e]"
+            onClick={() => setDrawerOpen(true)}
+            aria-label="Open navigation"
+          >
+            ☰
+          </button>
+        </div>
+      </header>
+
+      {/* Mobile drawer */}
+      {drawerOpen && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 bg-black/40 z-40 md:hidden"
+            onClick={() => setDrawerOpen(false)}
+          />
+          {/* Drawer */}
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Navigation"
+            className="fixed inset-y-0 left-0 w-64 bg-white border-r border-gray-200 z-50 flex flex-col md:hidden motion-safe:transition-transform dark:bg-[#0d1117] dark:border-[#21262d]"
+          >
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-[#21262d]">
+              <span className="font-black text-sm text-gray-900 tracking-tight dark:text-[#f0f6fc]">INVITEFLOW</span>
+              <button
+                onClick={() => setDrawerOpen(false)}
+                aria-label="Close navigation"
+                className="min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-500 dark:text-[#6e7681]"
+              >
+                ✕
+              </button>
+            </div>
+            <nav role="tablist" className="flex flex-col py-2">
+              {TABS.map(t => (
+                <button
+                  key={t.id}
+                  role="tab"
+                  aria-selected={state.tab === t.id}
+                  onClick={() => selectTab(t.id)}
+                  className={[
+                    'min-h-[44px] flex items-center px-5 text-xs font-mono tracking-[0.07em] uppercase cursor-pointer border-l-2',
+                    state.tab === t.id
+                      ? 'border-blue-600 bg-blue-50 text-blue-700 dark:border-[#1f6feb] dark:bg-[#0d1f3c] dark:text-[#58a6ff]'
+                      : 'border-transparent text-gray-600 hover:bg-gray-50 dark:text-[#8b949e] dark:hover:bg-[#161b22]',
+                  ].join(' ')}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </nav>
+          </div>
+        </>
+      )}
+
+      {/* Main content */}
+      <main className="flex-1 overflow-auto flex flex-col">
+        <TabContent />
+      </main>
+    </div>
+  );
+}
+
+export default function App() {
+  return <AppProvider><AppInner /></AppProvider>;
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Verify dev server visually**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:5173/src/inviteflow/index.html`. Verify:
+- Light theme loads by default
+- Header shows INVITEFLOW v3.1
+- Theme toggle (☾/☀) switches dark/light and persists after page reload
+- On narrow viewport (< 768px): hamburger ☰ appears, desktop nav hides
+- Drawer opens on ☰ tap, closes on backdrop or tab selection
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/inviteflow/App.tsx
+git commit -m "feat(v3.1): rebuild App.tsx — Tailwind classes, hamburger drawer, theme toggle"
+```
+
+---
+
+## Task 5: EventsTab
+
+**Files:**
+- Modify: `src/inviteflow/tabs/EventsTab.tsx`
+
+- [ ] **Step 1: Replace EventsTab.tsx with Tailwind classes**
+
+```tsx
+import { useEffect, useState } from 'react';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import { getToken } from '../api/auth';
+import { listAppDataFiles, getAppDataFile, createAppDataFile, deleteAppDataFile } from '../api/drive';
+import type { AppEvent } from '../types';
+
+function blankEvent(id: string): AppEvent {
+  return {
+    id,
+    name: 'New Event',
+    date: '',
+    venue: '',
+    orgName: '',
+    contactName: '',
+    contactEmail: '',
+    formUrl: '',
+    rsvpResponseUrl: '',
+    masterSheetUrl: '',
+    entryEmail: '',
+    imgEmblemUrl: '',
+    vipStart: '',
+    vipEnd: '',
+    googleClientId: localStorage.getItem('gClientId') ?? '',
+  };
+}
+
+export default function EventsTab() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState('');
+
+  async function loadEvents() {
+    setLoading(true);
+    setErr('');
+    try {
+      const token = await getToken('drive.appdata');
+      const files = await listAppDataFiles(token);
+      const configs = await Promise.all(
+        files
+          .filter(f => f.name.endsWith('.json'))
+          .map(async f => {
+            const data = await getAppDataFile(token, f.id) as AppEvent;
+            return { ...data, id: f.id };
+          })
+      );
+      dispatch({ type: 'SET_EVENTS', events: configs });
+    } catch (e) {
+      setErr(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { loadEvents(); }, []);
+
+  async function createEvent() {
+    setErr('');
+    try {
+      const token = await getToken('drive.appdata');
+      const tempId = crypto.randomUUID();
+      const ev = blankEvent(tempId);
+      const realId = await createAppDataFile(token, tempId + '.json', ev);
+      ev.id = realId;
+      dispatch({ type: 'ADD_EVENT', event: ev });
+      dispatch({ type: 'SET_ACTIVE_EVENT', id: realId });
+      dispatch({ type: 'SET_TAB', tab: 'setup' });
+    } catch (e) {
+      setErr(String(e));
+    }
+  }
+
+  async function deleteEvent(id: string) {
+    if (!confirm('Delete this event? This cannot be undone.')) return;
+    setErr('');
+    try {
+      const token = await getToken('drive.appdata');
+      await deleteAppDataFile(token, id);
+      dispatch({ type: 'DELETE_EVENT', id });
+    } catch (e) {
+      setErr(String(e));
+    }
+  }
+
+  return (
+    <div className="p-5 max-w-[860px] mx-auto w-full">
+      <div className="flex items-center justify-between mb-5">
+        <span className="text-sm font-bold tracking-[0.08em] text-gray-900 dark:text-[#f0f6fc]">EVENTS</span>
+        <div className="flex gap-2">
+          <button
+            onClick={loadEvents}
+            disabled={loading}
+            className="min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-gray-700 text-xs font-mono tracking-wide cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22] disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Loading…' : 'Refresh'}
+          </button>
+          <button
+            onClick={createEvent}
+            className="min-h-[44px] px-3 py-1 rounded border border-blue-600 bg-blue-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-700 dark:border-[#1f6feb] dark:bg-[#1f6feb]"
+          >
+            + New Event
+          </button>
+        </div>
+      </div>
+
+      {err && <div className="text-xs text-red-600 mb-3 dark:text-[#f85149]">{err}</div>}
+
+      {state.events.length === 0 && !loading && (
+        <div className="text-gray-500 text-xs text-center py-10 dark:text-[#6e7681]">
+          No events yet. Click &ldquo;+ New Event&rdquo; to create one.
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {state.events.map(ev => (
+          <div
+            key={ev.id}
+            className={[
+              'bg-white border rounded-lg p-4 cursor-pointer transition-colors dark:bg-[#0d1117]',
+              state.activeEventId === ev.id
+                ? 'border-[#C8A84B]'
+                : 'border-gray-200 hover:border-gray-400 dark:border-[#21262d] dark:hover:border-[#484f58]',
+            ].join(' ')}
+            onClick={() => { dispatch({ type: 'SET_ACTIVE_EVENT', id: ev.id }); dispatch({ type: 'SET_TAB', tab: 'setup' }); }}
+          >
+            <div className="text-sm font-bold text-gray-900 mb-1 dark:text-[#f0f6fc]">{ev.name || 'Unnamed Event'}</div>
+            <div className="text-[10px] text-gray-500 mb-3 dark:text-[#6e7681]">
+              {ev.date || 'No date'} · {ev.venue || 'No venue'}
+            </div>
+            <div className="flex gap-2" onClick={e => e.stopPropagation()}>
+              <button
+                onClick={() => { dispatch({ type: 'SET_ACTIVE_EVENT', id: ev.id }); dispatch({ type: 'SET_TAB', tab: 'setup' }); }}
+                className="min-h-[44px] px-3 py-1 rounded border border-blue-600 bg-blue-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-700 dark:border-[#1f6feb] dark:bg-[#1f6feb]"
+              >
+                {state.activeEventId === ev.id ? '✓ Active' : 'Activate'}
+              </button>
+              <button
+                onClick={() => deleteEvent(ev.id)}
+                className="min-h-[44px] px-3 py-1 rounded border border-red-500 bg-transparent text-red-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-red-50 dark:border-[#f85149] dark:text-[#f85149] dark:hover:bg-[#2d0f0e]"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build and commit**
+
+```bash
+npm run build && git add src/inviteflow/tabs/EventsTab.tsx && git commit -m "feat(v3.1): EventsTab — Tailwind classes, responsive card grid"
+```
+
+---
+
+## Task 6: SetupTab
+
+**Files:**
+- Modify: `src/inviteflow/tabs/SetupTab.tsx`
+
+- [ ] **Step 1: Replace SetupTab.tsx**
+
+```tsx
+import { useState } from 'react';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import { getToken, setClientId } from '../api/auth';
+import { updateAppDataFile } from '../api/drive';
+import type { AppEvent } from '../types';
+
+const FIELDS: Array<{ key: keyof AppEvent; label: string; type?: string; placeholder?: string }> = [
+  { key: 'name', label: 'Event Name', placeholder: 'Greater Triangle Dragon Boat Festival' },
+  { key: 'date', label: 'Event Date', type: 'date' },
+  { key: 'venue', label: 'Venue', placeholder: 'Jordan Lake State Recreation Area' },
+  { key: 'orgName', label: 'Organization Name', placeholder: 'Asian Focus NC' },
+  { key: 'contactName', label: 'Contact Name', placeholder: 'Lenya Chan' },
+  { key: 'contactEmail', label: 'Contact Email', type: 'email', placeholder: 'contact@org.com' },
+  { key: 'vipStart', label: 'VIP Start Time', placeholder: '10:00 AM' },
+  { key: 'vipEnd', label: 'VIP End Time', placeholder: '12:00 PM' },
+  { key: 'formUrl', label: 'Google Form Base URL', placeholder: 'https://docs.google.com/forms/d/e/…/viewform' },
+  { key: 'entryEmail', label: 'Form Email Entry ID', placeholder: 'entry.123456789' },
+  { key: 'rsvpResponseUrl', label: 'RSVP Response Sheet URL', placeholder: 'https://docs.google.com/spreadsheets/d/…' },
+  { key: 'masterSheetUrl', label: 'Master Sheet URL', placeholder: 'https://docs.google.com/spreadsheets/d/…' },
+  { key: 'imgEmblemUrl', label: 'Emblem Image URL', placeholder: 'https://drive.google.com/…' },
+];
+
+const INPUT = "w-full bg-white border border-gray-300 text-gray-900 text-xs font-mono px-2.5 py-1.5 rounded outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9] dark:focus:border-[#58a6ff]";
+const LABEL = "text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-1 block dark:text-[#6e7681]";
+const SECTION = "text-[10px] text-gray-500 tracking-widest font-mono uppercase mt-5 mb-2.5 border-b border-gray-200 pb-1.5 dark:text-[#6e7681] dark:border-[#21262d]";
+
+export default function SetupTab() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState('');
+  const [clientIdDraft, setClientIdDraft] = useState(localStorage.getItem('gClientId') ?? '');
+
+  const ev = state.events.find(e => e.id === state.activeEventId);
+
+  if (!ev) {
+    return (
+      <div className="p-10 text-gray-500 text-xs text-center dark:text-[#6e7681]">
+        No active event. Go to{' '}
+        <button
+          className="text-blue-600 bg-none border-none cursor-pointer font-mono text-xs dark:text-[#58a6ff]"
+          onClick={() => dispatch({ type: 'SET_TAB', tab: 'events' })}
+        >
+          Events
+        </button>{' '}
+        to create or activate one.
+      </div>
+    );
+  }
+
+  function update(key: keyof AppEvent, value: string) {
+    dispatch({ type: 'UPDATE_EVENT', event: { ...ev!, [key]: value } });
+  }
+
+  async function save() {
+    setSaving(true);
+    setStatus('');
+    try {
+      const token = await getToken('drive.appdata');
+      await updateAppDataFile(token, ev!.id, ev);
+      setClientId(clientIdDraft);
+      dispatch({ type: 'UPDATE_EVENT', event: { ...ev!, googleClientId: clientIdDraft } });
+      setStatus('Saved.');
+    } catch (e) {
+      setStatus('Error: ' + String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function authorize(scope: string) {
+    setStatus('');
+    try {
+      await getToken(scope);
+      setStatus(`${scope} authorized.`);
+    } catch (e) {
+      setStatus('Auth error: ' + String(e));
+    }
+  }
+
+  return (
+    <div className="p-5 max-w-[640px] mx-auto w-full">
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-sm font-bold tracking-[0.08em] text-gray-900 dark:text-[#f0f6fc]">SETUP</span>
+        <button
+          onClick={save}
+          disabled={saving}
+          className="min-h-[44px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-green-700 dark:border-[#238636] dark:bg-[#238636] disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+
+      {status && (
+        <div className={`text-xs mb-3 ${status.startsWith('Error') ? 'text-red-600 dark:text-[#f85149]' : 'text-green-600 dark:text-[#3fb950]'}`}>
+          {status}
+        </div>
+      )}
+
+      <div className={SECTION}>GOOGLE OAUTH</div>
+      <div className="mb-3">
+        <label className={LABEL}>Google Client ID</label>
+        <input
+          className={INPUT}
+          value={clientIdDraft}
+          onChange={e => setClientIdDraft(e.target.value)}
+          placeholder="123456789-abc.apps.googleusercontent.com"
+        />
+      </div>
+      <div className="flex flex-wrap gap-2 mb-5">
+        <button
+          className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c]"
+          onClick={() => authorize('spreadsheets')}
+        >Authorize Sheets</button>
+        <button
+          className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c]"
+          onClick={() => authorize('gmail.send')}
+        >Authorize Gmail</button>
+        <button
+          className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c]"
+          onClick={() => authorize('drive.appdata')}
+        >Authorize Drive</button>
+      </div>
+
+      <div className={SECTION}>EVENT DETAILS</div>
+      <div className="grid gap-3">
+        {FIELDS.map(f => (
+          <div key={f.key}>
+            <label className={LABEL}>{f.label}</label>
+            <input
+              className={INPUT}
+              type={f.type ?? 'text'}
+              value={String(ev[f.key] ?? '')}
+              onChange={e => update(f.key, e.target.value)}
+              placeholder={f.placeholder}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build and commit**
+
+```bash
+npm run build && git add src/inviteflow/tabs/SetupTab.tsx && git commit -m "feat(v3.1): SetupTab — Tailwind classes, responsive stacked form"
+```
+
+---
+
+## Task 7: InviteesTab + ContactScoutPanel
+
+**Files:**
+- Modify: `src/inviteflow/tabs/InviteesTab.tsx`
+- Modify: `src/inviteflow/components/ContactScoutPanel.tsx`
+
+### InviteesTab
+
+- [ ] **Step 1: Replace InviteesTab.tsx**
+
+Key changes: all inline styles → Tailwind, DataTable wrapped in `overflow-x-auto`, modal uses `max-w-sm w-full mx-4`.
+
+```tsx
+import { useRef, useState } from 'react';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import { getToken } from '../api/auth';
+import { sheetsGet, extractSheetId } from '../api/sheets';
+import type { Invitee } from '../types';
+import ContactScoutPanel from '../components/ContactScoutPanel';
+
+function makeInvitee(partial: Partial<Invitee> = {}): Invitee {
+  return {
+    id: crypto.randomUUID(),
+    firstName: '',
+    lastName: '',
+    title: '',
+    category: '',
+    email: '',
+    rsvpLink: '',
+    inviteStatus: 'pending',
+    sentAt: '',
+    rsvpStatus: 'No Response',
+    rsvpDate: '',
+    notes: '',
+    ...partial,
+  };
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: 'text-gray-500 dark:text-[#6e7681]',
+  sent: 'text-green-600 dark:text-[#3fb950]',
+  failed: 'text-red-600 dark:text-[#f85149]',
+};
+const RSVP_COLORS: Record<string, string> = {
+  'No Response': 'text-gray-500 dark:text-[#6e7681]',
+  Attending: 'text-green-600 dark:text-[#3fb950]',
+  Declined: 'text-red-600 dark:text-[#f85149]',
+};
+
+const INPUT = "w-full bg-white border border-gray-300 text-gray-900 text-xs font-mono px-2.5 py-1.5 rounded outline-none focus:border-blue-500 dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9]";
+
+export default function InviteesTab() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const [selected, setSelected] = useState<Invitee[]>([]);
+  const [showAdd, setShowAdd] = useState(false);
+  const [draft, setDraft] = useState<Partial<Invitee>>({});
+  const [sheetsUrl, setSheetsUrl] = useState('');
+  const [importing, setImporting] = useState(false);
+  const [importStatus, setImportStatus] = useState('');
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const ev = state.events.find(e => e.id === state.activeEventId);
+
+  async function importFromSheets() {
+    if (!sheetsUrl.trim()) return;
+    setImporting(true);
+    setImportStatus('');
+    try {
+      const token = await getToken('spreadsheets');
+      const id = extractSheetId(sheetsUrl);
+      const rows = await sheetsGet(token, id, 'Sheet1!A:K');
+      if (rows.length < 2) { setImportStatus('Sheet appears empty (need header + data rows).'); return; }
+      const [header, ...data] = rows;
+      const col = (name: string) => header.findIndex(h => h.trim().toLowerCase() === name.toLowerCase());
+      const ci = { fn: col('FirstName'), ln: col('LastName'), title: col('Title'), cat: col('Category'), email: col('Email'), rsvp: col('RSVP_Link'), sent: col('InviteSent'), sentDate: col('InviteSentDate'), rsvpStatus: col('RSVP_Status'), rsvpDate: col('RSVP_Date'), notes: col('Notes') };
+
+      const incoming = data.map(r => makeInvitee({
+        firstName: r[ci.fn] ?? '',
+        lastName: r[ci.ln] ?? '',
+        title: r[ci.title] ?? '',
+        category: r[ci.cat] ?? '',
+        email: r[ci.email] ?? '',
+        rsvpLink: r[ci.rsvp] ?? '',
+        inviteStatus: r[ci.sent]?.toLowerCase() === 'true' ? 'sent' : 'pending',
+        sentAt: r[ci.sentDate] ?? '',
+        rsvpStatus: (['Attending', 'Declined'].includes(r[ci.rsvpStatus]) ? r[ci.rsvpStatus] : 'No Response') as Invitee['rsvpStatus'],
+        rsvpDate: r[ci.rsvpDate] ?? '',
+        notes: r[ci.notes] ?? '',
+      })).filter(i => i.email);
+
+      const merged = [...state.invitees];
+      for (const inc of incoming) {
+        const idx = merged.findIndex(m => m.email.toLowerCase() === inc.email.toLowerCase());
+        if (idx >= 0) merged[idx] = { ...merged[idx], ...inc, id: merged[idx].id };
+        else merged.push(inc);
+      }
+      dispatch({ type: 'SET_INVITEES', invitees: merged });
+      setImportStatus(`Imported ${incoming.length} rows (${merged.length - state.invitees.length} new, rest merged).`);
+    } catch (e) {
+      setImportStatus('Error: ' + String(e));
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  function importJSON(file: File) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const raw = JSON.parse(reader.result as string) as Array<Record<string, string>>;
+        const parsed = raw.map(r => {
+          const full = r.name ?? `${r.firstName ?? ''} ${r.lastName ?? ''}`.trim();
+          const parts = full.split(' ');
+          return makeInvitee({
+            firstName: r.firstName ?? parts[0] ?? '',
+            lastName: r.lastName ?? parts.slice(1).join(' ') ?? '',
+            title: r.title ?? '',
+            category: r.category ?? '',
+            email: r.email ?? '',
+          });
+        }).filter(i => i.email);
+        const merged = [...state.invitees];
+        for (const inc of parsed) {
+          const idx = merged.findIndex(m => m.email.toLowerCase() === inc.email.toLowerCase());
+          if (idx < 0) merged.push(inc);
+        }
+        dispatch({ type: 'SET_INVITEES', invitees: merged });
+        setImportStatus(`JSON import: ${parsed.length} rows.`);
+      } catch (e) { setImportStatus('JSON parse error: ' + String(e)); }
+    };
+    reader.readAsText(file);
+  }
+
+  function exportCSV() {
+    const header = 'FirstName,LastName,Title,Category,Email,RSVP_Link,InviteSent,InviteSentDate,RSVP_Status,RSVP_Date,Notes';
+    const rows = state.invitees.map(i =>
+      [i.firstName, i.lastName, i.title, i.category, i.email, i.rsvpLink, i.inviteStatus === 'sent' ? 'TRUE' : 'FALSE', i.sentAt, i.rsvpStatus, i.rsvpDate, i.notes]
+        .map(v => `"${String(v).replace(/"/g, '""')}"`)
+        .join(',')
+    );
+    const blob = new Blob([[header, ...rows].join('\n')], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = `invitees-${new Date().toISOString().slice(0, 10)}.csv`; a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function addManually() {
+    if (!draft.email) return;
+    dispatch({ type: 'ADD_INVITEE', invitee: makeInvitee(draft) });
+    setDraft({});
+    setShowAdd(false);
+  }
+
+  function buildRsvpLink(inv: Invitee) {
+    if (!ev?.formUrl || !ev?.entryEmail) return '';
+    return `${ev.formUrl}?${ev.entryEmail}=${encodeURIComponent(inv.email)}`;
+  }
+
+  function generateAllRsvpLinks() {
+    const updated = state.invitees.map(i => ({ ...i, rsvpLink: i.rsvpLink || buildRsvpLink(i) }));
+    dispatch({ type: 'SET_INVITEES', invitees: updated });
+  }
+
+  function bulkMarkSent() {
+    const ids = new Set(selected.map(s => s.id));
+    const updated = state.invitees.map(i => ids.has(i.id) ? { ...i, inviteStatus: 'sent' as const, sentAt: new Date().toISOString() } : i);
+    dispatch({ type: 'SET_INVITEES', invitees: updated });
+    setSelected([]);
+  }
+
+  function bulkReset() {
+    const ids = new Set(selected.map(s => s.id));
+    const updated = state.invitees.map(i => ids.has(i.id) ? { ...i, inviteStatus: 'pending' as const, sentAt: '' } : i);
+    dispatch({ type: 'SET_INVITEES', invitees: updated });
+    setSelected([]);
+  }
+
+  function bulkDelete() {
+    if (!confirm(`Delete ${selected.length} invitee(s)?`)) return;
+    dispatch({ type: 'DELETE_INVITEES', ids: selected.map(s => s.id) });
+    setSelected([]);
+  }
+
+  return (
+    <div className="flex flex-col h-full px-4 py-3 gap-3">
+      {/* Toolbar */}
+      <div className="flex flex-wrap gap-2 items-center">
+        <span className="text-sm font-bold tracking-[0.08em] text-gray-900 mr-2 dark:text-[#f0f6fc]">
+          INVITEES <span className="text-[10px] text-gray-500 dark:text-[#6e7681]">({state.invitees.length})</span>
+        </span>
+        <button onClick={() => setShowAdd(true)} className="min-h-[44px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-green-700 dark:border-[#238636] dark:bg-[#238636]">+ Add</button>
+        <button onClick={exportCSV} className="min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-gray-700 text-xs font-mono tracking-wide cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22]">Export CSV</button>
+        <button onClick={generateAllRsvpLinks} className="min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-gray-700 text-xs font-mono tracking-wide cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22]">Gen RSVP Links</button>
+        <input ref={fileRef} type="file" accept=".json" className="hidden" onChange={e => e.target.files?.[0] && importJSON(e.target.files[0])} />
+        <button onClick={() => fileRef.current?.click()} className="min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-gray-700 text-xs font-mono tracking-wide cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22]">Import JSON</button>
+      </div>
+
+      {/* Sheets import row */}
+      <div className="flex flex-wrap gap-2 items-center">
+        <input
+          className="flex-1 min-w-[200px] bg-white border border-gray-300 text-gray-900 text-xs font-mono px-2.5 py-1.5 rounded outline-none focus:border-blue-500 dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9]"
+          placeholder="Paste Google Sheets URL to import…"
+          value={sheetsUrl}
+          onChange={e => setSheetsUrl(e.target.value)}
+        />
+        <button
+          onClick={importFromSheets}
+          disabled={importing}
+          className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c] disabled:opacity-50"
+        >
+          {importing ? 'Importing…' : 'Import Sheets'}
+        </button>
+        {importStatus && (
+          <span className={`text-[10px] ${importStatus.startsWith('Error') ? 'text-red-600 dark:text-[#f85149]' : 'text-green-600 dark:text-[#3fb950]'}`}>
+            {importStatus}
+          </span>
+        )}
+      </div>
+
+      {/* Bulk actions */}
+      {selected.length > 0 && (
+        <div className="flex flex-wrap gap-2 items-center bg-white border border-gray-200 rounded-lg px-3 py-2 dark:bg-[#0d1117] dark:border-[#21262d]">
+          <span className="text-[10px] text-[#C8A84B]">{selected.length} selected</span>
+          <button onClick={bulkMarkSent} className="min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-green-600 text-xs font-mono cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:hover:bg-[#161b22]">Mark Sent</button>
+          <button onClick={bulkReset} className="min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-gray-600 text-xs font-mono cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22]">Reset Status</button>
+          <button onClick={() => dispatch({ type: 'SET_TAB', tab: 'send' })} className="min-h-[44px] px-3 py-1 rounded border border-green-500 bg-transparent text-green-600 text-xs font-mono cursor-pointer hover:bg-green-50 dark:border-[#3fb950] dark:text-[#3fb950]">Send Selected →</button>
+          <button onClick={bulkDelete} className="min-h-[44px] px-3 py-1 rounded border border-red-500 bg-transparent text-red-600 text-xs font-mono cursor-pointer hover:bg-red-50 dark:border-[#f85149] dark:text-[#f85149]">Delete</button>
+        </div>
+      )}
+
+      {/* DataTable — overflow-x-auto for mobile scroll */}
+      <div
+        className="flex-1 overflow-hidden"
+        role="region"
+        aria-label="Invitees table"
+        tabIndex={0}
+      >
+        <div className="overflow-x-auto h-full">
+          <DataTable
+            value={state.invitees}
+            selection={selected}
+            onSelectionChange={e => setSelected(e.value as Invitee[])}
+            selectionMode="multiple"
+            dataKey="id"
+            scrollable
+            scrollHeight="flex"
+            virtualScrollerOptions={{ itemSize: 36 }}
+            size="small"
+            filterDisplay="row"
+            emptyMessage="No invitees yet."
+            style={{ fontSize: 11, minWidth: 700 }}
+            onRowEditComplete={e => dispatch({ type: 'UPDATE_INVITEE', invitee: e.newData as Invitee })}
+            editMode="row"
+          >
+            <Column selectionMode="multiple" style={{ width: 40 }} />
+            <Column field="firstName" header="First" sortable filter filterPlaceholder="Search" style={{ minWidth: 90 }} />
+            <Column field="lastName" header="Last" sortable filter filterPlaceholder="Search" style={{ minWidth: 90 }} />
+            <Column field="title" header="Title" sortable style={{ minWidth: 120 }} />
+            <Column field="category" header="Category" sortable filter filterPlaceholder="Filter" style={{ minWidth: 100 }} />
+            <Column field="email" header="Email" sortable style={{ minWidth: 160 }} />
+            <Column
+              field="inviteStatus"
+              header="Status"
+              sortable
+              filter
+              filterPlaceholder="Filter"
+              style={{ minWidth: 90 }}
+              body={(r: Invitee) => (
+                <span className={`text-[10px] tracking-[0.07em] font-mono ${STATUS_COLORS[r.inviteStatus] ?? 'text-gray-500'}`}>
+                  {r.inviteStatus.toUpperCase()}
+                </span>
+              )}
+            />
+            <Column field="sentAt" header="Sent At" sortable style={{ minWidth: 110 }} body={(r: Invitee) => r.sentAt ? new Date(r.sentAt).toLocaleDateString() : '—'} />
+            <Column
+              field="rsvpStatus"
+              header="RSVP"
+              sortable
+              filter
+              filterPlaceholder="Filter"
+              style={{ minWidth: 110 }}
+              body={(r: Invitee) => (
+                <span className={`text-[10px] font-mono ${RSVP_COLORS[r.rsvpStatus] ?? 'text-gray-500'}`}>
+                  {r.rsvpStatus}
+                </span>
+              )}
+            />
+            <Column field="notes" header="Notes" style={{ minWidth: 140 }} editor={(opts) => (
+              <input className={INPUT} value={opts.value} onChange={e => opts.editorCallback?.(e.target.value)} />
+            )} />
+            <Column rowEditor style={{ width: 70 }} />
+          </DataTable>
+        </div>
+      </div>
+
+      {/* ContactScout */}
+      <ContactScoutPanel />
+
+      {/* Add manually modal */}
+      {showAdd && (
+        <div className="fixed inset-0 bg-black/85 z-[300] flex items-center justify-center p-4">
+          <div className="bg-white border border-gray-200 rounded-lg p-6 w-full max-w-sm dark:bg-[#0d1117] dark:border-[#21262d]">
+            <div className="text-xs font-bold text-gray-900 mb-4 dark:text-[#f0f6fc]">ADD INVITEE</div>
+            {(['firstName', 'lastName', 'title', 'category', 'email'] as const).map(k => (
+              <div key={k} className="mb-2.5">
+                <label className="text-[10px] text-gray-500 font-mono uppercase tracking-widest block mb-1 dark:text-[#6e7681]">{k}</label>
+                <input className={INPUT} value={String(draft[k] ?? '')} onChange={e => setDraft(d => ({ ...d, [k]: e.target.value }))} />
+              </div>
+            ))}
+            <div className="flex gap-2 mt-4">
+              <button onClick={addManually} className="min-h-[44px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-xs font-mono cursor-pointer hover:bg-green-700 dark:border-[#238636] dark:bg-[#238636]">Add</button>
+              <button onClick={() => { setShowAdd(false); setDraft({}); }} className="min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-gray-700 text-xs font-mono cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22]">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+### ContactScoutPanel
+
+- [ ] **Step 2: Migrate ContactScoutPanel.tsx inline styles to Tailwind**
+
+`ContactScoutPanel.tsx` is a large file (~500 lines). Migrate every inline style object using the same pattern as other tabs:
+- Replace all `style={{ ... }}` attributes with `className="..."` Tailwind strings
+- Use the same color reference table from the plan header
+- Use the same button/input/label/section class strings
+- The panel wrapper: `className="mt-2 border-t border-gray-200 pt-3 dark:border-[#21262d]"`
+- The collapsible header button: `className="flex items-center gap-2 text-[10px] text-gray-500 tracking-widest font-mono uppercase cursor-pointer min-h-[44px] dark:text-[#6e7681]"`
+- Scan target cards: `className="bg-white border border-gray-200 rounded-lg p-3 dark:bg-[#0d1117] dark:border-[#21262d]"`
+- Status badges: map `pending` → `text-gray-400`, `checking`/`scanning` → `text-blue-600 dark:text-[#58a6ff]`, `done` → `text-green-600 dark:text-[#3fb950]`, `error` → `text-red-600 dark:text-[#f85149]`
+- Textarea: `className="w-full bg-white border border-gray-300 text-gray-900 text-xs font-mono px-2.5 py-1.5 rounded resize-y dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9]"`
+- Do NOT change any logic, state, API calls, or function bodies — only style attributes
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+npm run build && git add src/inviteflow/tabs/InviteesTab.tsx src/inviteflow/components/ContactScoutPanel.tsx && git commit -m "feat(v3.1): InviteesTab + ContactScoutPanel — Tailwind classes, overflow-x-auto DataTable"
+```
+
+---
+
+## Task 8: ComposeTab
+
+**Files:**
+- Modify: `src/inviteflow/tabs/ComposeTab.tsx`
+
+- [ ] **Step 1: Replace ComposeTab.tsx — add editor/preview mobile toggle**
+
+```tsx
+import { useEffect, useCallback, useState } from 'react';
+import { useEditor, EditorContent } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import { personalize } from '../api/gmail';
+
+const TOKENS = [
+  'FirstName', 'LastName', 'FullName', 'FullTitle',
+  'EventName', 'EventDate', 'Venue', 'OrgName',
+  'ContactName', 'ContactEmail',
+  'VIPStart', 'VIPEnd', 'RSVP_Link', 'Date_Sent',
+];
+
+type Pane = 'editor' | 'preview';
+
+export default function ComposeTab() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const [activePane, setActivePane] = useState<Pane>('editor');
+
+  const ev = state.events.find(e => e.id === state.activeEventId);
+  const sample = state.invitees[0];
+
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: state.htmlBody || '<p>Dear Honorable {{FirstName}} {{LastName}},</p><p></p><p>{{RSVP_Link}}</p>',
+    onUpdate({ editor }) {
+      dispatch({ type: 'SET_COMPOSE', subject: state.textSubject, html: editor.getHTML() });
+    },
+  });
+
+  useEffect(() => {
+    if (editor && state.htmlBody && editor.getHTML() !== state.htmlBody) {
+      editor.commands.setContent(state.htmlBody, false);
+    }
+  }, []);
+
+  const insertToken = useCallback((token: string) => {
+    editor?.commands.insertContent(`{{${token}}}`);
+  }, [editor]);
+
+  function updateSubject(val: string) {
+    dispatch({ type: 'SET_COMPOSE', subject: val, html: state.htmlBody });
+  }
+
+  const preview = ev && sample
+    ? personalize(state.htmlBody, sample, ev)
+    : state.htmlBody;
+
+  const fmtBtn = (active = false) => [
+    'min-h-[44px] px-2 py-1 rounded text-xs font-mono cursor-pointer',
+    active
+      ? 'border border-[#C8A84B] bg-[#2a1a00] text-[#C8A84B] dark:border-[#C8A84B] dark:bg-[#2a1a00] dark:text-[#C8A84B]'
+      : 'border border-gray-200 bg-transparent text-gray-600 hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22]',
+  ].join(' ');
+
+  const paneToggleBtn = (pane: Pane) => [
+    'min-h-[44px] px-4 py-1 text-xs font-mono tracking-wide cursor-pointer border-b-2',
+    activePane === pane
+      ? 'border-blue-600 text-blue-700 dark:border-[#1f6feb] dark:text-[#58a6ff]'
+      : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-[#6e7681] dark:hover:text-[#8b949e]',
+  ].join(' ');
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Top bar */}
+      <div className="px-4 py-3 border-b border-gray-200 flex flex-col gap-2.5 dark:border-[#21262d]">
+        {/* Subject line */}
+        <div className="flex items-center gap-2.5">
+          <span className="text-[10px] text-gray-500 tracking-widest font-mono uppercase min-w-[56px] dark:text-[#6e7681]">SUBJECT</span>
+          <input
+            className="flex-1 bg-white border border-gray-300 text-gray-900 text-xs font-mono px-2.5 py-1.5 rounded outline-none focus:border-blue-500 dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9] dark:focus:border-[#58a6ff]"
+            value={state.textSubject}
+            onChange={e => updateSubject(e.target.value)}
+            placeholder="You are cordially invited to {{EventName}}"
+          />
+        </div>
+        {/* Token insert bar */}
+        <div className="flex flex-wrap gap-1 items-center">
+          <span className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mr-1 dark:text-[#6e7681]">INSERT</span>
+          {TOKENS.map(t => (
+            <button key={t} className={fmtBtn()} onClick={() => insertToken(t)}>{`{{${t}}}`}</button>
+          ))}
+        </div>
+        {/* Format bar */}
+        <div className="flex flex-wrap gap-1">
+          <button className={fmtBtn(editor?.isActive('bold'))} onClick={() => editor?.chain().focus().toggleBold().run()}>B</button>
+          <button className={fmtBtn(editor?.isActive('italic'))} onClick={() => editor?.chain().focus().toggleItalic().run()}>I</button>
+          <button className={fmtBtn(editor?.isActive('bulletList'))} onClick={() => editor?.chain().focus().toggleBulletList().run()}>• List</button>
+          <button className={fmtBtn(editor?.isActive('orderedList'))} onClick={() => editor?.chain().focus().toggleOrderedList().run()}>1. List</button>
+        </div>
+      </div>
+
+      {/* Mobile pane toggle (hidden on md+) */}
+      <div className="flex md:hidden border-b border-gray-200 dark:border-[#21262d]">
+        <button className={paneToggleBtn('editor')} onClick={() => setActivePane('editor')}>EDITOR</button>
+        <button className={paneToggleBtn('preview')} onClick={() => setActivePane('preview')}>PREVIEW</button>
+      </div>
+
+      {/* Editor + Preview */}
+      <div className="flex-1 overflow-hidden md:grid md:grid-cols-2">
+        {/* Editor pane */}
+        <div className={[
+          'border-gray-200 overflow-auto p-4 dark:border-[#21262d]',
+          'md:block md:border-r',
+          activePane === 'editor' ? 'block' : 'hidden md:block',
+        ].join(' ')}>
+          <div className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-2 dark:text-[#6e7681]">EDITOR</div>
+          <EditorContent editor={editor} />
+        </div>
+        {/* Preview pane */}
+        <div className={[
+          'overflow-auto p-4 bg-gray-50 dark:bg-[#080c10]',
+          activePane === 'preview' ? 'block' : 'hidden md:block',
+        ].join(' ')}>
+          <div className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-2 dark:text-[#6e7681]">
+            PREVIEW {sample ? `(${sample.firstName} ${sample.lastName})` : '(no invitees)'}
+          </div>
+          <div
+            className="bg-white rounded p-4 text-gray-900 text-sm leading-relaxed"
+            dangerouslySetInnerHTML={{ __html: preview }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build and commit**
+
+```bash
+npm run build && git add src/inviteflow/tabs/ComposeTab.tsx && git commit -m "feat(v3.1): ComposeTab — Tailwind classes, mobile editor/preview toggle"
+```
+
+---
+
+## Task 9: SendTab
+
+**Files:**
+- Modify: `src/inviteflow/tabs/SendTab.tsx`
+
+- [ ] **Step 1: Replace SendTab.tsx**
+
+```tsx
+import { useState } from 'react';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import { getToken } from '../api/auth';
+import { buildMimeRaw, personalize, sendEmail } from '../api/gmail';
+import type { Invitee } from '../types';
+
+type Filter = 'all' | 'pending' | 'failed';
+
+const BATCH_SIZE = 80;
+const BATCH_DELAY_MS = 61000;
+
+export default function SendTab() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const [filter, setFilter] = useState<Filter>('pending');
+  const [err, setErr] = useState('');
+
+  const ev = state.events.find(e => e.id === state.activeEventId);
+
+  const filtered = state.invitees.filter(i => {
+    if (filter === 'all') return true;
+    if (filter === 'pending') return i.inviteStatus === 'pending';
+    return i.inviteStatus === 'failed';
+  });
+
+  async function sendBulk() {
+    if (!ev) { setErr('No active event — go to Setup.'); return; }
+    if (!state.htmlBody.trim()) { setErr('No email body — go to Compose.'); return; }
+    if (filtered.length === 0) { setErr('No invitees match the current filter.'); return; }
+    setErr('');
+
+    dispatch({ type: 'START_SEND', total: filtered.length });
+
+    let token: string;
+    try { token = await getToken('gmail.send'); }
+    catch (e) { setErr(String(e)); dispatch({ type: 'STOP_SEND' }); return; }
+
+    const from = ev.contactEmail || 'me';
+    let sent = 0;
+
+    for (let i = 0; i < filtered.length; i++) {
+      const inv = filtered[i];
+      const personalizedHtml = personalize(state.htmlBody, inv, ev);
+      const personalizedSubject = personalize(state.textSubject, inv, ev);
+      const raw = buildMimeRaw(from, inv.email, personalizedSubject, personalizedHtml);
+
+      try {
+        await sendEmail(token, raw);
+        dispatch({ type: 'UPDATE_INVITEE', invitee: { ...inv, inviteStatus: 'sent', sentAt: new Date().toISOString() } });
+        dispatch({ type: 'LOG_SEND', entry: { id: crypto.randomUUID(), email: inv.email, name: `${inv.firstName} ${inv.lastName}`, status: 'sent', timestamp: new Date().toISOString() } });
+      } catch (e) {
+        dispatch({ type: 'UPDATE_INVITEE', invitee: { ...inv, inviteStatus: 'failed' } });
+        dispatch({ type: 'LOG_SEND', entry: { id: crypto.randomUUID(), email: inv.email, name: `${inv.firstName} ${inv.lastName}`, status: 'failed', timestamp: new Date().toISOString(), error: String(e) } });
+      }
+
+      sent++;
+      dispatch({ type: 'SEND_PROGRESS', current: sent });
+
+      if (sent % BATCH_SIZE === 0 && i < filtered.length - 1) {
+        await new Promise(r => setTimeout(r, BATCH_DELAY_MS));
+      }
+    }
+
+    dispatch({ type: 'STOP_SEND' });
+  }
+
+  const progress = state.sendProgress.total > 0
+    ? Math.round((state.sendProgress.current / state.sendProgress.total) * 100)
+    : 0;
+
+  const filterBtn = (f: Filter) => [
+    'min-h-[44px] px-3 py-1 rounded border text-xs font-mono tracking-wide cursor-pointer',
+    filter === f
+      ? 'border-blue-600 bg-blue-600 text-white dark:border-[#1f6feb] dark:bg-[#1f6feb]'
+      : 'border-gray-300 bg-transparent text-gray-700 hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22]',
+  ].join(' ');
+
+  return (
+    <div className="p-5 max-w-[800px] mx-auto w-full">
+      <div className="text-sm font-bold tracking-[0.08em] text-gray-900 mb-4 dark:text-[#f0f6fc]">SEND</div>
+
+      {/* Filter + Send controls */}
+      <div className="flex flex-wrap gap-2 items-center mb-4">
+        <span className="text-[10px] text-gray-500 font-mono uppercase tracking-widest dark:text-[#6e7681]">FILTER</span>
+        {(['all', 'pending', 'failed'] as Filter[]).map(f => (
+          <button key={f} className={filterBtn(f)} onClick={() => setFilter(f)}>{f.toUpperCase()}</button>
+        ))}
+        <span className="text-[10px] text-gray-500 font-mono ml-2 dark:text-[#6e7681]">{filtered.length} invitees</span>
+        <button
+          onClick={sendBulk}
+          disabled={state.sending}
+          className="min-h-[44px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-green-700 dark:border-[#238636] dark:bg-[#238636] disabled:opacity-50 disabled:cursor-not-allowed ml-auto"
+        >
+          {state.sending ? 'Sending…' : `Send to ${filtered.length} →`}
+        </button>
+      </div>
+
+      {err && <div className="text-xs text-red-600 mb-3 dark:text-[#f85149]">{err}</div>}
+
+      {/* Progress bar */}
+      {state.sending && (
+        <div className="mb-4">
+          <div className="text-[10px] text-gray-500 font-mono mb-1.5 dark:text-[#6e7681]">
+            {state.sendProgress.current} / {state.sendProgress.total} sent ({progress}%)
+          </div>
+          <div className="h-1 bg-gray-200 rounded overflow-hidden dark:bg-[#161b22]">
+            <div
+              className="h-full bg-[#C8A84B] rounded transition-[width_.3s]"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Send log */}
+      {state.sendLog.length > 0 && (
+        <div>
+          <div className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-2 dark:text-[#6e7681]">SEND LOG</div>
+          <div
+            className="max-h-96 overflow-y-auto border border-gray-200 rounded-lg dark:border-[#21262d]"
+            role="region"
+            aria-label="Send log"
+            tabIndex={0}
+          >
+            {state.sendLog.map(entry => (
+              <div key={entry.id} className="flex flex-wrap gap-2.5 items-baseline px-3 py-1.5 border-b border-gray-100 text-xs dark:border-[#161b22]">
+                <span className={`text-[10px] font-mono tracking-[0.07em] min-w-[40px] ${entry.status === 'sent' ? 'text-green-600 dark:text-[#3fb950]' : 'text-red-600 dark:text-[#f85149]'}`}>
+                  {entry.status.toUpperCase()}
+                </span>
+                <span className="text-gray-900 min-w-[140px] dark:text-[#c9d1d9]">{entry.name}</span>
+                <span className="text-gray-500 flex-1 dark:text-[#6e7681]">{entry.email}</span>
+                {entry.error && <span className="text-red-600 text-[10px] dark:text-[#f85149]">{entry.error}</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {state.sendLog.length === 0 && !state.sending && (
+        <div className="text-gray-500 text-xs text-center py-10 dark:text-[#6e7681]">
+          No sends yet. Choose a filter and click Send.
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build and commit**
+
+```bash
+npm run build && git add src/inviteflow/tabs/SendTab.tsx && git commit -m "feat(v3.1): SendTab — Tailwind classes, flex-wrap controls"
+```
+
+---
+
+## Task 10: TrackerTab
+
+**Files:**
+- Modify: `src/inviteflow/tabs/TrackerTab.tsx`
+
+- [ ] **Step 1: Replace TrackerTab.tsx**
+
+```tsx
+import { useAppState } from '../state/AppContext';
+import type { Invitee } from '../types';
+
+interface CategoryRow {
+  category: string;
+  total: number;
+  sent: number;
+  attending: number;
+  declined: number;
+  noResponse: number;
+}
+
+export default function TrackerTab() {
+  const state = useAppState();
+  const inv = state.invitees;
+
+  const total = inv.length;
+  const sent = inv.filter(i => i.inviteStatus === 'sent').length;
+  const pending = inv.filter(i => i.inviteStatus === 'pending').length;
+  const failed = inv.filter(i => i.inviteStatus === 'failed').length;
+  const attending = inv.filter(i => i.rsvpStatus === 'Attending').length;
+  const declined = inv.filter(i => i.rsvpStatus === 'Declined').length;
+  const noResponse = inv.filter(i => i.rsvpStatus === 'No Response').length;
+
+  const cats = Array.from(new Set(inv.map(i => i.category).filter(Boolean))).sort();
+  const byCategory: CategoryRow[] = cats.map(cat => {
+    const rows = inv.filter(i => i.category === cat);
+    return {
+      category: cat,
+      total: rows.length,
+      sent: rows.filter(i => i.inviteStatus === 'sent').length,
+      attending: rows.filter(i => i.rsvpStatus === 'Attending').length,
+      declined: rows.filter(i => i.rsvpStatus === 'Declined').length,
+      noResponse: rows.filter(i => i.rsvpStatus === 'No Response').length,
+    };
+  });
+
+  type StatCard = { label: string; value: number; color: string };
+  const statCard = ({ label, value, color }: StatCard) => (
+    <div key={label} className={`bg-white border border-gray-200 rounded-lg p-4 border-l-[3px] dark:bg-[#0d1117] dark:border-[#21262d]`} style={{ borderLeftColor: color }}>
+      <div className="text-[9px] text-gray-500 tracking-[0.12em] font-mono uppercase mb-1.5 dark:text-[#6e7681]">{label}</div>
+      <div className="text-2xl font-bold" style={{ color }}>{value}</div>
+    </div>
+  );
+
+  if (total === 0) {
+    return (
+      <div className="p-10 text-center text-gray-500 text-xs dark:text-[#6e7681]">
+        No invitees yet. Add them in the Invitees tab.
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-5 max-w-[900px] mx-auto w-full">
+      <div className="text-sm font-bold tracking-[0.08em] text-gray-900 mb-5 dark:text-[#f0f6fc]">TRACKER</div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2.5 mb-7">
+        {statCard({ label: 'TOTAL', value: total, color: '#8b949e' })}
+        {statCard({ label: 'PENDING', value: pending, color: '#6e7681' })}
+        {statCard({ label: 'SENT', value: sent, color: '#3fb950' })}
+        {statCard({ label: 'FAILED', value: failed, color: '#f85149' })}
+        {statCard({ label: 'ATTENDING', value: attending, color: '#C8A84B' })}
+        {statCard({ label: 'DECLINED', value: declined, color: '#f85149' })}
+        {statCard({ label: 'NO RESPONSE', value: noResponse, color: '#6e7681' })}
+      </div>
+
+      {byCategory.length > 0 && (
+        <>
+          <div className="text-[10px] text-gray-500 tracking-[0.12em] font-mono uppercase mb-2.5 dark:text-[#6e7681]">BY CATEGORY</div>
+          <div
+            className="border border-gray-200 rounded-lg overflow-x-auto dark:border-[#21262d]"
+            role="region"
+            aria-label="RSVP by category"
+            tabIndex={0}
+          >
+            <table className="w-full border-collapse min-w-[500px]">
+              <thead>
+                <tr>
+                  {['Category', 'Total', 'Sent', 'Attending', 'Declined', 'No Response'].map(h => (
+                    <th key={h} className="text-[10px] text-gray-500 tracking-[0.1em] font-mono uppercase px-3 py-1.5 text-left border-b border-gray-200 dark:text-[#6e7681] dark:border-[#21262d]">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {byCategory.map(row => (
+                  <tr key={row.category}>
+                    <td className="text-xs text-gray-900 font-mono px-3 py-1.5 border-b border-gray-100 dark:text-[#c9d1d9] dark:border-[#161b22]">{row.category}</td>
+                    <td className="text-xs text-gray-900 font-mono px-3 py-1.5 border-b border-gray-100 dark:text-[#c9d1d9] dark:border-[#161b22]">{row.total}</td>
+                    <td className="text-xs font-mono px-3 py-1.5 border-b border-gray-100 text-green-600 dark:text-[#3fb950] dark:border-[#161b22]">{row.sent}</td>
+                    <td className="text-xs font-mono px-3 py-1.5 border-b border-gray-100 text-[#C8A84B] dark:border-[#161b22]">{row.attending}</td>
+                    <td className="text-xs font-mono px-3 py-1.5 border-b border-gray-100 text-red-600 dark:text-[#f85149] dark:border-[#161b22]">{row.declined}</td>
+                    <td className="text-xs font-mono px-3 py-1.5 border-b border-gray-100 text-gray-500 dark:text-[#6e7681] dark:border-[#161b22]">{row.noResponse}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build and commit**
+
+```bash
+npm run build && git add src/inviteflow/tabs/TrackerTab.tsx && git commit -m "feat(v3.1): TrackerTab — Tailwind classes, responsive grid, overflow-x-auto table"
+```
+
+---
+
+## Task 11: SyncTab
+
+**Files:**
+- Modify: `src/inviteflow/tabs/SyncTab.tsx`
+
+- [ ] **Step 1: Replace SyncTab.tsx**
+
+```tsx
+import { useState } from 'react';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import { getToken } from '../api/auth';
+import { sheetsGet, sheetsUpdate, sheetsClear, extractSheetId } from '../api/sheets';
+import type { Invitee } from '../types';
+
+const MASTER_COLUMNS = ['FirstName', 'LastName', 'Title', 'Category', 'Email', 'RSVP_Link', 'InviteSent', 'InviteSentDate', 'RSVP_Status', 'RSVP_Date', 'Notes'];
+
+const GAS_CODE = `// InviteFlow v3.1 — RSVP ingest trigger
+// Deploy: Extensions → Apps Script → add trigger: onFormSubmit (Form Submit)
+// Set script property MASTER_SHEET_URL via Project Settings → Script Properties
+
+function onFormSubmit(e) {
+  const props = PropertiesService.getScriptProperties();
+  const sheetUrl = props.getProperty('MASTER_SHEET_URL');
+  if (!sheetUrl) return;
+
+  const ss = SpreadsheetApp.openByUrl(sheetUrl);
+  const sheet = ss.getSheets()[0];
+  const responses = e.response.getItemResponses();
+
+  let email = '';
+  let attending = '';
+  for (const r of responses) {
+    const title = r.getItem().getTitle().toLowerCase();
+    if (title.includes('email')) email = r.getResponse().trim();
+    if (title.includes('attend') || title.includes('rsvp')) attending = r.getResponse().trim();
+  }
+  if (!email) return;
+
+  const data = sheet.getDataRange().getValues();
+  const header = data[0];
+  const emailCol = header.indexOf('Email');
+  const statusCol = header.indexOf('RSVP_Status');
+  const dateCol = header.indexOf('RSVP_Date');
+  if (emailCol < 0) return;
+
+  const today = new Date().toISOString().slice(0, 10);
+  for (let i = 1; i < data.length; i++) {
+    if (String(data[i][emailCol]).toLowerCase() === email.toLowerCase()) {
+      if (statusCol >= 0) sheet.getRange(i + 1, statusCol + 1).setValue(attending || 'Attending');
+      if (dateCol >= 0) sheet.getRange(i + 1, dateCol + 1).setValue(today);
+      break;
+    }
+  }
+}`;
+
+export default function SyncTab() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const [status, setStatus] = useState('');
+  const [pushing, setPushing] = useState(false);
+  const [pulling, setPulling] = useState(false);
+
+  const ev = state.events.find(e => e.id === state.activeEventId);
+
+  async function pushToSheets() {
+    if (!ev?.masterSheetUrl) { setStatus('Error: Master Sheet URL not set — go to Setup.'); return; }
+    setPushing(true);
+    setStatus('');
+    try {
+      const token = await getToken('spreadsheets');
+      const id = extractSheetId(ev.masterSheetUrl);
+      await sheetsClear(token, id, 'Sheet1!A:K');
+      const rows = state.invitees.map(i => [
+        i.firstName, i.lastName, i.title, i.category, i.email, i.rsvpLink,
+        i.inviteStatus === 'sent' ? 'TRUE' : 'FALSE',
+        i.sentAt, i.rsvpStatus, i.rsvpDate, i.notes,
+      ]);
+      await sheetsUpdate(token, id, 'Sheet1!A1', [MASTER_COLUMNS, ...rows]);
+      setStatus(`Pushed ${rows.length} rows to master sheet.`);
+    } catch (e) {
+      setStatus('Error: ' + String(e));
+    } finally {
+      setPushing(false);
+    }
+  }
+
+  async function pullRsvp() {
+    if (!ev?.rsvpResponseUrl) { setStatus('Error: RSVP Response Sheet URL not set — go to Setup.'); return; }
+    setPulling(true);
+    setStatus('');
+    try {
+      const token = await getToken('spreadsheets');
+      const id = extractSheetId(ev.rsvpResponseUrl);
+      const rows = await sheetsGet(token, id, 'Sheet1!A:K');
+      if (rows.length < 2) { setStatus('RSVP sheet appears empty.'); return; }
+      const [header, ...data] = rows;
+      const emailCol = header.findIndex(h => h.toLowerCase().includes('email'));
+      const statusCol = header.findIndex(h => h.toLowerCase().includes('attend') || h.toLowerCase().includes('rsvp'));
+      const dateCol = header.findIndex(h => h.toLowerCase().includes('date'));
+      if (emailCol < 0) { setStatus('Cannot find Email column in RSVP sheet.'); return; }
+
+      let updated = 0;
+      const invitees = state.invitees.map(inv => {
+        const match = data.find(r => r[emailCol]?.toLowerCase() === inv.email.toLowerCase());
+        if (!match) return inv;
+        const rawStatus = match[statusCol] ?? '';
+        const rsvpStatus: Invitee['rsvpStatus'] = rawStatus.toLowerCase().includes('yes') || rawStatus.toLowerCase().includes('attend')
+          ? 'Attending'
+          : rawStatus.toLowerCase().includes('no') || rawStatus.toLowerCase().includes('declin')
+            ? 'Declined'
+            : 'No Response';
+        const rsvpDate = dateCol >= 0 ? (match[dateCol] ?? '') : new Date().toISOString().slice(0, 10);
+        updated++;
+        return { ...inv, rsvpStatus, rsvpDate };
+      });
+      dispatch({ type: 'SET_INVITEES', invitees });
+      setStatus(`Updated ${updated} RSVP responses.`);
+    } catch (e) {
+      setStatus('Error: ' + String(e));
+    } finally {
+      setPulling(false);
+    }
+  }
+
+  const SECTION = "text-[10px] text-gray-500 tracking-[0.12em] font-mono uppercase mt-5 mb-2.5 dark:text-[#6e7681]";
+
+  return (
+    <div className="p-5 max-w-[760px] mx-auto w-full">
+      <div className="text-sm font-bold tracking-[0.08em] text-gray-900 mb-4 dark:text-[#f0f6fc]">SYNC</div>
+
+      {status && (
+        <div className={`text-xs mb-3.5 ${status.startsWith('Error') ? 'text-red-600 dark:text-[#f85149]' : 'text-green-600 dark:text-[#3fb950]'}`}>
+          {status}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-7">
+        {/* Push card */}
+        <div className="bg-white border border-gray-200 rounded-lg p-4 dark:bg-[#0d1117] dark:border-[#21262d]">
+          <div className={SECTION}>PUSH TO MASTER SHEET</div>
+          <div className="text-xs text-gray-500 mb-3.5 leading-relaxed dark:text-[#6e7681]">
+            Clears and rewrites all {state.invitees.length} invitees to your master Google Sheet.
+            {ev?.masterSheetUrl
+              ? <><br /><a href={ev.masterSheetUrl} target="_blank" rel="noreferrer" className="text-blue-600 text-[10px] dark:text-[#58a6ff]">Open sheet ↗</a></>
+              : <><br /><span className="text-red-600 text-[10px] dark:text-[#f85149]">Master Sheet URL not set in Setup.</span></>
+            }
+          </div>
+          <button
+            onClick={pushToSheets}
+            disabled={pushing}
+            className="min-h-[44px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-green-700 dark:border-[#238636] dark:bg-[#238636] disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {pushing ? 'Pushing…' : `Push ${state.invitees.length} rows`}
+          </button>
+        </div>
+
+        {/* Pull card */}
+        <div className="bg-white border border-gray-200 rounded-lg p-4 dark:bg-[#0d1117] dark:border-[#21262d]">
+          <div className={SECTION}>PULL RSVP RESPONSES</div>
+          <div className="text-xs text-gray-500 mb-3.5 leading-relaxed dark:text-[#6e7681]">
+            Reads RSVP statuses from your response sheet and updates invitee records.
+            {ev?.rsvpResponseUrl
+              ? <><br /><a href={ev.rsvpResponseUrl} target="_blank" rel="noreferrer" className="text-blue-600 text-[10px] dark:text-[#58a6ff]">Open sheet ↗</a></>
+              : <><br /><span className="text-red-600 text-[10px] dark:text-[#f85149]">RSVP Response Sheet URL not set in Setup.</span></>
+            }
+          </div>
+          <button
+            onClick={pullRsvp}
+            disabled={pulling}
+            className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c] disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {pulling ? 'Pulling…' : 'Pull RSVP Responses'}
+          </button>
+        </div>
+      </div>
+
+      <div className={SECTION}>GAS RSVP INGEST TRIGGER</div>
+      <div className="text-xs text-gray-500 leading-relaxed mb-3 dark:text-[#6e7681]">
+        Paste this script into your Google Form&rsquo;s Apps Script project. Add a trigger on{' '}
+        <code className="bg-gray-100 text-gray-800 px-1 py-0.5 rounded text-[10px] dark:bg-[#161b22] dark:text-[#c9d1d9]">onFormSubmit</code>{' '}
+        (Form Submit event). Set script property{' '}
+        <code className="bg-gray-100 text-gray-800 px-1 py-0.5 rounded text-[10px] dark:bg-[#161b22] dark:text-[#c9d1d9]">MASTER_SHEET_URL</code>{' '}
+        to your master sheet URL.
+      </div>
+      <div className="relative">
+        <pre
+          className="bg-gray-50 border border-gray-200 rounded-lg px-4 py-3.5 text-[10px] text-gray-800 overflow-x-auto leading-relaxed font-mono dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9]"
+          role="region"
+          aria-label="Google Apps Script code"
+          tabIndex={0}
+        >
+          {GAS_CODE}
+        </pre>
+        <button
+          className="absolute top-2 right-2 min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-gray-600 text-xs font-mono cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22]"
+          onClick={() => { navigator.clipboard.writeText(GAS_CODE); setStatus('Copied GAS code to clipboard.'); }}
+        >
+          Copy
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build and commit**
+
+```bash
+npm run build && git add src/inviteflow/tabs/SyncTab.tsx && git commit -m "feat(v3.1): SyncTab — Tailwind classes, responsive 2-col sync cards"
+```
+
+---
+
+## Task 12: Version Bump + Git Tag
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Update package.json version and name**
+
+Edit `package.json` — change `"name"` and `"version"`:
+
+```json
+{
+  "name": "inviteflow-v3.1",
+  "version": "3.1.0",
+  ...
+}
+```
+
+(Leave all other fields unchanged.)
+
+- [ ] **Step 2: Final build**
+
+```bash
+npm run build
+```
+
+Expected: PASS. Verify no TypeScript errors, no missing module errors.
+
+- [ ] **Step 3: Commit version bump**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore(v3.1): bump version to 3.1.0"
+```
+
+- [ ] **Step 4: Create annotated git tag**
+
+```bash
+git tag -a v3.1.0 -m "InviteFlow v3.1.0 — responsive mobile-first, light/dark theme, Tailwind CSS"
+```
+
+- [ ] **Step 5: Final smoke-test checklist**
+
+Run `npm run dev`, open `http://localhost:5173/src/inviteflow/index.html`, and verify:
+
+- [ ] Light theme loads on first visit
+- [ ] ☾ button switches to dark mode; ☀ switches back; preference survives page reload
+- [ ] At < 768px width: hamburger ☰ shows; desktop tabs hidden
+- [ ] Drawer opens, closes on backdrop tap and tab select
+- [ ] All 7 tabs render without white boxes or unstyled elements
+- [ ] ComposeTab: EDITOR/PREVIEW toggle visible on mobile; both panes show on desktop
+- [ ] InviteesTab: DataTable scrolls horizontally on narrow viewport
+- [ ] TrackerTab: category table scrolls horizontally on narrow viewport
+- [ ] SyncTab: two sync cards stack to single column on narrow viewport
+- [ ] All buttons meet 44px minimum height (inspect with browser devtools)

--- a/docs/superpowers/specs/2026-04-25-responsive-mobile-first-design.md
+++ b/docs/superpowers/specs/2026-04-25-responsive-mobile-first-design.md
@@ -1,0 +1,161 @@
+# Responsive Mobile-First Design — InviteFlow v3.1
+
+Author: Yu-Chin Chan
+Date: 2026-04-25
+
+## Overview
+
+Full Tailwind CSS migration with light-theme-default and dark-mode toggle, mobile-first responsive layout across all 7 tabs, hamburger drawer navigation on mobile, and WCAG AA accessibility improvements.
+
+## Section 1 — Setup & Architecture
+
+### Dependencies
+- Add `tailwindcss` and `@tailwindcss/vite` (Tailwind v4 Vite plugin — zero config file required)
+- No other new runtime dependencies
+
+### CSS entry point
+`src/index.css` gets `@import "tailwindcss"` as its first line. All existing inline styles are replaced with Tailwind utility classes during migration.
+
+### Theme system
+- **Light theme is the default.** Clean white/gray palette for all components.
+- **Dark mode** is opt-in via a `dark` class on `<html>`. The existing dark palette (`#080c10`, `#0d1117`, `#21262d`, `#c9d1d9`, `#C8A84B`, etc.) is preserved as `dark:` variant values using Tailwind arbitrary values.
+- Theme preference persisted in `localStorage` key `inviteflow_theme`.
+- `AppContext` gains `darkMode: boolean` state field and a `TOGGLE_DARK` action.
+- `App.tsx` syncs `document.documentElement.classList` in a `useEffect` whenever `darkMode` changes.
+
+### Style overrides
+Two small supplemental stylesheets in `src/inviteflow/styles/`:
+- `tiptap.css` — TipTap editor prose styles (cursor, placeholder, focus ring) for both themes
+- `primereact-reset.css` — neutralises PrimeReact's default white-theme backgrounds and borders so the DataTable inherits the app palette
+
+Both imported in `src/main.tsx` after the Tailwind import.
+
+### Version label
+Header displays `v3.1` (updated from `v3`).
+
+## Section 2 — App Header & Navigation
+
+### Header layout
+Two-zone flex bar (`justify-between`):
+
+**Left zone:**
+- "INVITEFLOW" wordmark (bold, tracking-tight)
+- "v3.1" badge
+- Active event name — `truncate max-w-[160px]` prevents overflow on narrow screens
+- Unsaved dot indicator
+
+**Right zone:**
+- Theme toggle button (sun ☀ / moon ☾ text label, or Unicode glyph) — visible at all widths
+- Hamburger `☰` button — `md:hidden`, opens the mobile drawer
+- Desktop tab nav — `hidden md:flex`, 7 horizontal tab buttons unchanged from current layout
+
+### Mobile drawer
+- Triggered by hamburger button; state: `useState<boolean>(drawerOpen)`
+- Fixed full-height panel sliding in from the left, `z-50`
+- 7 tab rows, each `min-h-[44px]`, active tab highlighted with blue left border + background tint
+- Closes on tab selection or backdrop tap
+- Backdrop: `fixed inset-0 bg-black/40 z-40`
+- Slide animation via `transition-transform`; `@media (prefers-reduced-motion: reduce)` disables animation
+- ARIA: button `aria-label="Open navigation"`, drawer `role="dialog" aria-modal="true"`, tab items `role="tab" aria-selected`
+
+## Section 3 — Per-Tab Responsive Changes
+
+### EventsTab
+- Card grid: `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4` (replaces `auto-fill minmax`)
+- All action buttons: `min-h-[44px]`
+- Card padding scaled to `p-4` on mobile, `p-5` on desktop
+
+### SetupTab
+- Form rows: `flex flex-col md:flex-row md:items-center gap-2` — stacked on mobile, inline label+input on `md:`
+- Each input: `w-full`
+- Google OAuth section: single-column on all breakpoints (already narrow content)
+- Save / Authorize buttons: `min-h-[44px] w-full sm:w-auto`
+
+### InviteesTab
+- DataTable wrapped in `overflow-x-auto` container with `role="region" aria-label="Invitees table" tabindex="0"`
+- PrimeReact DataTable gets `scrollable scrollHeight="flex"` props
+- Action toolbar (import buttons, Add Invitee button): `flex flex-wrap gap-2`
+- ContactScoutPanel: `w-full` on mobile, `max-w-sm` on `md:`
+- Import URL input: `w-full`
+
+### ComposeTab
+- Token insert bar: `flex flex-wrap gap-1` (already has `flexWrap: wrap` — convert to Tailwind)
+- Format toolbar: single row, `flex gap-1 flex-wrap`
+- **Editor/Preview split**: on `md:` and up, `grid grid-cols-2` (current 50/50). On mobile: two toggle buttons `EDITOR` / `PREVIEW` (visible only below `md:`) swap a `activePane: 'editor' | 'preview'` local `useState` (not persisted); only the selected pane renders. The other pane is `hidden`. Default is `'editor'`.
+- Both panes: `overflow-auto p-4`
+
+### SendTab
+- Filter + Send button row: `flex flex-wrap gap-2`
+- Send log table: `overflow-x-auto` wrapper with `role="region" tabindex="0"`
+- Progress bar and status text: full-width on mobile
+
+### TrackerTab
+- Stats card grid: `grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3` — 2-up on small phones
+- Category breakdown table: `overflow-x-auto` wrapper
+- Table itself: `min-w-[500px]` so columns don't collapse before scroll kicks in
+
+### SyncTab
+- Audit and apply same `w-full` inputs, `flex-wrap` toolbars, and `overflow-x-auto` table patterns
+
+## Section 4 — Accessibility & Polish
+
+### Touch targets
+- All `<button>` elements: `min-h-[44px]` at all breakpoints (44px on desktop is unobtrusive; avoiding a `md:` reset simplifies the rule)
+- Icon-only buttons also get `min-w-[44px]`
+
+### Focus visibility
+- All interactive elements: `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` (light) / `dark:focus-visible:ring-blue-400` (dark)
+- No focus suppression
+
+### Font size floor
+- Replace all `fontSize: 9` and `fontSize: 10` with minimum `text-[11px]` or `text-xs` (12px)
+- Body/label text: `text-sm` (14px) as the mobile baseline
+
+### Color contrast
+- Light theme: primary text `text-gray-900` on `bg-white` / `bg-gray-50` — passes WCAG AA
+- Dark theme: existing `#c9d1d9` on `#080c10` passes AA
+- Gold accent `#C8A84B` used only as decoration (borders, badges) — never as sole state indicator; status always paired with text label
+
+### Scrollable region accessibility
+- All `overflow-x-auto` wrappers: `role="region" aria-label="<descriptive name>" tabindex="0"`
+
+### Reduced motion
+- Drawer slide transition wrapped: `motion-safe:transition-transform` (Tailwind's built-in reduced-motion utility)
+
+## Light Theme Palette
+
+| Token | Light value | Dark value |
+|---|---|---|
+| App background | `bg-gray-50` | `dark:bg-[#080c10]` |
+| Surface / card | `bg-white` | `dark:bg-[#0d1117]` |
+| Border | `border-gray-200` | `dark:border-[#21262d]` |
+| Primary text | `text-gray-900` | `dark:text-[#c9d1d9]` |
+| Muted text | `text-gray-500` | `dark:text-[#6e7681]` |
+| Accent blue | `text-blue-600` | `dark:text-[#58a6ff]` |
+| Active tab | `bg-blue-600 text-white` | `dark:bg-[#1f6feb] dark:text-white` |
+| Gold accent | `text-[#C8A84B]` | `dark:text-[#C8A84B]` |
+| Success green | `text-green-600` | `dark:text-[#3fb950]` |
+| Error red | `text-red-600` | `dark:text-[#f85149]` |
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `package.json` | Add `tailwindcss`, `@tailwindcss/vite` |
+| `vite.config.ts` | Add `tailwindcss()` Vite plugin |
+| `src/index.css` | Add `@import "tailwindcss"` |
+| `src/main.tsx` | Import tiptap.css, primereact-reset.css |
+| `src/inviteflow/styles/tiptap.css` | New — TipTap prose overrides |
+| `src/inviteflow/styles/primereact-reset.css` | New — PrimeReact dark palette reset |
+| `src/inviteflow/state/AppContext.tsx` | Add `darkMode`, `TOGGLE_DARK` |
+| `src/inviteflow/state/reducer.ts` | Handle `TOGGLE_DARK` |
+| `src/inviteflow/state/actions.ts` | Add `TOGGLE_DARK` action type |
+| `src/inviteflow/App.tsx` | Hamburger drawer, theme toggle, v3.1 label, Tailwind classes |
+| `src/inviteflow/tabs/EventsTab.tsx` | Tailwind classes, responsive grid |
+| `src/inviteflow/tabs/SetupTab.tsx` | Tailwind classes, stacked mobile form |
+| `src/inviteflow/tabs/InviteesTab.tsx` | Tailwind classes, overflow-x-auto, flex-wrap toolbar |
+| `src/inviteflow/tabs/ComposeTab.tsx` | Tailwind classes, editor/preview toggle on mobile |
+| `src/inviteflow/tabs/SendTab.tsx` | Tailwind classes, flex-wrap, overflow-x-auto |
+| `src/inviteflow/tabs/TrackerTab.tsx` | Tailwind classes, responsive grid, overflow-x-auto |
+| `src/inviteflow/tabs/SyncTab.tsx` | Tailwind classes, flex-wrap, overflow-x-auto |
+| `src/inviteflow/components/ContactScoutPanel.tsx` | Tailwind classes, full-width on mobile |

--- a/docs/superpowers/specs/2026-04-25-responsive-mobile-first-design.md
+++ b/docs/superpowers/specs/2026-04-25-responsive-mobile-first-design.md
@@ -141,7 +141,7 @@ Two-zone flex bar (`justify-between`):
 
 | File | Change |
 |---|---|
-| `package.json` | Add `tailwindcss`, `@tailwindcss/vite` |
+| `package.json` | Bump `version` to `3.1.0`, `name` to `inviteflow-v3.1`, add `tailwindcss`, `@tailwindcss/vite` |
 | `vite.config.ts` | Add `tailwindcss()` Vite plugin |
 | `src/index.css` | Add `@import "tailwindcss"` |
 | `src/main.tsx` | Import tiptap.css, primereact-reset.css |
@@ -159,3 +159,4 @@ Two-zone flex bar (`justify-between`):
 | `src/inviteflow/tabs/TrackerTab.tsx` | Tailwind classes, responsive grid, overflow-x-auto |
 | `src/inviteflow/tabs/SyncTab.tsx` | Tailwind classes, flex-wrap, overflow-x-auto |
 | `src/inviteflow/components/ContactScoutPanel.tsx` | Tailwind classes, full-width on mobile |
+| Git tag | Create annotated tag `v3.1.0` after all changes land |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,15 @@
       "name": "inviteflow-v3",
       "version": "3.0.0",
       "dependencies": {
+        "@tailwindcss/vite": "^4.2.4",
         "@tiptap/react": "^2.11.7",
         "@tiptap/starter-kit": "^2.11.7",
         "primeflex": "^3.3.1",
         "primeicons": "^7.0.0",
         "primereact": "^10.8.3",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "tailwindcss": "^4.2.4"
       },
       "devDependencies": {
         "@types/react": "^18.3.12",
@@ -323,7 +325,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -340,7 +341,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -357,7 +357,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -374,7 +373,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -391,7 +389,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -408,7 +405,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -425,7 +421,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -442,7 +437,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -459,7 +453,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -476,7 +469,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -493,7 +485,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -510,7 +501,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -527,7 +517,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -544,7 +533,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -561,7 +549,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -578,7 +565,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -595,7 +581,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -612,7 +597,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -629,7 +613,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -646,7 +629,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -663,7 +645,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -680,7 +661,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -697,7 +677,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -714,7 +693,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -731,7 +709,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -748,7 +725,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -762,7 +738,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -773,7 +748,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -784,7 +758,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -794,14 +767,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -876,7 +847,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -890,7 +860,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -904,7 +873,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -918,7 +886,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -932,7 +899,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -946,7 +912,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -960,7 +925,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -977,7 +941,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -994,7 +957,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1011,7 +973,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1028,7 +989,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1045,7 +1005,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1062,7 +1021,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1079,7 +1037,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1096,7 +1053,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1113,7 +1069,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1130,7 +1085,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1147,7 +1101,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1164,7 +1117,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1181,7 +1133,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1195,7 +1146,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1209,7 +1159,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1223,7 +1172,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1237,7 +1185,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1251,12 +1198,280 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
+      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
+        "tailwindcss": "4.2.4"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
     },
     "node_modules/@tiptap/core": {
       "version": "2.27.2",
@@ -1692,7 +1907,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
@@ -1937,6 +2151,15 @@
         }
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1974,6 +2197,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -1990,7 +2226,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2175,7 +2410,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2257,7 +2491,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ignore": {
@@ -2301,6 +2534,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {
@@ -2348,6 +2590,267 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -2390,6 +2893,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -2466,7 +2978,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2566,7 +3077,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2599,7 +3109,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2967,7 +3476,6 @@
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -3071,7 +3579,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3100,11 +3607,29 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/tailwindcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -3121,7 +3646,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3139,7 +3663,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3267,7 +3790,6 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -3342,7 +3864,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3360,7 +3881,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "inviteflow-v3",
-  "version": "3.0.0",
+  "name": "inviteflow-v3.1",
+  "version": "3.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,15 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
+    "@tailwindcss/vite": "^4.2.4",
+    "@tiptap/react": "^2.11.7",
+    "@tiptap/starter-kit": "^2.11.7",
     "primeflex": "^3.3.1",
     "primeicons": "^7.0.0",
     "primereact": "^10.8.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@tiptap/react": "^2.11.7",
-    "@tiptap/starter-kit": "^2.11.7"
+    "tailwindcss": "^4.2.4"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,11 @@
+@import "tailwindcss";
+
+@variant dark (&:where(.dark, .dark *));
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}

--- a/src/inviteflow/App.tsx
+++ b/src/inviteflow/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { AppProvider, useAppState, useAppDispatch } from './state/AppContext';
 import type { TabId } from './types';
 import EventsTab from './tabs/EventsTab';
@@ -34,44 +35,122 @@ function TabContent() {
 function AppInner() {
   const state = useAppState();
   const dispatch = useAppDispatch();
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const activeEvent = state.events.find(e => e.id === state.activeEventId);
 
+  function selectTab(id: TabId) {
+    dispatch({ type: 'SET_TAB', tab: id });
+    setDrawerOpen(false);
+  }
+
   return (
-    <div style={{ height: '100vh', background: '#080c10', color: '#c9d1d9', fontFamily: 'monospace', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-      <header style={{ borderBottom: '1px solid #21262d', padding: '8px 20px', display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0 }}>
-        <span style={{ fontWeight: 800, fontSize: 15, color: '#f0f6fc', letterSpacing: '-0.02em' }}>INVITEFLOW</span>
-        <span style={{ fontSize: 9, color: '#6e7681', letterSpacing: '0.12em' }}>v3</span>
+    <div className="h-screen bg-gray-50 text-gray-900 font-mono flex flex-col overflow-hidden dark:bg-[#080c10] dark:text-[#c9d1d9]">
+      {/* Header */}
+      <header className="border-b border-gray-200 px-4 py-2 flex items-center gap-3 shrink-0 bg-white dark:bg-[#0d1117] dark:border-[#21262d]">
+        {/* Left zone */}
+        <span className="font-black text-sm text-gray-900 tracking-tight dark:text-[#f0f6fc]">INVITEFLOW</span>
+        <span className="text-[9px] text-gray-400 tracking-[0.12em] dark:text-[#6e7681]">v3.1</span>
         {activeEvent && (
-          <span style={{ fontSize: 10, color: '#C8A84B', letterSpacing: '0.08em', borderLeft: '1px solid #21262d', paddingLeft: 12 }}>
+          <span className="text-[10px] text-[#C8A84B] tracking-[0.08em] border-l border-gray-200 pl-3 truncate max-w-[160px] dark:border-[#21262d]">
             {activeEvent.name}
           </span>
         )}
-        {state.unsaved && <span style={{ fontSize: 9, color: '#6e7681', letterSpacing: '0.1em' }}>●</span>}
-        <nav style={{ marginLeft: 'auto', display: 'flex', gap: 3 }}>
-          {TABS.map(t => (
-            <button
-              key={t.id}
-              onClick={() => dispatch({ type: 'SET_TAB', tab: t.id })}
-              style={{
-                background: state.tab === t.id ? '#1f6feb' : 'transparent',
-                border: state.tab === t.id ? '1px solid #1f6feb' : '1px solid transparent',
-                color: state.tab === t.id ? '#fff' : '#8b949e',
-                padding: '4px 10px',
-                borderRadius: 4,
-                cursor: 'pointer',
-                fontFamily: 'monospace',
-                fontSize: 10,
-                letterSpacing: '0.07em',
-                textTransform: 'uppercase',
-              }}
-            >
-              {t.label}
-            </button>
-          ))}
-        </nav>
+        {state.unsaved && (
+          <span className="text-[9px] text-gray-400 tracking-[0.1em] dark:text-[#6e7681]">●</span>
+        )}
+
+        {/* Right zone */}
+        <div className="ml-auto flex items-center gap-2">
+          {/* Theme toggle */}
+          <button
+            onClick={() => dispatch({ type: 'TOGGLE_DARK' })}
+            aria-label={state.darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-sm text-gray-500 hover:text-gray-900 dark:text-[#6e7681] dark:hover:text-[#c9d1d9] rounded"
+          >
+            {state.darkMode ? '☀' : '☾'}
+          </button>
+
+          {/* Desktop nav */}
+          <nav className="hidden md:flex gap-1" role="tablist">
+            {TABS.map(t => (
+              <button
+                key={t.id}
+                role="tab"
+                aria-selected={state.tab === t.id}
+                onClick={() => selectTab(t.id)}
+                className={[
+                  'min-h-[44px] px-2.5 py-1 rounded border text-[10px] font-mono tracking-[0.07em] uppercase cursor-pointer',
+                  state.tab === t.id
+                    ? 'bg-blue-600 border-blue-600 text-white dark:bg-[#1f6feb] dark:border-[#1f6feb]'
+                    : 'bg-transparent border-transparent text-gray-500 hover:text-gray-900 dark:text-[#8b949e] dark:hover:text-[#c9d1d9]',
+                ].join(' ')}
+              >
+                {t.label}
+              </button>
+            ))}
+          </nav>
+
+          {/* Hamburger (mobile only) */}
+          <button
+            className="md:hidden min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-600 dark:text-[#8b949e]"
+            onClick={() => setDrawerOpen(true)}
+            aria-label="Open navigation"
+          >
+            ☰
+          </button>
+        </div>
       </header>
-      <main style={{ flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
+
+      {/* Mobile drawer */}
+      {drawerOpen && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 bg-black/40 z-40 md:hidden"
+            onClick={() => setDrawerOpen(false)}
+          />
+          {/* Drawer */}
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Navigation"
+            className="fixed inset-y-0 left-0 w-64 bg-white border-r border-gray-200 z-50 flex flex-col md:hidden motion-safe:transition-transform dark:bg-[#0d1117] dark:border-[#21262d]"
+          >
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-[#21262d]">
+              <span className="font-black text-sm text-gray-900 tracking-tight dark:text-[#f0f6fc]">INVITEFLOW</span>
+              <button
+                onClick={() => setDrawerOpen(false)}
+                aria-label="Close navigation"
+                className="min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-500 dark:text-[#6e7681]"
+              >
+                ✕
+              </button>
+            </div>
+            <nav role="tablist" className="flex flex-col py-2">
+              {TABS.map(t => (
+                <button
+                  key={t.id}
+                  role="tab"
+                  aria-selected={state.tab === t.id}
+                  onClick={() => selectTab(t.id)}
+                  className={[
+                    'min-h-[44px] flex items-center px-5 text-xs font-mono tracking-[0.07em] uppercase cursor-pointer border-l-2',
+                    state.tab === t.id
+                      ? 'border-blue-600 bg-blue-50 text-blue-700 dark:border-[#1f6feb] dark:bg-[#0d1f3c] dark:text-[#58a6ff]'
+                      : 'border-transparent text-gray-600 hover:bg-gray-50 dark:text-[#8b949e] dark:hover:bg-[#161b22]',
+                  ].join(' ')}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </nav>
+          </div>
+        </>
+      )}
+
+      {/* Main content */}
+      <main className="flex-1 overflow-auto flex flex-col">
         <TabContent />
       </main>
     </div>

--- a/src/inviteflow/components/ContactScoutPanel.tsx
+++ b/src/inviteflow/components/ContactScoutPanel.tsx
@@ -68,15 +68,31 @@ function saveScoutState(s: ScoutState) {
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
 
-// ── Status colors ─────────────────────────────────────────────────────────────
-const STATUS_COLOR: Record<string, string> = {
-  pending: '#6e7681', checking: '#C8A84B', done: '#3fb950',
-  changed: '#58a6ff', left_office: '#f85149', error: '#f85149',
+// ── Status styles ─────────────────────────────────────────────────────────────
+const STATUS_CLASS: Record<string, string> = {
+  pending: 'text-gray-400 dark:text-[#6e7681]',
+  checking: 'text-[#C8A84B]',
+  done: 'text-green-600 dark:text-[#3fb950]',
+  changed: 'text-blue-600 dark:text-[#58a6ff]',
+  left_office: 'text-red-600 dark:text-[#f85149]',
+  error: 'text-red-600 dark:text-[#f85149]',
 };
 const STATUS_LABEL: Record<string, string> = {
   pending: 'Pending', checking: 'Checking…', done: 'Verified',
   changed: 'Changed', left_office: 'Inactive', error: 'Error',
 };
+
+const BTN_GHOST = "min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-gray-700 text-xs font-mono tracking-wide cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22] disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap";
+const BTN_GREEN = "min-h-[44px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-green-700 dark:border-[#238636] dark:bg-[#238636] disabled:opacity-50 disabled:cursor-not-allowed";
+const BTN_BLUE_GHOST = "min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c] disabled:opacity-50 disabled:cursor-not-allowed";
+const BTN_GOLD = "min-h-[44px] px-3 py-1 rounded border border-[#C8A84B] bg-[#1c1a10] text-[#C8A84B] text-xs font-mono tracking-wide cursor-pointer hover:bg-[#2a2510] disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap";
+const BTN_DANGER = "min-h-[44px] px-3 py-1 rounded border border-red-500 bg-transparent text-red-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-red-50 dark:border-[#f85149] dark:text-[#f85149] disabled:opacity-50 disabled:cursor-not-allowed";
+const BTN_SCAN = (st: string) => `min-h-[44px] px-3 py-1 rounded border text-xs font-mono tracking-wide cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap ${
+  st === 'done' ? 'border-green-500 text-green-600 dark:border-[#3fb950] dark:text-[#3fb950]' :
+  st === 'scanning' ? 'border-[#C8A84B] text-[#C8A84B]' :
+  'border-gray-300 text-gray-600 dark:border-[#21262d] dark:text-[#8b949e]'
+}`;
+const INPUT = "bg-white border border-gray-300 text-gray-900 text-xs font-mono px-2.5 py-1.5 rounded outline-none focus:border-blue-500 dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9]";
 
 // ── Component ─────────────────────────────────────────────────────────────────
 export default function ContactScoutPanel() {
@@ -275,95 +291,81 @@ export default function ContactScoutPanel() {
     r.readAsText(file);
   }
 
-  // ── Styles ────────────────────────────────────────────────────────────────────
-  const s = {
-    panel: { border: '1px solid #21262d', borderRadius: 6, background: '#0d1117', marginTop: 8 } as React.CSSProperties,
-    header: { display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', cursor: 'pointer', userSelect: 'none' as const },
-    label: { fontSize: 10, color: '#6e7681', letterSpacing: '0.1em', textTransform: 'uppercase' as const },
-    body: { padding: '12px 16px', borderTop: '1px solid #21262d' },
-    btn: (color = '#8b949e', bg = 'transparent'): React.CSSProperties => ({
-      border: `1px solid ${color}`, background: bg, color, padding: '4px 10px',
-      borderRadius: 4, cursor: 'pointer', fontFamily: 'monospace', fontSize: 10,
-      letterSpacing: '0.05em', whiteSpace: 'nowrap',
-    }),
-    input: { background: '#0d1117', border: '1px solid #21262d', color: '#c9d1d9', padding: '5px 8px', borderRadius: 4, fontFamily: 'monospace', fontSize: 11 } as React.CSSProperties,
-  };
+  function tryUnlock() {
+    if (pwInput === 'scout2025') { setUnlocked(true); setPwErr(false); }
+    else { setPwErr(true); }
+  }
 
   // ── Lock screen ───────────────────────────────────────────────────────────────
   function renderLock() {
     return (
-      <div style={{ padding: '16px', display: 'flex', gap: 8, alignItems: 'center' }}>
+      <div className="px-4 py-3 flex flex-wrap gap-2 items-center border-t border-gray-200 dark:border-[#21262d]">
         <input
           type="password"
           placeholder="Enter passcode…"
           value={pwInput}
           onChange={e => { setPwInput(e.target.value); setPwErr(false); }}
           onKeyDown={e => e.key === 'Enter' && tryUnlock()}
-          style={{ ...s.input, width: 160 }}
+          className={`${INPUT} w-40`}
         />
-        <button style={s.btn('#58a6ff')} onClick={tryUnlock}>Unlock</button>
-        {pwErr && <span style={{ fontSize: 10, color: '#f85149' }}>Incorrect passcode</span>}
+        <button className={BTN_BLUE_GHOST} onClick={tryUnlock}>Unlock</button>
+        {pwErr && <span className="text-[10px] text-red-600 dark:text-[#f85149]">Incorrect passcode</span>}
       </div>
     );
-  }
-
-  function tryUnlock() {
-    if (pwInput === 'scout2025') { setUnlocked(true); setPwErr(false); }
-    else { setPwErr(true); }
   }
 
   // ── Main UI ───────────────────────────────────────────────────────────────────
   function renderContent() {
     return (
-      <div style={s.body}>
+      <div className="px-4 py-3 border-t border-gray-200 dark:border-[#21262d]">
         {/* API key row */}
         {showKeyInput ? (
-          <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 12 }}>
+          <div className="flex flex-wrap gap-2 items-center mb-3">
             <input
               type="password"
               placeholder="sk-ant-…"
               value={apiKeyDraft}
               onChange={e => setApiKeyDraft(e.target.value)}
-              style={{ ...s.input, flex: 1 }}
+              className={`${INPUT} flex-1 min-w-[180px]`}
             />
-            <button style={s.btn('#3fb950')} onClick={() => {
+            <button className={BTN_GREEN} onClick={() => {
               if (!apiKeyDraft.startsWith('sk-ant-')) return;
               setApiKey(apiKeyDraft);
               sessionStorage.setItem(SS_KEY, apiKeyDraft);
               setApiKeyDraft(''); setShowKeyInput(false);
             }}>Save Key</button>
-            <button style={s.btn()} onClick={() => setShowKeyInput(false)}>Cancel</button>
+            <button className={BTN_GHOST} onClick={() => setShowKeyInput(false)}>Cancel</button>
           </div>
         ) : (
-          <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 12, flexWrap: 'wrap' }}>
-            <span style={{ fontSize: 10, color: apiKey ? '#3fb950' : '#f85149' }}>
+          <div className="flex flex-wrap gap-2 items-center mb-3">
+            <span className={`text-[10px] font-mono ${apiKey ? 'text-green-600 dark:text-[#3fb950]' : 'text-red-600 dark:text-[#f85149]'}`}>
               {apiKey ? '● API key set' : '● No API key'}
             </span>
-            <button style={s.btn()} onClick={() => setShowKeyInput(true)}>
+            <button className={BTN_GHOST} onClick={() => setShowKeyInput(true)}>
               {apiKey ? 'Change Key' : 'Set API Key'}
             </button>
-            <button style={s.btn('#C8A84B', '#1c1a10')} onClick={exportToInviteFlow} title="Push active contacts to Invitees list">
+            <button className={BTN_GOLD} onClick={exportToInviteFlow} title="Push active contacts to Invitees list">
               Push to InviteFlow ({scout.contacts.filter(c => c.status !== 'left_office').length})
             </button>
-            <button style={s.btn()} onClick={exportBackup}>Backup</button>
-            <button style={s.btn()} onClick={() => importRef.current?.click()}>Restore</button>
-            <input ref={importRef} type="file" accept=".json" style={{ display: 'none' }}
+            <button className={BTN_GHOST} onClick={exportBackup}>Backup</button>
+            <button className={BTN_GHOST} onClick={() => importRef.current?.click()}>Restore</button>
+            <input ref={importRef} type="file" accept=".json" className="hidden"
               onChange={e => e.target.files?.[0] && importBackup(e.target.files[0])} />
             {running && (
               <>
-                <span style={{ fontSize: 10, color: '#C8A84B' }}>{progress.done}/{progress.total}</span>
-                <button style={s.btn('#f85149')} onClick={() => { abortRef.current = true; }}>Stop</button>
+                <span className="text-[10px] text-[#C8A84B] font-mono">{progress.done}/{progress.total}</span>
+                <button className={BTN_DANGER} onClick={() => { abortRef.current = true; }}>Stop</button>
               </>
             )}
           </div>
         )}
 
         {/* Scan targets */}
-        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 12 }}>
+        <div className="flex flex-wrap gap-1.5 mb-3">
           {SCAN_TARGETS.map(t => {
-            const st = scout.scanStatus[t.id];
+            const st = scout.scanStatus[t.id] ?? '';
             return (
-              <button key={t.id} style={s.btn(st === 'done' ? '#3fb950' : st === 'scanning' ? '#C8A84B' : '#8b949e')}
+              <button key={t.id} className={BTN_SCAN(st)}
                 onClick={() => runScan(t.id)} disabled={running} title={t.desc}>
                 {st === 'scanning' ? '↻ ' : st === 'done' ? '✓ ' : ''}
                 {t.label.split(' — ')[0]}
@@ -371,7 +373,7 @@ export default function ContactScoutPanel() {
             );
           })}
           {scout.contacts.length > 0 && (
-            <button style={s.btn('#58a6ff')} disabled={running}
+            <button className={BTN_BLUE_GHOST} disabled={running}
               onClick={() => runVerify(scout.contacts.filter(c => c.status === 'pending').map(c => c.name))}>
               Verify All Pending
             </button>
@@ -380,50 +382,59 @@ export default function ContactScoutPanel() {
 
         {/* New contacts found */}
         {scout.newContacts.length > 0 && (
-          <div style={{ marginBottom: 10, border: '1px solid #21262d', borderRadius: 4, overflow: 'hidden' }}>
-            <div style={{ padding: '6px 10px', background: '#161b22', fontSize: 10, color: '#C8A84B', letterSpacing: '0.08em' }}>
+          <div className="mb-2.5 border border-gray-200 rounded overflow-hidden dark:border-[#21262d]">
+            <div className="px-2.5 py-1.5 bg-gray-100 text-[10px] text-[#C8A84B] tracking-[0.08em] font-mono dark:bg-[#161b22]">
               NEW CONTACTS ({scout.newContacts.length})
             </div>
             {scout.newContacts.slice(0, 8).map(c => (
-              <div key={c.name} style={{ display: 'flex', gap: 8, alignItems: 'center', padding: '5px 10px', borderTop: '1px solid #0d1117', fontSize: 10 }}>
-                <span style={{ flex: 1, color: '#c9d1d9' }}>{c.name}</span>
-                <span style={{ color: '#6e7681' }}>{c.title}</span>
-                <button style={{ ...s.btn('#3fb950'), padding: '2px 7px', fontSize: 9 }} onClick={() => {
-                  persist({
-                    ...scout,
-                    contacts: [...scout.contacts, { ...c, status: 'pending', result: null }],
-                    newContacts: scout.newContacts.filter(x => x.name !== c.name),
-                  });
-                  addLog(`+ Added ${c.name}`);
-                }}>Add</button>
-                <button style={{ ...s.btn('#6e7681'), padding: '2px 7px', fontSize: 9 }} onClick={() => {
-                  persist({ ...scout, newContacts: scout.newContacts.filter(x => x.name !== c.name) });
-                }}>Dismiss</button>
+              <div key={c.name} className="flex flex-wrap gap-2 items-center px-2.5 py-1.5 border-t border-gray-100 text-xs dark:border-[#0d1117]">
+                <span className="flex-1 text-gray-900 dark:text-[#c9d1d9]">{c.name}</span>
+                <span className="text-gray-500 dark:text-[#6e7681]">{c.title}</span>
+                <button className="min-h-[32px] px-2 py-0.5 rounded border border-green-500 text-green-600 text-[9px] font-mono cursor-pointer hover:bg-green-50 dark:border-[#3fb950] dark:text-[#3fb950]"
+                  onClick={() => {
+                    persist({
+                      ...scout,
+                      contacts: [...scout.contacts, { ...c, status: 'pending', result: null }],
+                      newContacts: scout.newContacts.filter(x => x.name !== c.name),
+                    });
+                    addLog(`+ Added ${c.name}`);
+                  }}>Add</button>
+                <button className="min-h-[32px] px-2 py-0.5 rounded border border-gray-300 text-gray-500 text-[9px] font-mono cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#6e7681]"
+                  onClick={() => {
+                    persist({ ...scout, newContacts: scout.newContacts.filter(x => x.name !== c.name) });
+                  }}>Dismiss</button>
               </div>
             ))}
             {scout.newContacts.length > 8 && (
-              <div style={{ padding: '4px 10px', fontSize: 9, color: '#6e7681' }}>+{scout.newContacts.length - 8} more…</div>
+              <div className="px-2.5 py-1 text-[9px] text-gray-400 dark:text-[#6e7681]">+{scout.newContacts.length - 8} more…</div>
             )}
           </div>
         )}
 
         {/* Contact list */}
         {scout.contacts.length === 0 ? (
-          <div style={{ fontSize: 10, color: '#6e7681', fontStyle: 'italic', padding: '8px 0' }}>
+          <div className="text-[10px] text-gray-500 italic py-2 dark:text-[#6e7681]">
             No contacts yet — run a scan above or restore a backup.
           </div>
         ) : (
-          <div style={{ maxHeight: 260, overflowY: 'auto', border: '1px solid #21262d', borderRadius: 4 }}>
+          <div
+            className="max-h-64 overflow-y-auto border border-gray-200 rounded dark:border-[#21262d]"
+            role="region"
+            aria-label="Contact list"
+            tabIndex={0}
+          >
             {scout.contacts.map(c => (
-              <div key={c.name} style={{ display: 'flex', gap: 8, alignItems: 'center', padding: '5px 10px', borderBottom: '1px solid #0d1117', fontSize: 10 }}>
-                <span style={{ width: 56, color: STATUS_COLOR[c.status], letterSpacing: '0.06em', flexShrink: 0, fontSize: 9 }}>
+              <div key={c.name} className="flex flex-wrap gap-2 items-center px-2.5 py-1.5 border-b border-gray-100 text-xs dark:border-[#0d1117]">
+                <span className={`w-14 text-[9px] font-mono tracking-[0.06em] shrink-0 ${STATUS_CLASS[c.status] ?? 'text-gray-400'}`}>
                   {STATUS_LABEL[c.status]}
                 </span>
-                <span style={{ flex: 1, color: '#c9d1d9' }}>{c.name}</span>
-                <span style={{ color: '#6e7681', maxWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.title}</span>
-                <span style={{ color: '#6e7681', maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.officeEmail ?? c.directEmail}</span>
+                <span className="flex-1 text-gray-900 dark:text-[#c9d1d9]">{c.name}</span>
+                <span className="text-gray-500 max-w-[160px] truncate dark:text-[#6e7681]">{c.title}</span>
+                <span className="text-gray-500 max-w-[140px] truncate dark:text-[#6e7681]">{c.officeEmail ?? c.directEmail}</span>
                 {c.status === 'pending' && (
-                  <button style={{ ...s.btn('#58a6ff'), padding: '2px 7px', fontSize: 9 }} onClick={() => runVerify([c.name])} disabled={running}>
+                  <button
+                    className="min-h-[32px] px-2 py-0.5 rounded border border-blue-400 text-blue-600 text-[9px] font-mono cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] disabled:opacity-50"
+                    onClick={() => runVerify([c.name])} disabled={running}>
                     Verify
                   </button>
                 )}
@@ -434,7 +445,7 @@ export default function ContactScoutPanel() {
 
         {/* Log */}
         {log.length > 0 && (
-          <div style={{ marginTop: 10, maxHeight: 80, overflowY: 'auto', fontSize: 9, color: '#6e7681', fontFamily: 'monospace', lineHeight: 1.6 }}>
+          <div className="mt-2.5 max-h-20 overflow-y-auto text-[9px] text-gray-400 font-mono leading-relaxed dark:text-[#6e7681]">
             {log.slice(0, 10).map((l, i) => <div key={i}>{l}</div>)}
           </div>
         )}
@@ -443,12 +454,15 @@ export default function ContactScoutPanel() {
   }
 
   return (
-    <div style={{ ...s.panel, opacity: open && !unlocked ? 0.6 : 1 }}>
-      <div style={s.header} onClick={() => setOpen(o => !o)}>
-        <span style={s.label}>ContactScout</span>
-        <span style={{ fontSize: 9, color: '#6e7681' }}>— Claude-powered contact discovery</span>
-        {!unlocked && open && <span style={{ fontSize: 9, color: '#C8A84B', marginLeft: 4 }}>🔒</span>}
-        <span style={{ marginLeft: 'auto', fontSize: 10, color: '#6e7681' }}>{open ? '▲' : '▼'}</span>
+    <div className={`mt-2 border border-gray-200 rounded-lg bg-white dark:bg-[#0d1117] dark:border-[#21262d] ${open && !unlocked ? 'opacity-60' : ''}`}>
+      <div
+        className="flex items-center gap-2 px-3 py-2 cursor-pointer select-none min-h-[44px]"
+        onClick={() => setOpen(o => !o)}
+      >
+        <span className="text-[10px] text-gray-500 tracking-[0.1em] font-mono uppercase dark:text-[#6e7681]">ContactScout</span>
+        <span className="text-[9px] text-gray-400 dark:text-[#6e7681]">— Claude-powered contact discovery</span>
+        {!unlocked && open && <span className="text-[9px] text-[#C8A84B] ml-1">🔒</span>}
+        <span className="ml-auto text-[10px] text-gray-400 dark:text-[#6e7681]">{open ? '▲' : '▼'}</span>
       </div>
       {open && (unlocked ? renderContent() : renderLock())}
     </div>

--- a/src/inviteflow/index.html
+++ b/src/inviteflow/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>InviteFlow v3</title>
+  <title>InviteFlow v3.1</title>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
 </head>
 <body>

--- a/src/inviteflow/main.tsx
+++ b/src/inviteflow/main.tsx
@@ -1,9 +1,12 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import 'primereact/resources/themes/lara-dark-indigo/theme.css';
+import '../index.css';
+import 'primereact/resources/themes/lara-light-indigo/theme.css';
 import 'primereact/resources/primereact.min.css';
 import 'primeicons/primeicons.css';
 import 'primeflex/primeflex.css';
+import './styles/primereact-reset.css';
+import './styles/tiptap.css';
 import App from './App';
 
 const root = document.getElementById('root');

--- a/src/inviteflow/state/AppContext.tsx
+++ b/src/inviteflow/state/AppContext.tsx
@@ -6,7 +6,7 @@ import { reducer, INITIAL_STATE } from './reducer';
 const STORAGE_KEY = 'inviteflow_v3_state';
 
 function saveState(state: AppState) {
-  const { sendLog: _sl, sending: _s, sendProgress: _sp, ...rest } = state;
+  const { sendLog: _sl, sending: _s, sendProgress: _sp, darkMode: _d, ...rest } = state;
   try { localStorage.setItem(STORAGE_KEY, JSON.stringify(rest)); } catch { /* quota */ }
 }
 
@@ -27,6 +27,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
   }));
 
   useEffect(() => { saveState(state); }, [state]);
+
+  useEffect(() => {
+    if (state.darkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [state.darkMode]);
 
   return (
     <StateCtx.Provider value={state}>

--- a/src/inviteflow/state/actions.ts
+++ b/src/inviteflow/state/actions.ts
@@ -17,4 +17,5 @@ export type Action =
   | { type: 'LOG_SEND'; entry: SendLogEntry }
   | { type: 'STOP_SEND' }
   | { type: 'SET_UNSAVED'; unsaved: boolean }
+  | { type: 'TOGGLE_DARK' }
   | { type: 'LOAD_STATE'; partial: Partial<AppState> };

--- a/src/inviteflow/state/reducer.ts
+++ b/src/inviteflow/state/reducer.ts
@@ -1,6 +1,10 @@
 import type { AppState } from '../types';
 import type { Action } from './actions';
 
+function loadDarkPref(): boolean {
+  return localStorage.getItem('inviteflow_theme') === 'dark';
+}
+
 export const INITIAL_STATE: AppState = {
   activeEventId: null,
   events: [],
@@ -12,6 +16,7 @@ export const INITIAL_STATE: AppState = {
   sending: false,
   sendProgress: { current: 0, total: 0 },
   unsaved: false,
+  darkMode: loadDarkPref(),
 };
 
 export function reducer(state: AppState, action: Action): AppState {
@@ -51,6 +56,11 @@ export function reducer(state: AppState, action: Action): AppState {
       return { ...state, sending: false };
     case 'SET_UNSAVED':
       return { ...state, unsaved: action.unsaved };
+    case 'TOGGLE_DARK': {
+      const next = !state.darkMode;
+      localStorage.setItem('inviteflow_theme', next ? 'dark' : 'light');
+      return { ...state, darkMode: next };
+    }
     case 'LOAD_STATE':
       return { ...state, ...action.partial };
     default:

--- a/src/inviteflow/styles/primereact-reset.css
+++ b/src/inviteflow/styles/primereact-reset.css
@@ -1,0 +1,54 @@
+/* Override PrimeReact lara-light-indigo vars for dark mode */
+.dark {
+  --surface-ground: #080c10;
+  --surface-section: #080c10;
+  --surface-card: #0d1117;
+  --surface-overlay: #0d1117;
+  --surface-border: #21262d;
+  --surface-hover: #161b22;
+  --surface-0: #0d1117;
+  --surface-50: #0d1117;
+  --surface-100: #161b22;
+  --surface-200: #21262d;
+  --surface-300: #30363d;
+  --surface-400: #484f58;
+  --surface-500: #6e7681;
+  --surface-600: #8b949e;
+  --surface-700: #b1bac4;
+  --surface-800: #c9d1d9;
+  --surface-900: #f0f6fc;
+  --text-color: #c9d1d9;
+  --text-color-secondary: #6e7681;
+  --primary-color: #6366F1;
+  --primary-color-text: #ffffff;
+  color-scheme: dark;
+}
+
+.p-datatable .p-datatable-thead > tr > th {
+  background: var(--surface-card);
+  color: var(--text-color-secondary);
+  border-color: var(--surface-border);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  font-family: monospace;
+}
+
+.p-datatable .p-datatable-tbody > tr {
+  background: var(--surface-card);
+  color: var(--text-color);
+  font-size: 11px;
+  font-family: monospace;
+}
+
+.p-datatable .p-datatable-tbody > tr:hover {
+  background: var(--surface-hover) !important;
+}
+
+.p-datatable .p-datatable-tbody > tr > td {
+  border-color: var(--surface-border);
+  padding: 6px 10px;
+}
+
+.p-datatable .p-datatable-thead > tr > th {
+  padding: 6px 10px;
+}

--- a/src/inviteflow/styles/tiptap.css
+++ b/src/inviteflow/styles/tiptap.css
@@ -1,0 +1,26 @@
+/* TipTap editor content styles */
+.tiptap {
+  outline: none;
+  min-height: 200px;
+  font-size: 13px;
+  line-height: 1.8;
+  color: #111827;
+}
+
+.dark .tiptap {
+  color: #c9d1d9;
+}
+
+.tiptap p {
+  margin: 0.5em 0;
+}
+
+.tiptap ul,
+.tiptap ol {
+  padding-left: 1.5em;
+  margin: 0.5em 0;
+}
+
+.tiptap.ProseMirror-focused {
+  outline: none;
+}

--- a/src/inviteflow/tabs/ComposeTab.tsx
+++ b/src/inviteflow/tabs/ComposeTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { useAppState, useAppDispatch } from '../state/AppContext';
@@ -11,9 +11,24 @@ const TOKENS = [
   'VIPStart', 'VIPEnd', 'RSVP_Link', 'Date_Sent',
 ];
 
+const TOKEN_BTN = "px-1.5 py-0.5 rounded border border-gray-300 bg-transparent text-gray-600 text-[9px] font-mono tracking-wide cursor-pointer hover:border-[#C8A84B] hover:text-[#C8A84B] dark:border-[#21262d] dark:text-[#8b949e] dark:hover:border-[#C8A84B] dark:hover:text-[#C8A84B]";
+const FMT_BTN = (active: boolean) =>
+  `min-h-[36px] px-2.5 py-1 rounded border text-[10px] font-mono cursor-pointer ${
+    active
+      ? 'border-[#C8A84B] bg-[#2a1a00] text-[#C8A84B]'
+      : 'border-gray-300 bg-transparent text-gray-600 hover:border-gray-500 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:border-[#484f58]'
+  }`;
+const PANE_BTN = (active: boolean) =>
+  `min-h-[36px] px-3 py-1 rounded border text-[10px] font-mono tracking-wide cursor-pointer ${
+    active
+      ? 'border-blue-600 bg-blue-600 text-white dark:border-[#1f6feb] dark:bg-[#1f6feb]'
+      : 'border-gray-300 bg-transparent text-gray-600 dark:border-[#21262d] dark:text-[#8b949e]'
+  }`;
+
 export default function ComposeTab() {
   const state = useAppState();
   const dispatch = useAppDispatch();
+  const [activePane, setActivePane] = useState<'editor' | 'preview'>('editor');
   const ev = state.events.find(e => e.id === state.activeEventId);
   const sample = state.invitees[0];
 
@@ -43,61 +58,63 @@ export default function ComposeTab() {
     ? personalize(state.htmlBody, sample, ev)
     : state.htmlBody;
 
-  const btn = (active = false): React.CSSProperties => ({
-    border: `1px solid ${active ? '#C8A84B' : '#21262d'}`,
-    background: active ? '#2a1a00' : 'transparent',
-    color: active ? '#C8A84B' : '#8b949e',
-    padding: '3px 8px',
-    borderRadius: 3,
-    cursor: 'pointer',
-    fontFamily: 'monospace',
-    fontSize: 10,
-    letterSpacing: '0.05em',
-  });
-
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+    <div className="flex flex-col h-full overflow-hidden">
       {/* Top bar */}
-      <div style={{ padding: '12px 20px', borderBottom: '1px solid #21262d', display: 'flex', flexDirection: 'column', gap: 10 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <span style={{ fontSize: 10, color: '#6e7681', letterSpacing: '0.1em', minWidth: 60 }}>SUBJECT</span>
+      <div className="px-4 py-3 border-b border-gray-200 flex flex-col gap-2.5 shrink-0 dark:border-[#21262d]">
+        {/* Subject */}
+        <div className="flex items-center gap-2.5">
+          <span className="text-[10px] text-gray-500 tracking-widest font-mono uppercase shrink-0 dark:text-[#6e7681]">Subject</span>
           <input
-            style={{ flex: 1, background: '#0d1117', border: '1px solid #21262d', color: '#c9d1d9', padding: '5px 10px', borderRadius: 4, fontFamily: 'monospace', fontSize: 11, outline: 'none' }}
+            className="flex-1 min-w-0 bg-white border border-gray-300 text-gray-900 text-xs font-mono px-2.5 py-1.5 rounded outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9] dark:focus:border-[#58a6ff]"
             value={state.textSubject}
             onChange={e => updateSubject(e.target.value)}
             placeholder="You are cordially invited to {{EventName}}"
           />
         </div>
-        <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', alignItems: 'center' }}>
-          <span style={{ fontSize: 10, color: '#6e7681', letterSpacing: '0.1em', marginRight: 4 }}>INSERT</span>
+
+        {/* Token insert row */}
+        <div className="flex gap-1 flex-wrap items-center">
+          <span className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mr-1 dark:text-[#6e7681]">Insert</span>
           {TOKENS.map(t => (
-            <button key={t} style={btn()} onClick={() => insertToken(t)}>{`{{${t}}}`}</button>
+            <button key={t} className={TOKEN_BTN} onClick={() => insertToken(t)}>{`{{${t}}}`}</button>
           ))}
         </div>
-        {/* Format bar */}
-        <div style={{ display: 'flex', gap: 4 }}>
-          <button style={btn(editor?.isActive('bold'))} onClick={() => editor?.chain().focus().toggleBold().run()}>B</button>
-          <button style={btn(editor?.isActive('italic'))} onClick={() => editor?.chain().focus().toggleItalic().run()}>I</button>
-          <button style={btn(editor?.isActive('bulletList'))} onClick={() => editor?.chain().focus().toggleBulletList().run()}>• List</button>
-          <button style={btn(editor?.isActive('orderedList'))} onClick={() => editor?.chain().focus().toggleOrderedList().run()}>1. List</button>
+
+        {/* Format bar + mobile pane toggle */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex gap-1">
+            <button className={FMT_BTN(!!editor?.isActive('bold'))} onClick={() => editor?.chain().focus().toggleBold().run()}>B</button>
+            <button className={FMT_BTN(!!editor?.isActive('italic'))} onClick={() => editor?.chain().focus().toggleItalic().run()}>I</button>
+            <button className={FMT_BTN(!!editor?.isActive('bulletList'))} onClick={() => editor?.chain().focus().toggleBulletList().run()}>• List</button>
+            <button className={FMT_BTN(!!editor?.isActive('orderedList'))} onClick={() => editor?.chain().focus().toggleOrderedList().run()}>1. List</button>
+          </div>
+          {/* Pane toggle — mobile only */}
+          <div className="flex gap-1 md:hidden">
+            <button className={PANE_BTN(activePane === 'editor')} onClick={() => setActivePane('editor')}>Editor</button>
+            <button className={PANE_BTN(activePane === 'preview')} onClick={() => setActivePane('preview')}>Preview</button>
+          </div>
         </div>
       </div>
 
-      {/* Editor + Preview split */}
-      <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 1fr', overflow: 'hidden' }}>
-        <div style={{ borderRight: '1px solid #21262d', overflow: 'auto', padding: 16 }}>
-          <div style={{ fontSize: 10, color: '#6e7681', letterSpacing: '0.1em', marginBottom: 8 }}>EDITOR</div>
+      {/* Editor + Preview */}
+      <div className="flex-1 overflow-hidden md:grid md:grid-cols-2">
+        {/* Editor pane */}
+        <div className={`h-full overflow-auto p-4 border-gray-200 dark:border-[#21262d] md:border-r ${activePane === 'editor' ? 'block' : 'hidden'} md:block`}>
+          <div className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-2 dark:text-[#6e7681]">EDITOR</div>
           <EditorContent
             editor={editor}
-            style={{ color: '#c9d1d9', fontSize: 13, lineHeight: 1.8, minHeight: 200 }}
+            className="text-gray-900 text-sm leading-relaxed min-h-[200px] dark:text-[#c9d1d9]"
           />
         </div>
-        <div style={{ overflow: 'auto', padding: 16, background: '#080c10' }}>
-          <div style={{ fontSize: 10, color: '#6e7681', letterSpacing: '0.1em', marginBottom: 8 }}>
+
+        {/* Preview pane */}
+        <div className={`h-full overflow-auto p-4 bg-gray-50 dark:bg-[#080c10] ${activePane === 'preview' ? 'block' : 'hidden'} md:block`}>
+          <div className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-2 dark:text-[#6e7681]">
             PREVIEW {sample ? `(${sample.firstName} ${sample.lastName})` : '(no invitees)'}
           </div>
           <div
-            style={{ background: '#fff', borderRadius: 4, padding: 16, color: '#1a1a1a', fontSize: 13, lineHeight: 1.8 }}
+            className="bg-white rounded p-4 text-[#1a1a1a] text-sm leading-relaxed"
             dangerouslySetInnerHTML={{ __html: preview }}
           />
         </div>

--- a/src/inviteflow/tabs/EventsTab.tsx
+++ b/src/inviteflow/tabs/EventsTab.tsx
@@ -24,31 +24,6 @@ function blankEvent(id: string): AppEvent {
   };
 }
 
-function cardStyle(active: boolean): React.CSSProperties {
-  return {
-    background: '#0d1117',
-    border: `1px solid ${active ? '#C8A84B' : '#21262d'}`,
-    borderRadius: 7,
-    padding: '16px 18px',
-    cursor: 'pointer',
-    transition: 'border-color .15s',
-  };
-}
-
-function btnStyle(variant: 'pri' | 'del' | 'def'): React.CSSProperties {
-  return {
-    border: `1px solid ${variant === 'pri' ? '#1f6feb' : variant === 'del' ? '#da3633' : '#21262d'}`,
-    background: variant === 'pri' ? '#1f6feb' : 'transparent',
-    color: variant === 'pri' ? '#fff' : variant === 'del' ? '#f85149' : '#8b949e',
-    padding: '4px 10px',
-    borderRadius: 4,
-    cursor: 'pointer',
-    fontFamily: 'monospace',
-    fontSize: 10,
-    letterSpacing: '0.05em',
-  };
-}
-
 export default function EventsTab() {
   const state = useAppState();
   const dispatch = useAppDispatch();
@@ -108,44 +83,63 @@ export default function EventsTab() {
   }
 
   return (
-    <div style={{ padding: 24, maxWidth: 860, margin: '0 auto' }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20 }}>
-        <span style={{ fontSize: 13, color: '#f0f6fc', fontWeight: 700, letterSpacing: '0.08em' }}>EVENTS</span>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button style={btnStyle('def')} onClick={loadEvents} disabled={loading}>
+    <div className="p-5 max-w-[860px] mx-auto w-full">
+      <div className="flex items-center justify-between mb-5">
+        <span className="text-sm font-bold tracking-[0.08em] text-gray-900 dark:text-[#f0f6fc]">EVENTS</span>
+        <div className="flex gap-2">
+          <button
+            onClick={loadEvents}
+            disabled={loading}
+            className="min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-gray-700 text-xs font-mono tracking-wide cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22] disabled:opacity-50 disabled:cursor-not-allowed"
+          >
             {loading ? 'Loading…' : 'Refresh'}
           </button>
-          <button style={btnStyle('pri')} onClick={createEvent}>+ New Event</button>
+          <button
+            onClick={createEvent}
+            className="min-h-[44px] px-3 py-1 rounded border border-blue-600 bg-blue-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-700 dark:border-[#1f6feb] dark:bg-[#1f6feb]"
+          >
+            + New Event
+          </button>
         </div>
       </div>
 
-      {err && <div style={{ color: '#f85149', fontSize: 11, marginBottom: 12 }}>{err}</div>}
+      {err && <div className="text-xs text-red-600 mb-3 dark:text-[#f85149]">{err}</div>}
 
       {state.events.length === 0 && !loading && (
-        <div style={{ color: '#6e7681', fontSize: 12, textAlign: 'center', padding: 40 }}>
-          No events yet. Click "+ New Event" to create one.
+        <div className="text-gray-500 text-xs text-center py-10 dark:text-[#6e7681]">
+          No events yet. Click &ldquo;+ New Event&rdquo; to create one.
         </div>
       )}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(260px,1fr))', gap: 12 }}>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
         {state.events.map(ev => (
           <div
             key={ev.id}
-            style={cardStyle(state.activeEventId === ev.id)}
+            className={[
+              'bg-white border rounded-lg p-4 cursor-pointer transition-colors dark:bg-[#0d1117]',
+              state.activeEventId === ev.id
+                ? 'border-[#C8A84B]'
+                : 'border-gray-200 hover:border-gray-400 dark:border-[#21262d] dark:hover:border-[#484f58]',
+            ].join(' ')}
             onClick={() => { dispatch({ type: 'SET_ACTIVE_EVENT', id: ev.id }); dispatch({ type: 'SET_TAB', tab: 'setup' }); }}
           >
-            <div style={{ fontSize: 13, color: '#f0f6fc', fontWeight: 700, marginBottom: 4 }}>{ev.name || 'Unnamed Event'}</div>
-            <div style={{ fontSize: 10, color: '#6e7681', marginBottom: 12 }}>
+            <div className="text-sm font-bold text-gray-900 mb-1 dark:text-[#f0f6fc]">{ev.name || 'Unnamed Event'}</div>
+            <div className="text-[10px] text-gray-500 mb-3 dark:text-[#6e7681]">
               {ev.date || 'No date'} · {ev.venue || 'No venue'}
             </div>
-            <div style={{ display: 'flex', gap: 6 }} onClick={e => e.stopPropagation()}>
+            <div className="flex gap-2" onClick={e => e.stopPropagation()}>
               <button
-                style={btnStyle('pri')}
                 onClick={() => { dispatch({ type: 'SET_ACTIVE_EVENT', id: ev.id }); dispatch({ type: 'SET_TAB', tab: 'setup' }); }}
+                className="min-h-[44px] px-3 py-1 rounded border border-blue-600 bg-blue-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-700 dark:border-[#1f6feb] dark:bg-[#1f6feb]"
               >
                 {state.activeEventId === ev.id ? '✓ Active' : 'Activate'}
               </button>
-              <button style={btnStyle('del')} onClick={() => deleteEvent(ev.id)}>Delete</button>
+              <button
+                onClick={() => deleteEvent(ev.id)}
+                className="min-h-[44px] px-3 py-1 rounded border border-red-500 bg-transparent text-red-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-red-50 dark:border-[#f85149] dark:text-[#f85149] dark:hover:bg-[#2d0f0e]"
+              >
+                Delete
+              </button>
             </div>
           </div>
         ))}

--- a/src/inviteflow/tabs/SendTab.tsx
+++ b/src/inviteflow/tabs/SendTab.tsx
@@ -2,12 +2,18 @@ import { useState } from 'react';
 import { useAppState, useAppDispatch } from '../state/AppContext';
 import { getToken } from '../api/auth';
 import { buildMimeRaw, personalize, sendEmail } from '../api/gmail';
-import type { Invitee } from '../types';
 
 type Filter = 'all' | 'pending' | 'failed';
 
 const BATCH_SIZE = 80;
 const BATCH_DELAY_MS = 61000;
+
+const FILTER_BTN = (active: boolean) =>
+  `min-h-[36px] px-3 py-1 rounded border text-[10px] font-mono tracking-wide cursor-pointer ${
+    active
+      ? 'border-blue-600 bg-blue-600 text-white dark:border-[#1f6feb] dark:bg-[#1f6feb]'
+      : 'border-gray-300 bg-transparent text-gray-600 hover:border-gray-500 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:border-[#484f58]'
+  }`;
 
 export default function SendTab() {
   const state = useAppState();
@@ -46,23 +52,11 @@ export default function SendTab() {
 
       try {
         await sendEmail(token, raw);
-        dispatch({
-          type: 'UPDATE_INVITEE',
-          invitee: { ...inv, inviteStatus: 'sent', sentAt: new Date().toISOString() },
-        });
-        dispatch({
-          type: 'LOG_SEND',
-          entry: { id: crypto.randomUUID(), email: inv.email, name: `${inv.firstName} ${inv.lastName}`, status: 'sent', timestamp: new Date().toISOString() },
-        });
+        dispatch({ type: 'UPDATE_INVITEE', invitee: { ...inv, inviteStatus: 'sent', sentAt: new Date().toISOString() } });
+        dispatch({ type: 'LOG_SEND', entry: { id: crypto.randomUUID(), email: inv.email, name: `${inv.firstName} ${inv.lastName}`, status: 'sent', timestamp: new Date().toISOString() } });
       } catch (e) {
-        dispatch({
-          type: 'UPDATE_INVITEE',
-          invitee: { ...inv, inviteStatus: 'failed' },
-        });
-        dispatch({
-          type: 'LOG_SEND',
-          entry: { id: crypto.randomUUID(), email: inv.email, name: `${inv.firstName} ${inv.lastName}`, status: 'failed', timestamp: new Date().toISOString(), error: String(e) },
-        });
+        dispatch({ type: 'UPDATE_INVITEE', invitee: { ...inv, inviteStatus: 'failed' } });
+        dispatch({ type: 'LOG_SEND', entry: { id: crypto.randomUUID(), email: inv.email, name: `${inv.firstName} ${inv.lastName}`, status: 'failed', timestamp: new Date().toISOString(), error: String(e) } });
       }
 
       sent++;
@@ -80,26 +74,19 @@ export default function SendTab() {
     ? Math.round((state.sendProgress.current / state.sendProgress.total) * 100)
     : 0;
 
-  const btn = (active = false, color = '#8b949e', bg = 'transparent'): React.CSSProperties => ({
-    border: `1px solid ${active ? '#1f6feb' : color}`,
-    background: active ? '#1f6feb' : bg,
-    color: active ? '#fff' : color,
-    padding: '4px 10px', borderRadius: 4, cursor: 'pointer', fontFamily: 'monospace', fontSize: 10, letterSpacing: '0.05em',
-  });
-
   return (
-    <div style={{ padding: 24, maxWidth: 800, margin: '0 auto' }}>
-      <div style={{ fontSize: 13, color: '#f0f6fc', fontWeight: 700, letterSpacing: '0.08em', marginBottom: 16 }}>SEND</div>
+    <div className="p-5 max-w-[800px] mx-auto w-full">
+      <div className="text-sm font-bold tracking-[0.08em] text-gray-900 mb-4 dark:text-[#f0f6fc]">SEND</div>
 
       {/* Filter + Send controls */}
-      <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 16, flexWrap: 'wrap' }}>
-        <span style={{ fontSize: 10, color: '#6e7681' }}>FILTER</span>
+      <div className="flex flex-wrap gap-2 items-center mb-4">
+        <span className="text-[10px] text-gray-500 tracking-widest font-mono uppercase dark:text-[#6e7681]">Filter</span>
         {(['all', 'pending', 'failed'] as Filter[]).map(f => (
-          <button key={f} style={btn(filter === f)} onClick={() => setFilter(f)}>{f.toUpperCase()}</button>
+          <button key={f} className={FILTER_BTN(filter === f)} onClick={() => setFilter(f)}>{f.toUpperCase()}</button>
         ))}
-        <span style={{ fontSize: 10, color: '#6e7681', marginLeft: 8 }}>{filtered.length} invitees</span>
+        <span className="text-[10px] text-gray-500 font-mono ml-2 dark:text-[#6e7681]">{filtered.length} invitees</span>
         <button
-          style={{ ...btn(false, '#fff', '#238636'), border: '1px solid #238636', marginLeft: 'auto' }}
+          className="min-h-[36px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-[10px] font-mono tracking-wide cursor-pointer hover:bg-green-700 ml-auto disabled:opacity-50 disabled:cursor-not-allowed dark:border-[#238636] dark:bg-[#238636]"
           onClick={sendBulk}
           disabled={state.sending}
         >
@@ -107,16 +94,16 @@ export default function SendTab() {
         </button>
       </div>
 
-      {err && <div style={{ fontSize: 11, color: '#f85149', marginBottom: 12 }}>{err}</div>}
+      {err && <div className="text-xs text-red-600 mb-3 dark:text-[#f85149]">{err}</div>}
 
       {/* Progress bar */}
       {state.sending && (
-        <div style={{ marginBottom: 16 }}>
-          <div style={{ fontSize: 10, color: '#6e7681', marginBottom: 6 }}>
+        <div className="mb-4">
+          <div className="text-[10px] text-gray-500 mb-1.5 dark:text-[#6e7681]">
             {state.sendProgress.current} / {state.sendProgress.total} sent ({progress}%)
           </div>
-          <div style={{ height: 4, background: '#161b22', borderRadius: 2, overflow: 'hidden' }}>
-            <div style={{ height: '100%', width: `${progress}%`, background: '#C8A84B', borderRadius: 2, transition: 'width .3s' }} />
+          <div className="h-1 bg-gray-200 rounded overflow-hidden dark:bg-[#161b22]">
+            <div className="h-full bg-[#C8A84B] rounded transition-[width] duration-300" style={{ width: `${progress}%` }} />
           </div>
         </div>
       )}
@@ -124,16 +111,16 @@ export default function SendTab() {
       {/* Send log */}
       {state.sendLog.length > 0 && (
         <div>
-          <div style={{ fontSize: 10, color: '#6e7681', letterSpacing: '0.1em', marginBottom: 8 }}>SEND LOG</div>
-          <div style={{ maxHeight: 400, overflowY: 'auto', border: '1px solid #21262d', borderRadius: 6 }}>
+          <div className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-2 dark:text-[#6e7681]">SEND LOG</div>
+          <div className="max-h-96 overflow-y-auto border border-gray-200 rounded-lg dark:border-[#21262d]">
             {state.sendLog.map(entry => (
-              <div key={entry.id} style={{ display: 'flex', gap: 10, alignItems: 'baseline', padding: '6px 12px', borderBottom: '1px solid #161b22', fontSize: 11 }}>
-                <span style={{ color: entry.status === 'sent' ? '#3fb950' : '#f85149', minWidth: 40, fontSize: 10, letterSpacing: '0.07em' }}>
+              <div key={entry.id} className="flex gap-2.5 items-baseline px-3 py-1.5 border-b border-gray-100 text-xs last:border-0 dark:border-[#161b22]">
+                <span className={`min-w-[40px] text-[10px] tracking-[0.07em] font-mono ${entry.status === 'sent' ? 'text-green-600 dark:text-[#3fb950]' : 'text-red-600 dark:text-[#f85149]'}`}>
                   {entry.status.toUpperCase()}
                 </span>
-                <span style={{ color: '#c9d1d9', minWidth: 160 }}>{entry.name}</span>
-                <span style={{ color: '#6e7681', flex: 1 }}>{entry.email}</span>
-                {entry.error && <span style={{ color: '#f85149', fontSize: 10 }}>{entry.error}</span>}
+                <span className="text-gray-900 min-w-[160px] dark:text-[#c9d1d9]">{entry.name}</span>
+                <span className="text-gray-500 flex-1 dark:text-[#6e7681]">{entry.email}</span>
+                {entry.error && <span className="text-[10px] text-red-600 dark:text-[#f85149]">{entry.error}</span>}
               </div>
             ))}
           </div>
@@ -141,7 +128,7 @@ export default function SendTab() {
       )}
 
       {state.sendLog.length === 0 && !state.sending && (
-        <div style={{ color: '#6e7681', fontSize: 12, textAlign: 'center', padding: 40 }}>
+        <div className="text-gray-500 text-xs text-center py-10 dark:text-[#6e7681]">
           No sends yet. Choose a filter and click Send.
         </div>
       )}

--- a/src/inviteflow/tabs/SetupTab.tsx
+++ b/src/inviteflow/tabs/SetupTab.tsx
@@ -20,6 +20,10 @@ const FIELDS: Array<{ key: keyof AppEvent; label: string; type?: string; placeho
   { key: 'imgEmblemUrl', label: 'Emblem Image URL', placeholder: 'https://drive.google.com/…' },
 ];
 
+const INPUT = "w-full bg-white border border-gray-300 text-gray-900 text-xs font-mono px-2.5 py-1.5 rounded outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9] dark:focus:border-[#58a6ff]";
+const LABEL = "text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-1 block dark:text-[#6e7681]";
+const SECTION = "text-[10px] text-gray-500 tracking-widest font-mono uppercase mt-5 mb-2.5 border-b border-gray-200 pb-1.5 dark:text-[#6e7681] dark:border-[#21262d]";
+
 export default function SetupTab() {
   const state = useAppState();
   const dispatch = useAppDispatch();
@@ -31,11 +35,15 @@ export default function SetupTab() {
 
   if (!ev) {
     return (
-      <div style={{ padding: 40, color: '#6e7681', fontSize: 12, textAlign: 'center' }}>
-        No active event. Go to <button
-          style={{ background: 'none', border: 'none', color: '#58a6ff', cursor: 'pointer', fontFamily: 'monospace', fontSize: 12 }}
+      <div className="p-10 text-gray-500 text-xs text-center dark:text-[#6e7681]">
+        No active event. Go to{' '}
+        <button
+          className="text-blue-600 bg-transparent border-none cursor-pointer font-mono text-xs dark:text-[#58a6ff]"
           onClick={() => dispatch({ type: 'SET_TAB', tab: 'events' })}
-        >Events</button> to create or activate one.
+        >
+          Events
+        </button>{' '}
+        to create or activate one.
       </div>
     );
   }
@@ -70,69 +78,57 @@ export default function SetupTab() {
     }
   }
 
-  const inputStyle: React.CSSProperties = {
-    background: '#0d1117',
-    border: '1px solid #21262d',
-    color: '#c9d1d9',
-    padding: '6px 10px',
-    borderRadius: 5,
-    fontFamily: 'monospace',
-    fontSize: 11,
-    width: '100%',
-    outline: 'none',
-  };
-  const labelStyle: React.CSSProperties = { fontSize: 10, color: '#6e7681', letterSpacing: '0.1em', marginBottom: 4, display: 'block' };
-  const sectionStyle: React.CSSProperties = { fontSize: 10, color: '#6e7681', letterSpacing: '0.12em', marginTop: 20, marginBottom: 10, borderBottom: '1px solid #21262d', paddingBottom: 6 };
-  const btnStyle = (color: string): React.CSSProperties => ({
-    border: `1px solid ${color}`,
-    background: 'transparent',
-    color,
-    padding: '5px 12px',
-    borderRadius: 4,
-    cursor: 'pointer',
-    fontFamily: 'monospace',
-    fontSize: 10,
-    letterSpacing: '0.05em',
-  });
-
   return (
-    <div style={{ padding: 24, maxWidth: 640, margin: '0 auto' }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
-        <span style={{ fontSize: 13, color: '#f0f6fc', fontWeight: 700, letterSpacing: '0.08em' }}>SETUP</span>
+    <div className="p-5 max-w-[640px] mx-auto w-full">
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-sm font-bold tracking-[0.08em] text-gray-900 dark:text-[#f0f6fc]">SETUP</span>
         <button
-          style={{ ...btnStyle('#3fb950'), background: '#238636', color: '#fff', border: '1px solid #238636' }}
           onClick={save}
           disabled={saving}
+          className="min-h-[44px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-green-700 dark:border-[#238636] dark:bg-[#238636] disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {saving ? 'Saving…' : 'Save'}
         </button>
       </div>
 
-      {status && <div style={{ fontSize: 11, color: status.startsWith('Error') ? '#f85149' : '#3fb950', marginBottom: 12 }}>{status}</div>}
+      {status && (
+        <div className={`text-xs mb-3 ${status.startsWith('Error') ? 'text-red-600 dark:text-[#f85149]' : 'text-green-600 dark:text-[#3fb950]'}`}>
+          {status}
+        </div>
+      )}
 
-      <div style={sectionStyle}>GOOGLE OAUTH</div>
-      <div style={{ marginBottom: 12 }}>
-        <label style={labelStyle}>Google Client ID</label>
+      <div className={SECTION}>GOOGLE OAUTH</div>
+      <div className="mb-3">
+        <label className={LABEL}>Google Client ID</label>
         <input
-          style={inputStyle}
+          className={INPUT}
           value={clientIdDraft}
           onChange={e => setClientIdDraft(e.target.value)}
           placeholder="123456789-abc.apps.googleusercontent.com"
         />
       </div>
-      <div style={{ display: 'flex', gap: 8, marginBottom: 20, flexWrap: 'wrap' }}>
-        <button style={btnStyle('#58a6ff')} onClick={() => authorize('spreadsheets')}>Authorize Sheets</button>
-        <button style={btnStyle('#58a6ff')} onClick={() => authorize('gmail.send')}>Authorize Gmail</button>
-        <button style={btnStyle('#58a6ff')} onClick={() => authorize('drive.appdata')}>Authorize Drive</button>
+      <div className="flex flex-wrap gap-2 mb-5">
+        <button
+          className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c]"
+          onClick={() => authorize('spreadsheets')}
+        >Authorize Sheets</button>
+        <button
+          className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c]"
+          onClick={() => authorize('gmail.send')}
+        >Authorize Gmail</button>
+        <button
+          className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c]"
+          onClick={() => authorize('drive.appdata')}
+        >Authorize Drive</button>
       </div>
 
-      <div style={sectionStyle}>EVENT DETAILS</div>
-      <div style={{ display: 'grid', gap: 12 }}>
+      <div className={SECTION}>EVENT DETAILS</div>
+      <div className="grid gap-3">
         {FIELDS.map(f => (
           <div key={f.key}>
-            <label style={labelStyle}>{f.label.toUpperCase()}</label>
+            <label className={LABEL}>{f.label}</label>
             <input
-              style={inputStyle}
+              className={INPUT}
               type={f.type ?? 'text'}
               value={String(ev[f.key] ?? '')}
               onChange={e => update(f.key, e.target.value)}

--- a/src/inviteflow/tabs/SyncTab.tsx
+++ b/src/inviteflow/tabs/SyncTab.tsx
@@ -45,6 +45,8 @@ function onFormSubmit(e) {
   }
 }`;
 
+const SECTION = "text-[10px] text-gray-500 tracking-widest font-mono uppercase mt-5 mb-2.5 border-b border-gray-200 pb-1.5 dark:text-[#6e7681] dark:border-[#21262d]";
+
 export default function SyncTab() {
   const state = useAppState();
   const dispatch = useAppDispatch();
@@ -62,13 +64,12 @@ export default function SyncTab() {
       const token = await getToken('spreadsheets');
       const id = extractSheetId(ev.masterSheetUrl);
       await sheetsClear(token, id, 'Sheet1!A:K');
-      const header = MASTER_COLUMNS;
       const rows = state.invitees.map(i => [
         i.firstName, i.lastName, i.title, i.category, i.email, i.rsvpLink,
         i.inviteStatus === 'sent' ? 'TRUE' : 'FALSE',
         i.sentAt, i.rsvpStatus, i.rsvpDate, i.notes,
       ]);
-      await sheetsUpdate(token, id, 'Sheet1!A1', [header, ...rows]);
+      await sheetsUpdate(token, id, 'Sheet1!A1', [MASTER_COLUMNS, ...rows]);
       setStatus(`Pushed ${rows.length} rows to master sheet.`);
     } catch (e) {
       setStatus('Error: ' + String(e));
@@ -115,62 +116,72 @@ export default function SyncTab() {
     }
   }
 
-  const btn = (color = '#8b949e', bg = 'transparent', disabled = false): React.CSSProperties => ({
-    border: `1px solid ${color}`, background: bg, color, padding: '6px 14px',
-    borderRadius: 4, cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
-    fontFamily: 'monospace', fontSize: 11, letterSpacing: '0.05em',
-  });
-
-  const sectionLabel: React.CSSProperties = { fontSize: 10, color: '#6e7681', letterSpacing: '0.12em', marginBottom: 10, marginTop: 20 };
-
   return (
-    <div style={{ padding: 24, maxWidth: 760, margin: '0 auto' }}>
-      <div style={{ fontSize: 13, color: '#f0f6fc', fontWeight: 700, letterSpacing: '0.08em', marginBottom: 16 }}>SYNC</div>
+    <div className="p-5 max-w-[760px] mx-auto w-full">
+      <div className="text-sm font-bold tracking-[0.08em] text-gray-900 mb-4 dark:text-[#f0f6fc]">SYNC</div>
 
       {status && (
-        <div style={{ fontSize: 11, color: status.startsWith('Error') ? '#f85149' : '#3fb950', marginBottom: 14 }}>{status}</div>
+        <div className={`text-xs mb-4 ${status.startsWith('Error') ? 'text-red-600 dark:text-[#f85149]' : 'text-green-600 dark:text-[#3fb950]'}`}>
+          {status}
+        </div>
       )}
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 28 }}>
-        <div style={{ background: '#0d1117', border: '1px solid #21262d', borderRadius: 7, padding: '18px 20px' }}>
-          <div style={sectionLabel}>PUSH TO MASTER SHEET</div>
-          <div style={{ fontSize: 11, color: '#6e7681', marginBottom: 14, lineHeight: 1.7 }}>
+      {/* Action cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-7">
+        {/* Push card */}
+        <div className="bg-white border border-gray-200 rounded-lg p-5 dark:bg-[#0d1117] dark:border-[#21262d]">
+          <div className={SECTION}>PUSH TO MASTER SHEET</div>
+          <p className="text-xs text-gray-500 mb-4 leading-relaxed dark:text-[#6e7681]">
             Clears and rewrites all {state.invitees.length} invitees to your master Google Sheet.
-            {ev?.masterSheetUrl
-              ? <><br /><a href={ev.masterSheetUrl} target="_blank" rel="noreferrer" style={{ color: '#58a6ff', fontSize: 10 }}>Open sheet ↗</a></>
-              : <><br /><span style={{ color: '#f85149', fontSize: 10 }}>Master Sheet URL not set in Setup.</span></>
-            }
-          </div>
-          <button style={btn('#3fb950', '#238636', pushing)} onClick={pushToSheets} disabled={pushing}>
+          </p>
+          {ev?.masterSheetUrl
+            ? <a href={ev.masterSheetUrl} target="_blank" rel="noreferrer" className="text-[10px] text-blue-600 dark:text-[#58a6ff] mb-3 block">Open sheet ↗</a>
+            : <span className="text-[10px] text-red-600 dark:text-[#f85149] mb-3 block">Master Sheet URL not set in Setup.</span>
+          }
+          <button
+            className="min-h-[44px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed dark:border-[#238636] dark:bg-[#238636]"
+            onClick={pushToSheets}
+            disabled={pushing}
+          >
             {pushing ? 'Pushing…' : `Push ${state.invitees.length} rows`}
           </button>
         </div>
 
-        <div style={{ background: '#0d1117', border: '1px solid #21262d', borderRadius: 7, padding: '18px 20px' }}>
-          <div style={sectionLabel}>PULL RSVP RESPONSES</div>
-          <div style={{ fontSize: 11, color: '#6e7681', marginBottom: 14, lineHeight: 1.7 }}>
+        {/* Pull card */}
+        <div className="bg-white border border-gray-200 rounded-lg p-5 dark:bg-[#0d1117] dark:border-[#21262d]">
+          <div className={SECTION}>PULL RSVP RESPONSES</div>
+          <p className="text-xs text-gray-500 mb-4 leading-relaxed dark:text-[#6e7681]">
             Reads RSVP statuses from your response sheet and updates invitee records.
-            {ev?.rsvpResponseUrl
-              ? <><br /><a href={ev.rsvpResponseUrl} target="_blank" rel="noreferrer" style={{ color: '#58a6ff', fontSize: 10 }}>Open sheet ↗</a></>
-              : <><br /><span style={{ color: '#f85149', fontSize: 10 }}>RSVP Response Sheet URL not set in Setup.</span></>
-            }
-          </div>
-          <button style={btn('#58a6ff', 'transparent', pulling)} onClick={pullRsvp} disabled={pulling}>
+          </p>
+          {ev?.rsvpResponseUrl
+            ? <a href={ev.rsvpResponseUrl} target="_blank" rel="noreferrer" className="text-[10px] text-blue-600 dark:text-[#58a6ff] mb-3 block">Open sheet ↗</a>
+            : <span className="text-[10px] text-red-600 dark:text-[#f85149] mb-3 block">RSVP Response Sheet URL not set in Setup.</span>
+          }
+          <button
+            className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 disabled:opacity-50 disabled:cursor-not-allowed dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c]"
+            onClick={pullRsvp}
+            disabled={pulling}
+          >
             {pulling ? 'Pulling…' : 'Pull RSVP Responses'}
           </button>
         </div>
       </div>
 
-      <div style={sectionLabel}>GAS RSVP INGEST TRIGGER</div>
-      <div style={{ fontSize: 11, color: '#6e7681', lineHeight: 1.8, marginBottom: 12 }}>
-        Paste this script into your Google Form's Apps Script project. Add a trigger on <code style={{ background: '#161b22', padding: '1px 4px', borderRadius: 3 }}>onFormSubmit</code> (Form Submit event). Set script property <code style={{ background: '#161b22', padding: '1px 4px', borderRadius: 3 }}>MASTER_SHEET_URL</code> to your master sheet URL.
-      </div>
-      <div style={{ position: 'relative' }}>
-        <pre style={{ background: '#0d1117', border: '1px solid #21262d', borderRadius: 6, padding: '14px 16px', fontSize: 10, color: '#c9d1d9', overflowX: 'auto', lineHeight: 1.7 }}>
+      {/* GAS section */}
+      <div className={SECTION}>GAS RSVP INGEST TRIGGER</div>
+      <p className="text-xs text-gray-500 leading-relaxed mb-3 dark:text-[#6e7681]">
+        Paste this script into your Google Form's Apps Script project. Add a trigger on{' '}
+        <code className="bg-gray-100 px-1 rounded text-[10px] dark:bg-[#161b22]">onFormSubmit</code>{' '}
+        (Form Submit event). Set script property{' '}
+        <code className="bg-gray-100 px-1 rounded text-[10px] dark:bg-[#161b22]">MASTER_SHEET_URL</code>{' '}
+        to your master sheet URL.
+      </p>
+      <div className="relative">
+        <pre className="bg-gray-50 border border-gray-200 rounded-lg p-4 text-[10px] text-gray-800 overflow-x-auto leading-relaxed dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9]">
           {GAS_CODE}
         </pre>
         <button
-          style={{ position: 'absolute', top: 8, right: 8, ...btn('#6e7681') }}
+          className="absolute top-2 right-2 min-h-[32px] px-2.5 py-1 rounded border border-gray-300 bg-white text-gray-600 text-[10px] font-mono cursor-pointer hover:border-gray-500 dark:bg-[#161b22] dark:border-[#21262d] dark:text-[#8b949e]"
           onClick={() => { navigator.clipboard.writeText(GAS_CODE); setStatus('Copied GAS code to clipboard.'); }}
         >
           Copy

--- a/src/inviteflow/tabs/TrackerTab.tsx
+++ b/src/inviteflow/tabs/TrackerTab.tsx
@@ -1,5 +1,4 @@
 import { useAppState } from '../state/AppContext';
-import type { Invitee } from '../types';
 
 interface CategoryRow {
   category: string;
@@ -9,6 +8,25 @@ interface CategoryRow {
   declined: number;
   noResponse: number;
 }
+
+const STAT_COLORS: Record<string, string> = {
+  TOTAL: 'border-l-gray-400 dark:border-l-[#8b949e]',
+  PENDING: 'border-l-gray-400 dark:border-l-[#6e7681]',
+  SENT: 'border-l-green-500 dark:border-l-[#3fb950]',
+  FAILED: 'border-l-red-500 dark:border-l-[#f85149]',
+  ATTENDING: 'border-l-[#C8A84B]',
+  DECLINED: 'border-l-red-500 dark:border-l-[#f85149]',
+  'NO RESPONSE': 'border-l-gray-400 dark:border-l-[#6e7681]',
+};
+const STAT_VALUE_COLORS: Record<string, string> = {
+  TOTAL: 'text-gray-500 dark:text-[#8b949e]',
+  PENDING: 'text-gray-500 dark:text-[#6e7681]',
+  SENT: 'text-green-600 dark:text-[#3fb950]',
+  FAILED: 'text-red-600 dark:text-[#f85149]',
+  ATTENDING: 'text-[#C8A84B]',
+  DECLINED: 'text-red-600 dark:text-[#f85149]',
+  'NO RESPONSE': 'text-gray-400 dark:text-[#6e7681]',
+};
 
 export default function TrackerTab() {
   const state = useAppState();
@@ -21,6 +39,11 @@ export default function TrackerTab() {
   const attending = inv.filter(i => i.rsvpStatus === 'Attending').length;
   const declined = inv.filter(i => i.rsvpStatus === 'Declined').length;
   const noResponse = inv.filter(i => i.rsvpStatus === 'No Response').length;
+
+  const stats: [string, number][] = [
+    ['TOTAL', total], ['PENDING', pending], ['SENT', sent],
+    ['FAILED', failed], ['ATTENDING', attending], ['DECLINED', declined], ['NO RESPONSE', noResponse],
+  ];
 
   const cats = Array.from(new Set(inv.map(i => i.category).filter(Boolean))).sort();
   const byCategory: CategoryRow[] = cats.map(cat => {
@@ -35,63 +58,61 @@ export default function TrackerTab() {
     };
   });
 
-  const card = (label: string, value: number, color: string) => (
-    <div key={label} style={{ background: '#0d1117', border: `1px solid #21262d`, borderRadius: 7, padding: '16px 20px', borderLeft: `3px solid ${color}` }}>
-      <div style={{ fontSize: 9, color: '#6e7681', letterSpacing: '0.12em', marginBottom: 6 }}>{label}</div>
-      <div style={{ fontSize: 28, color, fontWeight: 700 }}>{value}</div>
-    </div>
-  );
-
-  const th: React.CSSProperties = { fontSize: 10, color: '#6e7681', letterSpacing: '0.1em', padding: '6px 12px', textAlign: 'left', borderBottom: '1px solid #21262d' };
-  const td: React.CSSProperties = { fontSize: 11, color: '#c9d1d9', padding: '7px 12px', borderBottom: '1px solid #161b22' };
-
   if (total === 0) {
     return (
-      <div style={{ padding: 40, textAlign: 'center', color: '#6e7681', fontSize: 12 }}>
+      <div className="p-10 text-gray-500 text-xs text-center dark:text-[#6e7681]">
         No invitees yet. Add them in the Invitees tab.
       </div>
     );
   }
 
   return (
-    <div style={{ padding: 24, maxWidth: 900, margin: '0 auto' }}>
-      <div style={{ fontSize: 13, color: '#f0f6fc', fontWeight: 700, letterSpacing: '0.08em', marginBottom: 20 }}>TRACKER</div>
+    <div className="p-5 max-w-[900px] mx-auto w-full">
+      <div className="text-sm font-bold tracking-[0.08em] text-gray-900 mb-5 dark:text-[#f0f6fc]">TRACKER</div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(130px,1fr))', gap: 10, marginBottom: 28 }}>
-        {card('TOTAL', total, '#8b949e')}
-        {card('PENDING', pending, '#6e7681')}
-        {card('SENT', sent, '#3fb950')}
-        {card('FAILED', failed, '#f85149')}
-        {card('ATTENDING', attending, '#C8A84B')}
-        {card('DECLINED', declined, '#f85149')}
-        {card('NO RESPONSE', noResponse, '#6e7681')}
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-2.5 mb-7">
+        {stats.map(([label, value]) => (
+          <div
+            key={label}
+            className={`bg-white border border-gray-200 border-l-4 rounded-lg px-4 py-3 dark:bg-[#0d1117] dark:border-[#21262d] ${STAT_COLORS[label]}`}
+          >
+            <div className="text-[9px] text-gray-500 tracking-[0.12em] font-mono mb-1.5 dark:text-[#6e7681]">{label}</div>
+            <div className={`text-2xl font-bold ${STAT_VALUE_COLORS[label]}`}>{value}</div>
+          </div>
+        ))}
       </div>
 
+      {/* By category table */}
       {byCategory.length > 0 && (
         <>
-          <div style={{ fontSize: 10, color: '#6e7681', letterSpacing: '0.12em', marginBottom: 10 }}>BY CATEGORY</div>
-          <div style={{ border: '1px solid #21262d', borderRadius: 7, overflow: 'hidden' }}>
-            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-              <thead>
-                <tr>
-                  {['Category', 'Total', 'Sent', 'Attending', 'Declined', 'No Response'].map(h => (
-                    <th key={h} style={th}>{h.toUpperCase()}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {byCategory.map(row => (
-                  <tr key={row.category}>
-                    <td style={td}>{row.category}</td>
-                    <td style={td}>{row.total}</td>
-                    <td style={{ ...td, color: '#3fb950' }}>{row.sent}</td>
-                    <td style={{ ...td, color: '#C8A84B' }}>{row.attending}</td>
-                    <td style={{ ...td, color: '#f85149' }}>{row.declined}</td>
-                    <td style={{ ...td, color: '#6e7681' }}>{row.noResponse}</td>
+          <div className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-2.5 dark:text-[#6e7681]">BY CATEGORY</div>
+          <div className="border border-gray-200 rounded-lg overflow-hidden dark:border-[#21262d]">
+            <div className="overflow-x-auto" role="region" aria-label="Category breakdown" tabIndex={0}>
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr>
+                    {['Category', 'Total', 'Sent', 'Attending', 'Declined', 'No Response'].map(h => (
+                      <th key={h} className="text-[10px] text-gray-500 tracking-widest font-mono uppercase text-left px-3 py-2 border-b border-gray-200 dark:text-[#6e7681] dark:border-[#21262d]">
+                        {h}
+                      </th>
+                    ))}
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {byCategory.map(row => (
+                    <tr key={row.category} className="border-b border-gray-100 last:border-0 dark:border-[#161b22]">
+                      <td className="text-xs text-gray-900 px-3 py-1.5 dark:text-[#c9d1d9]">{row.category}</td>
+                      <td className="text-xs text-gray-700 px-3 py-1.5 dark:text-[#c9d1d9]">{row.total}</td>
+                      <td className="text-xs text-green-600 px-3 py-1.5 dark:text-[#3fb950]">{row.sent}</td>
+                      <td className="text-xs text-[#C8A84B] px-3 py-1.5">{row.attending}</td>
+                      <td className="text-xs text-red-600 px-3 py-1.5 dark:text-[#f85149]">{row.declined}</td>
+                      <td className="text-xs text-gray-500 px-3 py-1.5 dark:text-[#6e7681]">{row.noResponse}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         </>
       )}

--- a/src/inviteflow/types.ts
+++ b/src/inviteflow/types.ts
@@ -53,4 +53,5 @@ export interface AppState {
   sending: boolean;
   sendProgress: { current: number; total: number };
   unsaved: boolean;
+  darkMode: boolean;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [tailwindcss(), react()],
   base: process.env.VITE_BASE_URL ?? './',
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- Migrated all tabs and components from inline styles to Tailwind CSS v4 (`@tailwindcss/vite`)
- Added light/dark theme toggle with `darkMode` state, persisted to `localStorage`, synced to `<html>` class
- Replaced desktop-only layout with mobile-first responsive design: hamburger/drawer nav on mobile, `md:` breakpoints for desktop grid layouts
- ComposeTab: editor/preview toggle on mobile (`activePane` state), `md:grid-cols-2` split on desktop
- TrackerTab: responsive stat card grid (`grid-cols-2 sm:grid-cols-4 lg:grid-cols-7`)
- All interactive elements have `min-h-[44px]` touch targets; `text-xs` font floor throughout
- Version bumped to `3.1.0`, git tag `v3.1.0`

## Test Plan
- [ ] Light mode renders correctly on desktop and mobile viewport
- [ ] Dark mode toggle persists across page reloads
- [ ] Hamburger menu opens/closes drawer on narrow viewport; backdrop dismisses it
- [ ] ComposeTab editor/preview toggle works on mobile; desktop shows both panes side-by-side
- [ ] All tab content scrolls independently without clipping on small screens
- [ ] DataTable in InviteesTab scrolls horizontally on mobile
- [ ] TrackerTab stat cards wrap correctly at each breakpoint
- [ ] SyncTab push/pull cards stack on mobile, sit side-by-side on sm+