### PR TITLE
fix(theme): CSS vars dark mode — reliable across PrimeReact/PrimeFlex layer conflicts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 
-@variant dark (&:where(.dark, .dark *));
+@custom-variant dark (&:where(.dark, .dark *));
 
 * {
   box-sizing: border-box;

--- a/src/inviteflow/App.tsx
+++ b/src/inviteflow/App.tsx
@@ -45,19 +45,19 @@ function AppInner() {
   }
 
   return (
-    <div className="h-screen bg-gray-50 text-gray-900 font-mono flex flex-col overflow-hidden dark:bg-[#080c10] dark:text-[#c9d1d9]">
+    <div className="h-screen font-mono flex flex-col overflow-hidden" style={{ background: 'var(--bg-root)', color: 'var(--text-base)' }}>
       {/* Header */}
-      <header className="border-b border-gray-200 px-4 py-2 flex items-center gap-3 shrink-0 bg-white dark:bg-[#0d1117] dark:border-[#21262d]">
+      <header className="px-4 py-2 flex items-center gap-3 shrink-0" style={{ background: 'var(--bg-surface)', borderBottom: '1px solid var(--border)' }}>
         {/* Left zone */}
-        <span className="font-black text-sm text-gray-900 tracking-tight dark:text-[#f0f6fc]">INVITEFLOW</span>
-        <span className="text-[9px] text-gray-400 tracking-[0.12em] dark:text-[#6e7681]">v3.1</span>
+        <span className="font-black text-sm tracking-tight" style={{ color: 'var(--text-heading)' }}>INVITEFLOW</span>
+        <span className="text-[9px] tracking-[0.12em]" style={{ color: 'var(--text-muted)' }}>v3.1</span>
         {activeEvent && (
-          <span className="text-[10px] text-[#C8A84B] tracking-[0.08em] border-l border-gray-200 pl-3 truncate max-w-[160px] dark:border-[#21262d]">
+          <span className="text-[10px] text-[#C8A84B] tracking-[0.08em] pl-3 truncate max-w-[160px]" style={{ borderLeft: '1px solid var(--border)' }}>
             {activeEvent.name}
           </span>
         )}
         {state.unsaved && (
-          <span className="text-[9px] text-gray-400 tracking-[0.1em] dark:text-[#6e7681]">●</span>
+          <span className="text-[9px] tracking-[0.1em]" style={{ color: 'var(--text-muted)' }}>●</span>
         )}
 
         {/* Right zone */}
@@ -66,7 +66,8 @@ function AppInner() {
           <button
             onClick={() => dispatch({ type: 'TOGGLE_DARK' })}
             aria-label={state.darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-sm text-gray-500 hover:text-gray-900 dark:text-[#6e7681] dark:hover:text-[#c9d1d9] rounded"
+            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-sm rounded"
+            style={{ color: 'var(--text-muted)' }}
           >
             {state.darkMode ? '☀' : '☾'}
           </button>
@@ -79,12 +80,10 @@ function AppInner() {
                 role="tab"
                 aria-selected={state.tab === t.id}
                 onClick={() => selectTab(t.id)}
-                className={[
-                  'min-h-[44px] px-2.5 py-1 rounded border text-[10px] font-mono tracking-[0.07em] uppercase cursor-pointer',
-                  state.tab === t.id
-                    ? 'bg-blue-600 border-blue-600 text-white dark:bg-[#1f6feb] dark:border-[#1f6feb]'
-                    : 'bg-transparent border-transparent text-gray-500 hover:text-gray-900 dark:text-[#8b949e] dark:hover:text-[#c9d1d9]',
-                ].join(' ')}
+                className="min-h-[44px] px-2.5 py-1 rounded border text-[10px] font-mono tracking-[0.07em] uppercase cursor-pointer"
+                style={state.tab === t.id
+                  ? { background: 'var(--accent)', borderColor: 'var(--accent)', color: '#fff' }
+                  : { background: 'transparent', borderColor: 'transparent', color: 'var(--text-secondary)' }}
               >
                 {t.label}
               </button>
@@ -93,7 +92,8 @@ function AppInner() {
 
           {/* Hamburger (mobile only) */}
           <button
-            className="md:hidden min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-600 dark:text-[#8b949e]"
+            className="md:hidden min-h-[44px] min-w-[44px] flex items-center justify-center"
+            style={{ color: 'var(--text-secondary)' }}
             onClick={() => setDrawerOpen(true)}
             aria-label="Open navigation"
           >
@@ -115,14 +115,16 @@ function AppInner() {
             role="dialog"
             aria-modal="true"
             aria-label="Navigation"
-            className="fixed inset-y-0 left-0 w-64 bg-white border-r border-gray-200 z-50 flex flex-col md:hidden motion-safe:transition-transform dark:bg-[#0d1117] dark:border-[#21262d]"
+            className="fixed inset-y-0 left-0 w-64 z-50 flex flex-col md:hidden motion-safe:transition-transform"
+            style={{ background: 'var(--bg-surface)', borderRight: '1px solid var(--border)' }}
           >
-            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-[#21262d]">
-              <span className="font-black text-sm text-gray-900 tracking-tight dark:text-[#f0f6fc]">INVITEFLOW</span>
+            <div className="flex items-center justify-between px-4 py-3" style={{ borderBottom: '1px solid var(--border)' }}>
+              <span className="font-black text-sm tracking-tight" style={{ color: 'var(--text-heading)' }}>INVITEFLOW</span>
               <button
                 onClick={() => setDrawerOpen(false)}
                 aria-label="Close navigation"
-                className="min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-500 dark:text-[#6e7681]"
+                className="min-h-[44px] min-w-[44px] flex items-center justify-center"
+                style={{ color: 'var(--text-muted)' }}
               >
                 ✕
               </button>
@@ -134,12 +136,10 @@ function AppInner() {
                   role="tab"
                   aria-selected={state.tab === t.id}
                   onClick={() => selectTab(t.id)}
-                  className={[
-                    'min-h-[44px] flex items-center px-5 text-xs font-mono tracking-[0.07em] uppercase cursor-pointer border-l-2',
-                    state.tab === t.id
-                      ? 'border-blue-600 bg-blue-50 text-blue-700 dark:border-[#1f6feb] dark:bg-[#0d1f3c] dark:text-[#58a6ff]'
-                      : 'border-transparent text-gray-600 hover:bg-gray-50 dark:text-[#8b949e] dark:hover:bg-[#161b22]',
-                  ].join(' ')}
+                  className="min-h-[44px] flex items-center px-5 text-xs font-mono tracking-[0.07em] uppercase cursor-pointer border-l-2"
+                  style={state.tab === t.id
+                    ? { borderColor: 'var(--accent)', background: 'var(--bg-subtle)', color: 'var(--accent)' }
+                    : { borderColor: 'transparent', color: 'var(--text-secondary)', background: 'transparent' }}
                 >
                   {t.label}
                 </button>


### PR DESCRIPTION
## Summary
- Replace Tailwind `dark:` classes on App shell with CSS var inline styles — immune to `@layer` cascade conflicts with unlayered PrimeReact/PrimeFlex CSS
- Switch `@variant dark` → `@custom-variant dark` (documented Tailwind v4 API)
- Root cause: Tailwind utilities live in `@layer utilities`; unlayered third-party CSS always wins regardless of specificity

## Test plan
- [ ] Toggle dark mode — full shell (header, nav, root bg) switches correctly
- [ ] TipTap editor dark styling still applies
- [ ] Light mode defaults look unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)