### PR TITLE
refactor(theme): replace !important hacks with CSS var cascade

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,4 +8,10 @@
 
 body {
   margin: 0;
+  background: var(--bg-root);
+  color: var(--text-base);
 }
+
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: var(--bg-subtle); }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }

--- a/src/inviteflow/index.html
+++ b/src/inviteflow/index.html
@@ -5,23 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>InviteFlow v3.1</title>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
-  <style>
-    html, body { margin: 0; padding: 0; background: #080c10; color: #c9d1d9; }
-    /* TipTap editor — prevent PrimeReact contenteditable overrides from injecting white */
-    .ProseMirror { background: transparent !important; outline: none; }
-    /* PrimeReact DataTable — ensure filter inputs stay dark */
-    .p-inputtext { background: #0d1117!important; color: #c9d1d9!important; border-color: #21262d!important; }
-    .p-datatable .p-datatable-thead > tr > th { background: #0d1117!important; color: #6e7681!important; border-color: #21262d!important; }
-    .p-datatable .p-datatable-tbody > tr { background: #080c10!important; color: #c9d1d9!important; }
-    .p-datatable .p-datatable-tbody > tr:nth-child(even) { background: #0d1117!important; }
-    .p-datatable .p-datatable-tbody > tr > td { border-color: #161b22!important; }
-    .p-datatable .p-row-editor-init, .p-datatable .p-row-editor-save, .p-datatable .p-row-editor-cancel { color: #6e7681!important; }
-    .p-paginator { background: #0d1117!important; border-color: #21262d!important; color: #6e7681!important; }
-    /* Scrollbar gutter */
-    ::-webkit-scrollbar { width: 6px; height: 6px; }
-    ::-webkit-scrollbar-track { background: #0d1117; }
-    ::-webkit-scrollbar-thumb { background: #21262d; border-radius: 3px; }
-  </style>
 </head>
 <body>
   <div id="root"></div>

--- a/src/inviteflow/styles/primereact-reset.css
+++ b/src/inviteflow/styles/primereact-reset.css
@@ -52,3 +52,17 @@
 .p-datatable .p-datatable-thead > tr > th {
   padding: 6px 10px;
 }
+
+/* Row editor icon colors inherit text-color-secondary */
+.p-datatable .p-row-editor-init,
+.p-datatable .p-row-editor-save,
+.p-datatable .p-row-editor-cancel {
+  color: var(--text-color-secondary);
+}
+
+/* Paginator follows surface vars — explicit for safety */
+.p-paginator {
+  background: var(--surface-card);
+  border-color: var(--surface-border);
+  color: var(--text-color-secondary);
+}

--- a/src/inviteflow/styles/tiptap.css
+++ b/src/inviteflow/styles/tiptap.css
@@ -1,14 +1,11 @@
 /* TipTap editor content styles */
 .tiptap {
   outline: none;
+  background: transparent;
   min-height: 200px;
   font-size: 13px;
   line-height: 1.8;
-  color: #111827;
-}
-
-.dark .tiptap {
-  color: #c9d1d9;
+  color: var(--text-base);
 }
 
 .tiptap p {


### PR DESCRIPTION
## Why we kept fighting PrimeReact

The previous theme fix added a `<style>` block in `index.html` with hardcoded dark hex values and `!important` everywhere. That block always wins the specificity war — it silently disabled light mode and made PrimeReact's own CSS-var system irrelevant.

## Correct approach: lara-light-indigo + .dark CSS var overrides

PrimeReact v10 is 100% CSS-custom-property driven. `lara-light-indigo` defines all surface/color/border tokens as `--surface-*` / `--text-color` vars at `:root`. Overriding those vars under `.dark` cascades through every component automatically — no selector specificity, no `!important`.

AppContext already applies `.dark` to `<html>` on toggle. Tailwind v4's `@custom-variant dark` is scoped to `.dark` too. Everything was already wired — just the wrong CSS layer was fighting it.

## Changes

| File | Change |
|---|---|
| `src/inviteflow/index.html` | Strip entire `<style>` block |
| `src/index.css` | `body` bg/color via `var(--bg-root)` / `var(--text-base)`; scrollbar uses `var(--bg-subtle)` / `var(--border)` |
| `styles/primereact-reset.css` | Add row-editor icons + paginator via CSS vars |
| `styles/tiptap.css` | `background: transparent`; color uses `var(--text-base)`; drop redundant `.dark` hardcode |

## Test plan

- [ ] Light mode: body is light gray, DataTable headers/rows white, inputs white
- [ ] Dark mode toggle: everything flips dark — no light backgrounds anywhere
- [ ] TipTap editor: transparent bg, no white flash
- [ ] Scrollbars: dark in dark mode, subtle in light mode
- [ ] `tsc && vite build` passes clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)