### PR TITLE
Fix PrimeReact dark mode CSS overrides

### DIFF
--- a/src/inviteflow/index.html
+++ b/src/inviteflow/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>InviteFlow v3.1</title>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <script>if (localStorage.getItem('inviteflow_theme') === 'dark') document.documentElement.classList.add('dark');</script>
 </head>
 <body>
   <div id="root"></div>

--- a/src/inviteflow/styles/primereact-reset.css
+++ b/src/inviteflow/styles/primereact-reset.css
@@ -1,5 +1,11 @@
+:root {
+  color-scheme: light;
+}
+
 /* Override PrimeReact lara-light-indigo vars for dark mode */
 .dark {
+  --highlight-bg: #1f3a5f;
+  --highlight-text-color: #58a6ff;
   --surface-ground: #080c10;
   --surface-section: #080c10;
   --surface-card: #0d1117;

--- a/src/inviteflow/theme.css
+++ b/src/inviteflow/theme.css
@@ -12,7 +12,7 @@
   --gold: #9a6700;
   --gold-bg: #fdf6e3;
   --success: #1a7f37;
-  --success-bg: #1a7f37;
+  --success-bg: #dafbe1;
   --danger: #cf222e;
   --danger-dark: #cf222e;
   --blue: #0969da;


### PR DESCRIPTION
## Summary

- `theme.css`: `--success-bg` was identical to `--success` (`#1a7f37`) — green text on green background made action buttons invisible in light mode; fixed to `#dafbe1`
- `index.html`: added synchronous FOUC-guard `<script>` so dark-mode preference is applied before React mounts, eliminating the light flash on reload
- `primereact-reset.css`: added `color-scheme: light` to `:root`; added `--highlight-bg` / `--highlight-text-color` dark overrides so selected DataTable rows don't bleed lara-light-indigo's `#EFF6FF` blue into dark mode

## Test plan

- [ ] Light mode: "Add" button and other success-styled buttons are visible (mint green bg)
- [ ] Dark mode: hard-reload shows no light flash before dark colors apply
- [ ] Dark mode: selected DataTable rows are dark blue (`#1f3a5f`), not light blue
- [ ] Toggle: switching dark ↔ light is consistent on first load and subsequent toggles
- [ ] `tsc && vite build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)