### PR TITLE
feat: remove ContactScout from InviteFlow

### DIFF
--- a/src/inviteflow/tabs/InviteesTab.tsx
+++ b/src/inviteflow/tabs/InviteesTab.tsx
@@ -5,7 +5,6 @@ import { useAppState, useAppDispatch } from '../state/AppContext';
 import { getToken } from '../api/auth';
 import { sheetsGet, extractSheetId } from '../api/sheets';
 import type { Invitee } from '../types';
-import ContactScoutPanel from '../components/ContactScoutPanel';
 
 function makeInvitee(partial: Partial<Invitee> = {}): Invitee {
   return {
@@ -270,9 +269,6 @@ export default function InviteesTab() {
           <Column rowEditor style={{ width: 70 }} />
         </DataTable>
       </div>
-
-      {/* ContactScout */}
-      <ContactScoutPanel />
 
       {/* Add manually modal */}
       {showAdd && (


### PR DESCRIPTION
## Summary
- Removes `ContactScoutPanel` import and JSX usage from `InviteesTab.tsx` (4 lines deleted)
- ContactScout now lives as a standalone app at [lychan110/contact-scout](https://github.com/lychan110/contact-scout)
- Workflow: run ContactScout → Export for InviteFlow → Import JSON in InviteesTab

## Test plan
- [ ] Build passes (`npm run build` — verified clean ✓)
- [ ] InviteesTab renders without ContactScout panel
- [ ] Import JSON button still works for ingesting ContactScout export

🤖 Generated with [Claude Code](https://claude.com/claude-code)