### PR TITLE
ContactScout: split into modules, redesign UI (mobile-first, 3-tab workflow)

### DIFF
--- a/src/contact-scout/src/App.tsx
+++ b/src/contact-scout/src/App.tsx
@@ -1,133 +1,19 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import type { CSOfficial, CSScanMeta, CSPersistedState, CSStatus, ScanState, InviteeExport } from './types';
+import { CSS } from './css';
+import { CS_APIKEY_SK, VERIFY_SYS, SCAN_SYS, SCAN_TARGETS } from './constants';
+import { loadCSState, saveCSState, loadJurisdiction } from './storage';
+import { sleep, officialToInvitee, buildScanPrompts, downloadBlob, todaySlug } from './utils';
+import { callClaude } from './api';
+import PasswordGate from './components/PasswordGate';
+import ApiKeyModal from './components/ApiKeyModal';
+import JurisdictionModal from './components/JurisdictionModal';
+import LogSidebar from './components/LogSidebar';
+import DiscoverTab from './components/DiscoverTab';
+import OfficialsTab from './components/OfficialsTab';
+import ExportTab from './components/ExportTab';
+import type { CSOfficial, CSPersistedState, CSStatus, ScanState, CSJurisdiction } from './types';
 
-// ── Constants ─────────────────────────────────────────────────────────────────
-
-const CS_LS_KEY = 'contactscout_state';
-const CS_APIKEY_SK = 'cs_api_key';
-const SCOUT_PW = 'scout2025';
-
-const SCAN_TARGETS = [
-  { id: 'us-congress',  label: 'US Congress — all seats',        desc: 'All current US reps + senators for your state' },
-  { id: 'state-exec',   label: 'State Executive Branch',         desc: 'Governor, Lt. Gov, AG, Treasurer, Auditor, commissioners' },
-  { id: 'state-senate', label: 'State Senate — all seats',       desc: 'Full current state senate roster' },
-  { id: 'state-house',  label: 'State House — tracked counties', desc: 'House members for your tracked counties' },
-  { id: 'city-1',       label: 'City Council (City 1)',          desc: 'Current mayor and all council members' },
-  { id: 'city-2',       label: 'City Council (City 2)',          desc: 'Current mayor and all council members' },
-  { id: 'city-3',       label: 'City Council (City 3)',          desc: 'Current mayor and all council members' },
-];
-
-const SCAN_PROMPTS: Record<string, string> = {
-  'us-congress':  'Search for every current US Congress member for [YOUR STATE] (119th Congress 2025-2026): all House reps + 2 senators. For each: full name, title, district, official scheduler/contact email.',
-  'state-exec':   'Search for all current [YOUR STATE] statewide executive elected officials as of 2025: Governor, Lt. Governor, AG, Treasurer, Auditor, Superintendent of Public Instruction, and other commissioners. Full name, title, email.',
-  'state-senate': 'Search for all current [YOUR STATE] State Senate members as of 2025. Full name, district, official email.',
-  'state-house':  'Search for all current [YOUR STATE] House members for [YOUR COUNTIES] as of 2025. Full name, district, county, official email.',
-  'city-1':       'Search for current [CITY 1] City Council as of 2025. Mayor + every council member: full name, title, official email.',
-  'city-2':       'Search for current [CITY 2] City Council as of 2025. Mayor + every council member: full name, title, official email.',
-  'city-3':       'Search for current [CITY 3] City Council as of 2025. Mayor + every council member: full name, title, official email.',
-};
-
-const VERIFY_SYS = `Verify this elected official for 2025-2026 using web search. Respond ONLY with valid JSON no markdown:
-{"stillInOffice":true,"currentTitle":"","directEmail":"","officeEmail":"","officePhone":"","changes":"No changes detected","flags":"","replacedBy":"","confidence":"high"}`;
-
-const SCAN_SYS = `Find all current elected officials for 2025-2026 using web search. Respond ONLY with valid JSON no markdown:
-{"officials":[{"name":"","title":"","district":"","county":"","category":"US Senate|US House|Executive|State Senate|House|City Council","directEmail":"","officeEmail":"","officePhone":""}],"confidence":"high","notes":""}`;
-
-const CATS = ['All', 'US Senate', 'US House', 'Executive', 'State Senate', 'House', 'City Council'];
-
-const STATUS_LABEL: Record<CSStatus, string> = {
-  pending: 'PENDING', checking: 'CHECKING', done: 'VERIFIED',
-  changed: 'CHANGED', left_office: 'LEFT OFFICE', error: 'ERROR',
-};
-const STATUS_COLOR: Record<CSStatus, string> = {
-  pending: '#8b949e', checking: '#f59e0b', done: '#3fb950',
-  changed: '#58a6ff', left_office: '#f85149', error: '#e3b341',
-};
-
-// ── Persistence ───────────────────────────────────────────────────────────────
-
-function loadCSState(): CSPersistedState {
-  try {
-    const raw = localStorage.getItem(CS_LS_KEY);
-    if (!raw) return { officials: [], newOfficials: [], scanStatus: {}, scanMeta: {} };
-    return JSON.parse(raw) as CSPersistedState;
-  } catch { return { officials: [], newOfficials: [], scanStatus: {}, scanMeta: {} }; }
-}
-
-function saveCSState(s: CSPersistedState) {
-  try { localStorage.setItem(CS_LS_KEY, JSON.stringify(s)); } catch { /* quota */ }
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
-
-function officialToInvitee(o: CSOfficial): InviteeExport {
-  const parts = o.name.trim().split(/\s+/);
-  return {
-    firstName: parts[0] ?? '',
-    lastName: parts.slice(1).join(' '),
-    title: o.title,
-    category: o.category,
-    email: o.officeEmail || o.directEmail || '',
-    rsvpLink: '',
-    inviteStatus: 'pending',
-    sentAt: '',
-    rsvpStatus: 'No Response',
-    rsvpDate: '',
-    notes: [o.district, o.county].filter(Boolean).join(' · '),
-  };
-}
-
-function needsCustomization() {
-  return Object.values(SCAN_PROMPTS).some(p =>
-    p.includes('[YOUR STATE]') || p.includes('[YOUR COUNTIES]') || p.includes('[CITY')
-  );
-}
-
-// ── Password gate ─────────────────────────────────────────────────────────────
-
-function PasswordGate({ onUnlock }: { onUnlock: () => void }) {
-  const [pw, setPw] = useState('');
-  const [err, setErr] = useState(false);
-
-  function attempt() {
-    if (pw === SCOUT_PW) onUnlock();
-    else { setErr(true); setPw(''); }
-  }
-
-  return (
-    <div style={{ height: '100dvh', background: '#080c10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-      <div style={{ background: '#0d1117', border: '1px solid #21262d', borderRadius: 10, padding: '32px 36px', width: 360, fontFamily: 'monospace' }}>
-        <div style={{ fontSize: 17, fontWeight: 800, color: '#f0f6fc', letterSpacing: '-0.02em', marginBottom: 4 }}>CONTACT SCOUT</div>
-        <div style={{ fontSize: 9, color: '#8b949e', letterSpacing: '0.12em', marginBottom: 20 }}>by Lenya Chan · ELECTED OFFICIALS DISCOVERY</div>
-        <div style={{ fontSize: 11, color: '#8b949e', lineHeight: 1.7, marginBottom: 16 }}>
-          ContactScout uses Claude AI to discover and verify elected officials. Enter your access code to continue.
-        </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <input
-            type="password"
-            placeholder="Access code"
-            value={pw}
-            onChange={e => { setPw(e.target.value); setErr(false); }}
-            onKeyDown={e => e.key === 'Enter' && attempt()}
-            autoFocus
-            style={{ flex: 1, background: '#010409', border: `1px solid ${err ? '#da3633' : '#30363d'}`, borderRadius: 4, color: '#c9d1d9', fontFamily: 'monospace', fontSize: 11, padding: '8px 10px' }}
-          />
-          <button
-            onClick={attempt}
-            style={{ background: '#1f6feb', border: '1px solid #1f6feb', color: '#fff', padding: '8px 16px', borderRadius: 4, cursor: 'pointer', fontFamily: 'monospace', fontSize: 11, whiteSpace: 'nowrap' }}
-          >
-            Unlock
-          </button>
-        </div>
-        {err && <div style={{ fontSize: 10, color: '#f85149', marginTop: 8 }}>Incorrect access code.</div>}
-      </div>
-    </div>
-  );
-}
-
-// ── Main app ──────────────────────────────────────────────────────────────────
+// ── Root ───────────────────────────────────────────────────────────────────────
 
 export default function App() {
   const [unlocked, setUnlocked] = useState(() => sessionStorage.getItem('cs_unlocked') === '1');
@@ -144,28 +30,29 @@ export default function App() {
   return <ContactScoutInner />;
 }
 
-// ── Inner component ───────────────────────────────────────────────────────────
+// ── Inner component (all app state lives here) ─────────────────────────────────
 
 function ContactScoutInner() {
-  const persisted = loadCSState();
-  const [officials, setOfficials] = useState<CSOfficial[]>(persisted.officials);
-  const [newOfficials, setNewOfficials] = useState<CSOfficial[]>(persisted.newOfficials);
-  const [scanStatus, setScanStatus] = useState<Record<string, ScanState>>(persisted.scanStatus);
-  const [scanMeta, setScanMeta] = useState<Record<string, CSScanMeta>>(persisted.scanMeta);
+  const init = loadCSState();
+  const [officials,    setOfficials]    = useState<CSOfficial[]>(init.officials);
+  const [newOfficials, setNewOfficials] = useState<CSOfficial[]>(init.newOfficials);
+  const [scanStatus,   setScanStatus]   = useState<Record<string, ScanState>>(init.scanStatus);
+  const [scanMeta,     setScanMeta]     = useState<CSPersistedState['scanMeta']>(init.scanMeta);
 
-  const [tab, setTab] = useState<0 | 1>(0);
-  const [activeCat, setActiveCat] = useState('All');
-  const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [running, setRunning] = useState(false);
-  const [progress, setProgress] = useState({ done: 0, total: 0 });
-  const [log, setLog] = useState<string[]>([]);
-  const [apiKey, setApiKey] = useState(() => sessionStorage.getItem(CS_APIKEY_SK) || '');
+  const [tab,          setTab]          = useState<0 | 1 | 2>(0);
+  const [activeCat,    setActiveCat]    = useState('All');
+  const [selected,     setSelected]     = useState<Set<string>>(new Set());
+  const [running,      setRunning]      = useState(false);
+  const [progress,     setProgress]     = useState({ done: 0, total: 0 });
+  const [log,          setLog]          = useState<string[]>([]);
+  const [apiKey,       setApiKey]       = useState(() => sessionStorage.getItem(CS_APIKEY_SK) || '');
+  const [jx,           setJx]           = useState<CSJurisdiction>(loadJurisdiction);
   const [showKeyModal, setShowKeyModal] = useState(false);
-  const [keyDraft, setKeyDraft] = useState('');
-  const [keyErr, setKeyErr] = useState(false);
-  const [exportStatus, setExportStatus] = useState('');
-  const abortRef = useRef(false);
-  const pendingRef = useRef<(() => void) | null>(null);
+  const [showJxModal,  setShowJxModal]  = useState(false);
+  const [showLog,      setShowLog]      = useState(false);
+
+  const abortRef     = useRef(false);
+  const pendingRef   = useRef<(() => void) | null>(null);
   const importFileRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -177,63 +64,36 @@ function ContactScoutInner() {
     setLog(prev => [`[${ts}] ${msg}`, ...prev.slice(0, 99)]);
   }, []);
 
-  // ── API key modal ──────────────────────────────────────────────────────────
+  // ── API call wrapper (handles missing key + invalid key) ───────────────────
 
   function openKeyModal(onSave?: () => void) {
     pendingRef.current = onSave ?? null;
-    setKeyDraft(apiKey);
-    setKeyErr(false);
     setShowKeyModal(true);
   }
 
-  function saveKey() {
-    if (!keyDraft.startsWith('sk-ant-')) { setKeyErr(true); return; }
-    setApiKey(keyDraft);
-    sessionStorage.setItem(CS_APIKEY_SK, keyDraft);
-    setShowKeyModal(false);
-    const pending = pendingRef.current;
+  function handleKeySave(key: string) {
+    setApiKey(key);
+    sessionStorage.setItem(CS_APIKEY_SK, key);
+    const cb = pendingRef.current;
     pendingRef.current = null;
-    pending?.();
+    cb?.();
   }
 
-  // ── Claude API ─────────────────────────────────────────────────────────────
-
-  async function callClaude(sys: string, user: string): Promise<Record<string, unknown>> {
-    const key = apiKey;
-    if (!key) {
+  async function apiCall(sys: string, user: string): Promise<Record<string, unknown>> {
+    if (!apiKey) {
       return new Promise((resolve, reject) => {
-        openKeyModal(() => callClaude(sys, user).then(resolve).catch(reject));
+        openKeyModal(() => apiCall(sys, user).then(resolve).catch(reject));
       });
     }
-    const res = await fetch('https://api.anthropic.com/v1/messages', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': key,
-        'anthropic-version': '2023-06-01',
-        'anthropic-dangerous-direct-browser-access': 'true',
-      },
-      body: JSON.stringify({
-        model: 'claude-sonnet-4-20250514',
-        max_tokens: 1500,
-        system: sys,
-        tools: [{ type: 'web_search_20250305', name: 'web_search' }],
-        messages: [{ role: 'user', content: user }],
-      }),
-    });
-    if (res.status === 401) {
-      setApiKey('');
-      sessionStorage.removeItem(CS_APIKEY_SK);
-      throw new Error('Invalid API key');
+    try {
+      return await callClaude(apiKey, sys, user);
+    } catch (e) {
+      if (String(e).includes('Invalid API key')) setApiKey('');
+      throw e;
     }
-    const d = await res.json() as { content?: Array<{ type: string; text?: string }>; error?: { message: string } };
-    if (d.error) throw new Error(d.error.message ?? 'API error');
-    const text = d.content?.find(b => b.type === 'text')?.text ?? '';
-    if (!text) throw new Error('No text response');
-    return JSON.parse(text.replace(/```json|```/g, '').trim()) as Record<string, unknown>;
   }
 
-  // ── Verify ─────────────────────────────────────────────────────────────────
+  // ── Verify loop ────────────────────────────────────────────────────────────
 
   async function runVerify(names: string[]) {
     if (!apiKey) { openKeyModal(() => runVerify(names)); return; }
@@ -246,27 +106,32 @@ function ContactScoutInner() {
       const name = names[i];
       const off = officials.find(o => o.name === name);
       if (!off) continue;
+
       addLog(`Verifying ${name}…`);
       setOfficials(prev => prev.map(o => o.name === name ? { ...o, status: 'checking' } : o));
+
       try {
-        const r = await callClaude(VERIFY_SYS, `Verify for 2025-2026:\nName: ${off.name}\nTitle: ${off.title}\nCategory: ${off.category}\nDistrict: ${off.district || 'N/A'}\nEmail: ${off.directEmail || off.officeEmail || 'none'}`);
+        const prompt = `Verify for 2025-2026:\nName: ${off.name}\nTitle: ${off.title}\nCategory: ${off.category}\nDistrict: ${off.district || 'N/A'}\nEmail: ${off.directEmail || off.officeEmail || 'none'}`;
+        const r = await apiCall(VERIFY_SYS, prompt);
         const changed = !r.stillInOffice || r.changes !== 'No changes detected' || r.flags;
         const newStatus: CSStatus = !r.stillInOffice ? 'left_office' : changed ? 'changed' : 'done';
         setOfficials(prev => prev.map(o => o.name === name ? {
           ...o, status: newStatus, result: r as Record<string, string | boolean>,
           directEmail: (r.directEmail as string) || o.directEmail,
-          officeEmail: (r.officeEmail as string) || o.officeEmail,
-          officePhone: (r.officePhone as string) || o.officePhone,
-          title: (r.currentTitle as string) || o.title,
+          officeEmail:  (r.officeEmail  as string) || o.officeEmail,
+          officePhone:  (r.officePhone  as string) || o.officePhone,
+          title:        (r.currentTitle as string) || o.title,
         } : o));
         addLog(`✓ ${name}: ${r.stillInOffice ? 'In office' : '⚠ LEFT OFFICE'} — ${r.changes}`);
       } catch (e) {
         setOfficials(prev => prev.map(o => o.name === name ? { ...o, status: 'error', result: { error: String(e) } } : o));
         addLog(`✗ ${name}: ${String(e)}`);
       }
+
       setProgress({ done: i + 1, total: names.length });
       if (i < names.length - 1) await sleep(700);
     }
+
     setRunning(false);
     addLog(`Done — ${names.length} checked.`);
   }
@@ -280,17 +145,25 @@ function ContactScoutInner() {
     setRunning(true);
     setScanStatus(prev => ({ ...prev, [id]: 'scanning' }));
     addLog(`Scanning: ${SCAN_TARGETS.find(t => t.id === id)?.label}…`);
+
     try {
-      const r = await callClaude(SCAN_SYS, SCAN_PROMPTS[id]);
+      const r = await apiCall(SCAN_SYS, buildScanPrompts(jx)[id]);
       const currentNames = new Set(officials.map(o => o.name.toLowerCase().trim()));
       const found = (r.officials as CSOfficial[]) ?? [];
       const fresh = found.filter(o => !currentNames.has(o.name.toLowerCase().trim()));
+
       setScanStatus(prev => ({ ...prev, [id]: 'done' }));
       setScanMeta(prev => ({ ...prev, [id]: { total: found.length, confidence: r.confidence as string, notes: r.notes as string } }));
+
       if (fresh.length > 0) {
         setNewOfficials(prev => {
           const ex = new Set(prev.map(x => x.name.toLowerCase()));
-          return [...prev, ...fresh.filter(x => !ex.has(x.name.toLowerCase())).map(x => ({ ...x, _scanId: id, status: 'pending' as CSStatus, result: null }))];
+          return [
+            ...prev,
+            ...fresh
+              .filter(x => !ex.has(x.name.toLowerCase()))
+              .map(x => ({ ...x, _scanId: id, status: 'pending' as CSStatus, result: null })),
+          ];
         });
         addLog(`✓ ${fresh.length} new found.`);
       } else {
@@ -301,6 +174,7 @@ function ContactScoutInner() {
       setScanStatus(prev => ({ ...prev, [id]: 'error' }));
       addLog(`✗ Scan: ${String(e)}`);
     }
+
     setRunning(false);
   }
 
@@ -329,8 +203,11 @@ function ContactScoutInner() {
     if (!name) return;
     const title = prompt('Title:', '') ?? '';
     const email = prompt('Email:', '') ?? '';
-    const cat = prompt('Category (US Senate/US House/Executive/State Senate/House/City Council):', 'City Council') ?? 'City Council';
-    setOfficials(prev => [...prev, { name, title, directEmail: email, officeEmail: '', officePhone: '', district: '', county: '', category: cat, status: 'pending', result: null }]);
+    const cat   = prompt('Category (US Senate/US House/Executive/State Senate/House/City Council):', 'City Council') ?? 'City Council';
+    setOfficials(prev => [...prev, {
+      name, title, directEmail: email, officeEmail: '', officePhone: '',
+      district: '', county: '', category: cat, status: 'pending', result: null,
+    }]);
     addLog(`+ Added ${name}`);
   }
 
@@ -340,41 +217,24 @@ function ContactScoutInner() {
     const invitees = officials
       .filter(o => o.status !== 'left_office' && (o.officeEmail || o.directEmail))
       .map(officialToInvitee);
-    if (invitees.length === 0) { setExportStatus('No officials with email to export.'); return; }
-    const blob = new Blob([JSON.stringify({
-      exportedAt: new Date().toISOString(),
-      source: 'ContactScout',
-      count: invitees.length,
-      invitees,
-    }, null, 2)], { type: 'application/json' });
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = `contactscout-invitees-${new Date().toISOString().slice(0, 10)}.json`;
-    a.click();
-    URL.revokeObjectURL(a.href);
-    setExportStatus(`✓ Exported ${invitees.length} invitees.`);
-    addLog(`⬡ Exported ${invitees.length} invitees for InviteFlow.`);
+    if (invitees.length === 0) { addLog('No officials with email to export.'); return; }
+    downloadBlob(
+      new Blob([JSON.stringify({ exportedAt: new Date().toISOString(), source: 'ContactScout', count: invitees.length, invitees }, null, 2)], { type: 'application/json' }),
+      `contactscout-invitees-${todaySlug()}.json`,
+    );
+    addLog(`✓ Exported ${invitees.length} invitees for InviteFlow.`);
   }
 
   function exportBackup() {
-    const blob = new Blob([JSON.stringify({
-      exportedAt: new Date().toISOString(),
-      source: 'ContactScout',
-      officials,
-      newOfficials,
-      scanStatus,
-      scanMeta,
-    }, null, 2)], { type: 'application/json' });
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = `contactscout-backup-${new Date().toISOString().slice(0, 10)}.json`;
-    a.click();
-    URL.revokeObjectURL(a.href);
+    downloadBlob(
+      new Blob([JSON.stringify({ exportedAt: new Date().toISOString(), source: 'ContactScout', officials, newOfficials, scanStatus, scanMeta }, null, 2)], { type: 'application/json' }),
+      `contactscout-backup-${todaySlug()}.json`,
+    );
     addLog(`✓ Backup saved (${officials.length} officials).`);
   }
 
   function exportCSV() {
-    const h = ['Name', 'Title', 'District', 'County', 'Category', 'Direct Email', 'Office Email', 'Phone', 'Status', 'Changes', 'Flags', 'Replaced By', 'Confidence'];
+    const h = ['Name','Title','District','County','Category','Direct Email','Office Email','Phone','Status','Changes','Flags','Replaced By','Confidence'];
     const rows = officials.map(o => [
       o.name, o.title, o.district, o.county, o.category,
       o.directEmail, o.officeEmail, o.officePhone, o.status,
@@ -382,11 +242,7 @@ function ContactScoutInner() {
       o.result?.replacedBy as string || '', o.result?.confidence as string || '',
     ]);
     const csv = [h, ...rows].map(r => r.map(c => `"${(c || '').replace(/"/g, '""')}"`).join(',')).join('\n');
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(new Blob([csv], { type: 'text/csv' }));
-    a.download = `contactscout-officials-${new Date().toISOString().slice(0, 10)}.csv`;
-    a.click();
-    URL.revokeObjectURL(a.href);
+    downloadBlob(new Blob([csv], { type: 'text/csv' }), `contactscout-officials-${todaySlug()}.csv`);
     addLog('✓ CSV exported.');
   }
 
@@ -395,11 +251,11 @@ function ContactScoutInner() {
     reader.onload = () => {
       try {
         const d = JSON.parse(reader.result as string) as Partial<CSPersistedState>;
-        if (d.officials) setOfficials(d.officials.map(o => ({ ...o, result: o.result || null })));
+        if (d.officials)    setOfficials(d.officials.map(o => ({ ...o, result: o.result || null })));
         if (d.newOfficials) setNewOfficials(d.newOfficials);
-        if (d.scanStatus) setScanStatus(d.scanStatus);
-        if (d.scanMeta) setScanMeta(d.scanMeta);
-        addLog(`✓ Backup loaded.`);
+        if (d.scanStatus)   setScanStatus(d.scanStatus);
+        if (d.scanMeta)     setScanMeta(d.scanMeta);
+        addLog('✓ Backup loaded.');
       } catch (e) { addLog(`✗ Import failed: ${String(e)}`); }
     };
     reader.readAsText(file);
@@ -407,129 +263,155 @@ function ContactScoutInner() {
 
   function clearAll() {
     if (!confirm('Clear all ContactScout data? This cannot be undone.')) return;
-    setOfficials([]);
-    setNewOfficials([]);
-    setScanStatus({});
-    setScanMeta({});
-    localStorage.removeItem(CS_LS_KEY);
+    setOfficials([]); setNewOfficials([]); setScanStatus({}); setScanMeta({});
+    localStorage.removeItem('contactscout_state');
     addLog('✓ All data cleared.');
   }
 
-  // ── Computed ───────────────────────────────────────────────────────────────
+  // ── Derived state ──────────────────────────────────────────────────────────
 
   const filtered = activeCat === 'All' ? officials : officials.filter(o => o.category === activeCat);
   const stats = {
-    total: officials.length,
-    done: officials.filter(o => o.status === 'done').length,
+    total:   officials.length,
+    done:    officials.filter(o => o.status === 'done').length,
     changed: officials.filter(o => o.status === 'changed').length,
-    left: officials.filter(o => o.status === 'left_office').length,
-    ready: officials.filter(o => o.status !== 'left_office' && (o.officeEmail || o.directEmail)).length,
+    left:    officials.filter(o => o.status === 'left_office').length,
+    ready:   officials.filter(o => o.status !== 'left_office' && (o.officeEmail || o.directEmail)).length,
   };
-  const pct = progress.total ? Math.round(progress.done / progress.total * 100) : 0;
+  const pct       = progress.total ? Math.round(progress.done / progress.total * 100) : 0;
+  const jxMissing = !jx.state.trim();
 
-  // ── Style helpers ──────────────────────────────────────────────────────────
+  const TABS = [
+    `DISCOVER${newOfficials.length > 0 ? ` · ${newOfficials.length} NEW` : ''}`,
+    `OFFICIALS${officials.length > 0 ? ` · ${officials.length}` : ''}`,
+    'EXPORT',
+  ] as const;
 
-  const btn = (variant: 'pri' | 'grn' | 'del' | 'def' = 'def', disabled = false): React.CSSProperties => ({
-    border: `1px solid ${variant === 'pri' ? '#1f6feb' : variant === 'grn' ? '#238636' : variant === 'del' ? '#da3633' : '#21262d'}`,
-    background: variant === 'pri' ? '#1f6feb' : variant === 'grn' ? '#238636' : 'transparent',
-    color: variant === 'pri' || variant === 'grn' ? '#fff' : variant === 'del' ? '#f85149' : '#8b949e',
-    padding: '3px 9px', borderRadius: 4, cursor: disabled ? 'not-allowed' : 'pointer',
-    fontFamily: 'monospace', fontSize: 10, letterSpacing: '0.05em', opacity: disabled ? 0.4 : 1,
-  });
-
-  const tagStyle = (status: CSStatus): React.CSSProperties => ({
-    fontSize: 10, padding: '2px 6px', borderRadius: 3, letterSpacing: '0.07em',
-    border: `1px solid ${STATUS_COLOR[status]}`, color: STATUS_COLOR[status],
-    animation: status === 'checking' ? 'cs-pulse 1.4s ease-in-out infinite' : undefined,
-  });
+  const STAT_ROWS = [
+    ['TOTAL',        stats.total,   '#8b949e'],
+    ['VERIFIED',     stats.done,    '#3fb950'],
+    ['CHANGED',      stats.changed, '#58a6ff'],
+    ['LEFT OFFICE',  stats.left,    '#f85149'],
+    ['READY',        stats.ready,   '#a371f7'],
+  ] as const;
 
   // ── Render ─────────────────────────────────────────────────────────────────
 
   return (
-    <div style={{ height: '100dvh', display: 'flex', flexDirection: 'column', background: '#080c10', fontFamily: 'monospace', fontSize: 11, overflow: 'hidden' }}>
-      <style>{`@keyframes cs-pulse{0%,100%{opacity:1}50%{opacity:.3}}*:focus-visible{outline:2px solid #58a6ff;outline-offset:2px;}`}</style>
-      <input ref={importFileRef} type="file" accept=".json" style={{ display: 'none' }} onChange={e => { const f = e.target.files?.[0]; if (f) { importBackup(f); e.target.value = ''; } }} />
+    <div className="cs-root">
+      <style>{CSS}</style>
+      <input
+        ref={importFileRef} type="file" accept=".json" style={{ display: 'none' }}
+        onChange={e => { const f = e.target.files?.[0]; if (f) { importBackup(f); e.target.value = ''; } }}
+      />
 
       {/* Header */}
-      <div style={{ padding: '10px 20px', borderBottom: '1px solid #21262d', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 8, flexShrink: 0 }}>
+      <div style={{ padding: '8px 16px', borderBottom: '1px solid #21262d', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, flexShrink: 0 }}>
         <div>
-          <span style={{ fontWeight: 800, fontSize: 16, color: '#f0f6fc', letterSpacing: '-0.02em' }}>CONTACT SCOUT</span>
-          <span style={{ fontSize: 9, color: '#8b949e', letterSpacing: '0.1em', marginLeft: 10 }}>ELECTED OFFICIALS · VERIFY + DISCOVER</span>
-          <div style={{ fontSize: 9, color: '#8b949e', marginTop: 1 }}>by Lenya Chan</div>
+          <span style={{ fontWeight: 800, fontSize: 15, color: '#f0f6fc', letterSpacing: '-0.02em' }}>CONTACT SCOUT</span>
+          <div style={{ fontSize: 9, color: '#7d8590', letterSpacing: '0.1em', marginTop: 1 }}>by Lenya Chan</div>
         </div>
-        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
-          {newOfficials.length > 0 && (
-            <span style={{ background: '#0c1a2e', color: '#58a6ff', border: '1px solid #1f6feb', borderRadius: 4, padding: '2px 7px', fontSize: 10 }}>
-              {newOfficials.length} NEW
-            </span>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <button className="cs-btn sm cs-log-btn" onClick={() => setShowLog(v => !v)}>☰ Log</button>
+          <button
+            className="cs-btn sm"
+            onClick={() => setShowJxModal(true)}
+            style={jxMissing ? { borderColor: '#bb8009', color: '#e3b341' } : {}}
+            title={jxMissing ? 'Configure jurisdiction' : `Jurisdiction: ${jx.state}`}
+          >
+            ⊙ {jxMissing ? 'Jurisdiction' : jx.state}
+          </button>
+          <button
+            className={`cs-btn sm${apiKey ? ' grn' : ' del'}`}
+            onClick={() => openKeyModal()}
+          >
+            ⚙ Key{apiKey ? ' ✓' : ''}
+          </button>
+          {running && (
+            <button className="cs-btn sm del" onClick={() => { abortRef.current = true; }}>■ Stop</button>
           )}
-          <button style={btn(apiKey ? 'grn' : 'del')} onClick={() => openKeyModal()}>⚙ Key{apiKey ? ' ✓' : ''}</button>
-          <button style={btn('grn')} onClick={exportForInviteFlow}>⬡ Export → InviteFlow</button>
-          <button style={btn()} onClick={exportBackup}>↓ Backup</button>
-          <button style={btn()} onClick={exportCSV}>↓ CSV</button>
-          <button style={btn()} onClick={() => importFileRef.current?.click()}>↑ Import</button>
-          <button style={btn('del', running)} onClick={() => { abortRef.current = true; }} disabled={!running}>■ Stop</button>
-          <button style={btn()} onClick={clearAll}>✕ Clear</button>
         </div>
       </div>
 
-      {exportStatus && (
-        <div style={{ padding: '5px 20px', fontSize: 10, color: exportStatus.startsWith('✓') ? '#3fb950' : '#f85149', background: '#0d1117', borderBottom: '1px solid #21262d', flexShrink: 0 }}>
-          {exportStatus}
+      {/* Onboarding banners */}
+      {!apiKey && (
+        <div className="cs-banner info">
+          <div className="cs-banner-body">
+            <div className="cs-banner-title">Welcome to ContactScout</div>
+            <div className="cs-banner-text">
+              Add your Claude API key to start discovering officials.
+              Get a free key at console.anthropic.com → API Keys → Create Key.
+            </div>
+            <button className="cs-btn pri sm" onClick={() => openKeyModal()}>Add Claude API Key</button>
+          </div>
         </div>
       )}
-
-      {/* Welcome banner (no API key) */}
-      {!apiKey && (
-        <div style={{ background: '#060d1a', borderBottom: '1px solid #1f6feb', padding: '12px 20px', flexShrink: 0 }}>
-          <div style={{ fontSize: 11, color: '#58a6ff', fontWeight: 600, marginBottom: 4 }}>Welcome to ContactScout — by Lenya Chan</div>
-          <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.7, marginBottom: 8 }}>
-            ContactScout uses Claude AI to find and verify elected officials. Add your Claude API key to get started, then configure the Scan targets for your jurisdiction.
-          </div>
-          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-            <button style={btn('pri')} onClick={() => openKeyModal()}>→ Add Claude API Key</button>
-            <span style={{ fontSize: 9, color: '#8b949e' }}>Free key at console.anthropic.com → API Keys → Create Key</span>
+      {apiKey && jxMissing && (
+        <div className="cs-banner warn">
+          <div className="cs-banner-body">
+            <div className="cs-banner-title">Jurisdiction not configured</div>
+            <div className="cs-banner-text">
+              Configure your state, counties, and cities so scan prompts target the right officials.
+            </div>
+            <button className="cs-btn sm" style={{ borderColor: '#bb8009', color: '#e3b341' }} onClick={() => setShowJxModal(true)}>
+              Configure Jurisdiction
+            </button>
           </div>
         </div>
       )}
 
       {/* Stats bar */}
-      <div style={{ padding: '5px 20px', borderBottom: '1px solid #161b22', display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'center', flexShrink: 0 }}>
-        {([['TOTAL', stats.total, '#8b949e'], ['VERIFIED', stats.done, '#3fb950'], ['CHANGED', stats.changed, '#58a6ff'], ['LEFT OFFICE', stats.left, '#f85149'], ['READY TO INVITE', stats.ready, '#a371f7']] as const).map(([label, n, col]) => (
-          <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-            <span style={{ width: 5, height: 5, borderRadius: '50%', background: col, display: 'inline-block' }} />
-            <span style={{ fontSize: 9, color: '#8b949e', letterSpacing: '0.1em' }}>{label}</span>
-            <span style={{ fontSize: 12, fontWeight: 500, color: col }}>{n}</span>
-          </div>
-        ))}
-        {running && (
-          <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 6 }}>
-            <div style={{ width: 90, height: 3, background: '#21262d', borderRadius: 2 }}>
-              <div style={{ width: `${pct}%`, height: '100%', background: '#1f6feb', borderRadius: 2 }} />
+      {officials.length > 0 && (
+        <div className="cs-stats">
+          {STAT_ROWS.map(([label, n, col]) => (
+            <div className="cs-stat" key={label}>
+              <span className="cs-stat-dot" style={{ background: col }} />
+              <span className="cs-stat-label">{label}</span>
+              <span className="cs-stat-val" style={{ color: col }}>{n}</span>
             </div>
-            <span style={{ fontSize: 10, color: '#58a6ff' }}>{progress.done}/{progress.total}</span>
-          </div>
-        )}
-      </div>
+          ))}
+          {running && (
+            <div className="cs-progress-wrap">
+              <div className="cs-progress-track">
+                <div className="cs-progress-fill" style={{ width: `${pct}%` }} />
+              </div>
+              <span style={{ fontSize: 10, color: '#58a6ff' }}>{progress.done}/{progress.total}</span>
+            </div>
+          )}
+        </div>
+      )}
 
-      {/* Tabs */}
-      <div style={{ borderBottom: '1px solid #21262d', display: 'flex', flexShrink: 0 }}>
-        {[`✓ Verify Existing`, `＋ Scan for New${newOfficials.length > 0 ? ` (${newOfficials.length})` : ''}`].map((label, i) => (
+      {/* Tab bar */}
+      <div className="cs-tab-bar">
+        {TABS.map((label, i) => (
           <button
             key={i}
-            onClick={() => setTab(i as 0 | 1)}
-            style={{ background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'monospace', fontSize: 10, letterSpacing: '0.04em', padding: '8px 16px', color: tab === i ? '#f0f6fc' : '#8b949e', borderBottom: `2px solid ${tab === i ? '#1f6feb' : 'transparent'}` }}
+            className={`cs-tab${tab === i ? ' active' : ''}`}
+            onClick={() => setTab(i as 0 | 1 | 2)}
           >
             {label}
           </button>
         ))}
       </div>
 
-      {/* Content */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 220px', flex: 1, overflow: 'hidden', minHeight: 0 }}>
-        <div style={{ overflowY: 'auto', minHeight: 0 }}>
-          {tab === 0 ? (
-            <VerifyTab
+      {/* Main content + log */}
+      <div className="cs-layout">
+        <div className="cs-main">
+          {tab === 0 && (
+            <DiscoverTab
+              jx={jx}
+              scanStatus={scanStatus}
+              scanMeta={scanMeta}
+              newOfficials={newOfficials}
+              running={running}
+              runScan={runScan}
+              addNew={addNew}
+              dismissNew={dismissNew}
+              onConfigureJx={() => setShowJxModal(true)}
+            />
+          )}
+          {tab === 1 && (
+            <OfficialsTab
               officials={filtered}
               allOfficials={officials}
               activeCat={activeCat}
@@ -540,258 +422,39 @@ function ContactScoutInner() {
               running={running}
               runVerify={runVerify}
               addManually={addManually}
-              btn={btn}
-              tagStyle={tagStyle}
+              onGoDiscover={() => setTab(0)}
             />
-          ) : (
-            <ScanTab
-              scanStatus={scanStatus}
-              scanMeta={scanMeta}
-              newOfficials={newOfficials}
-              running={running}
-              runScan={runScan}
-              addNew={addNew}
-              dismissNew={dismissNew}
-              btn={btn}
+          )}
+          {tab === 2 && (
+            <ExportTab
+              officials={officials}
+              exportForInviteFlow={exportForInviteFlow}
+              exportBackup={exportBackup}
+              exportCSV={exportCSV}
+              importBackup={() => importFileRef.current?.click()}
+              clearAll={clearAll}
             />
           )}
         </div>
 
-        {/* Log panel */}
-        <div style={{ overflowY: 'auto', padding: '11px 13px', background: '#050709', borderLeft: '1px solid #161b22', minHeight: 0 }}>
-          <div style={{ fontSize: 9, color: '#8b949e', letterSpacing: '0.14em', marginBottom: 6 }}>ACTIVITY LOG</div>
-          <div style={{ fontSize: 10, color: '#8b949e', fontStyle: 'italic', marginBottom: 6 }}>⬡ Export → InviteFlow to download invitee list.</div>
-          {log.length === 0 && <div style={{ fontSize: 10, color: '#7d8590', fontStyle: 'italic' }}>No activity yet.</div>}
-          {log.map((entry, i) => (
-            <div key={i} style={{ fontSize: 10, color: i === 0 ? '#8b949e' : '#7d8590', marginBottom: 3, lineHeight: 1.5, borderLeft: `2px solid ${i === 0 ? '#1f6feb' : 'transparent'}`, paddingLeft: 5 }}>
-              {entry}
-            </div>
-          ))}
-          <div style={{ marginTop: 14, paddingTop: 10, borderTop: '1px solid #161b22' }}>
-            <div style={{ fontSize: 9, color: '#8b949e', letterSpacing: '0.1em', marginBottom: 6 }}>DATA</div>
-            <button style={{ ...btn(), width: '100%', marginBottom: 4, textAlign: 'left' }} onClick={exportBackup}>↓ Backup (.json)</button>
-            <button style={{ ...btn(), width: '100%', marginBottom: 4, textAlign: 'left' }} onClick={() => importFileRef.current?.click()}>↑ Import backup</button>
-            <button style={{ ...btn('del'), width: '100%', textAlign: 'left' }} onClick={clearAll}>✕ Clear all data</button>
-          </div>
-        </div>
+        <LogSidebar log={log} show={showLog} onClose={() => setShowLog(false)} />
       </div>
 
-      {/* API key modal */}
+      {/* Modals */}
       {showKeyModal && (
-        <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,.8)', zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <div style={{ background: '#0d1117', border: '1px solid #30363d', borderRadius: 8, padding: '22px 24px', width: 380, maxWidth: '90vw' }}>
-            <div style={{ fontSize: 12, color: '#f0f6fc', fontWeight: 700, marginBottom: 6 }}>Claude API Key</div>
-            <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.6, marginBottom: 12 }}>
-              Enter your Anthropic API key. Get a free key at{' '}
-              <a href="https://console.anthropic.com/" target="_blank" rel="noreferrer" style={{ color: '#58a6ff' }}>console.anthropic.com</a>
-              {' '}→ API Keys → Create Key. Starts with <code>sk-ant-</code>. Stored in session only — never persisted.
-            </div>
-            <input
-              type="password"
-              placeholder="sk-ant-..."
-              value={keyDraft}
-              onChange={e => { setKeyDraft(e.target.value); setKeyErr(false); }}
-              onKeyDown={e => e.key === 'Enter' && saveKey()}
-              style={{ width: '100%', background: '#010409', border: `1px solid ${keyErr ? '#da3633' : '#30363d'}`, borderRadius: 4, color: '#c9d1d9', fontFamily: 'monospace', fontSize: 11, padding: '7px 10px', marginBottom: 8 }}
-              autoFocus
-            />
-            {keyErr && <div style={{ fontSize: 10, color: '#f85149', marginBottom: 8 }}>Must start with sk-ant-</div>}
-            <div style={{ display: 'flex', gap: 7, justifyContent: 'flex-end' }}>
-              <button style={btn()} onClick={() => setShowKeyModal(false)}>Cancel</button>
-              <button style={btn('pri')} onClick={saveKey}>Save</button>
-            </div>
-          </div>
-        </div>
+        <ApiKeyModal
+          apiKey={apiKey}
+          onSave={handleKeySave}
+          onClose={() => { setShowKeyModal(false); pendingRef.current = null; }}
+        />
       )}
-    </div>
-  );
-}
-
-// ── VerifyTab ─────────────────────────────────────────────────────────────────
-
-interface VerifyTabProps {
-  officials: CSOfficial[];
-  allOfficials: CSOfficial[];
-  activeCat: string;
-  setActiveCat: (c: string) => void;
-  selected: Set<string>;
-  toggleSel: (name: string) => void;
-  setSelected: React.Dispatch<React.SetStateAction<Set<string>>>;
-  running: boolean;
-  runVerify: (names: string[]) => void;
-  addManually: () => void;
-  btn: (v?: 'pri' | 'grn' | 'del' | 'def', d?: boolean) => React.CSSProperties;
-  tagStyle: (s: CSStatus) => React.CSSProperties;
-}
-
-function VerifyTab({ officials, allOfficials, activeCat, setActiveCat, selected, toggleSel, setSelected, running, runVerify, addManually, btn, tagStyle }: VerifyTabProps) {
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const names = officials.map(o => o.name);
-
-  function toggleExpand(name: string) {
-    setExpanded(prev => { const n = new Set(prev); n.has(name) ? n.delete(name) : n.add(name); return n; });
-  }
-
-  return (
-    <div>
-      <div style={{ padding: '6px 18px', borderBottom: '1px solid #161b22', display: 'flex', gap: 5, alignItems: 'center', flexWrap: 'wrap', position: 'sticky', top: 0, background: '#080c10', zIndex: 2 }}>
-        <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap', flex: 1 }}>
-          {CATS.map(c => (
-            <button
-              key={c}
-              onClick={() => setActiveCat(c)}
-              style={{ border: `1px solid ${activeCat === c ? '#1f6feb' : '#21262d'}`, background: activeCat === c ? '#0c2d6b' : 'transparent', color: activeCat === c ? '#58a6ff' : '#8b949e', padding: '3px 8px', borderRadius: 20, cursor: 'pointer', fontFamily: 'monospace', fontSize: 9, letterSpacing: '0.07em' }}
-            >
-              {c.toUpperCase()}
-            </button>
-          ))}
-        </div>
-        <div style={{ display: 'flex', gap: 4 }}>
-          <button style={btn('def', running)} onClick={() => setSelected(new Set(names))} disabled={running}>Sel All</button>
-          <button style={btn('def', running)} onClick={() => setSelected(new Set())} disabled={running}>Clear</button>
-          <button style={btn('pri', running || selected.size === 0)} onClick={() => runVerify([...selected])} disabled={running || selected.size === 0}>▶ ({selected.size})</button>
-          <button style={btn('pri', running)} onClick={() => runVerify(names)} disabled={running}>▶ All</button>
-        </div>
-      </div>
-
-      {officials.length === 0 && (
-        <div style={{ padding: '40px 20px', textAlign: 'center', color: '#8b949e', fontSize: 11 }}>
-          No officials yet. Use <strong style={{ color: '#c9d1d9' }}>＋ Scan for New</strong> to discover, or{' '}
-          <button style={{ background: 'none', border: 'none', color: '#58a6ff', cursor: 'pointer', fontFamily: 'monospace', fontSize: 11 }} onClick={addManually}>+ Add Manually</button>.
-        </div>
+      {showJxModal && (
+        <JurisdictionModal
+          jx={jx}
+          onSave={updated => setJx(updated)}
+          onClose={() => setShowJxModal(false)}
+        />
       )}
-
-      {officials.map(o => {
-        const isOpen = expanded.has(o.name);
-        const r = o.result;
-        return (
-          <div key={o.name} style={{ borderBottom: '1px solid #0d1117' }}>
-            <div
-              style={{ display: 'grid', gridTemplateColumns: '20px 1fr 105px 82px 14px', gap: 7, padding: '8px 18px', cursor: 'pointer' }}
-              onClick={() => toggleExpand(o.name)}
-            >
-              <input type="checkbox" checked={selected.has(o.name)} onClick={e => { e.stopPropagation(); toggleSel(o.name); }} style={{ accentColor: '#1f6feb' }} readOnly />
-              <div>
-                <div style={{ fontSize: 11, fontWeight: 500, color: '#f0f6fc' }}>{o.name}</div>
-                <div style={{ fontSize: 9, color: '#8b949e' }}>{o.title}{o.district ? ` · D${o.district}` : ''}{o.county ? ` · ${o.county}` : ''}</div>
-                <div style={{ fontSize: 9, color: '#8b949e', fontStyle: 'italic' }}>{o.directEmail || o.officeEmail || 'no email'}</div>
-              </div>
-              <div style={{ fontSize: 9, color: '#8b949e', paddingTop: 1 }}>{o.category}</div>
-              <div><span style={tagStyle(o.status)}>{STATUS_LABEL[o.status]}</span></div>
-              <div style={{ fontSize: 10, color: '#30363d' }}>{isOpen ? '▲' : '▼'}</div>
-            </div>
-            {isOpen && r && (
-              <div style={{ padding: '0 18px 8px 45px' }}>
-                <div style={{ background: '#0d1117', border: '1px solid #21262d', borderRadius: 5, padding: '8px 12px', fontSize: 10, lineHeight: 1.8 }}>
-                  {r.error
-                    ? <span style={{ color: '#e3b341' }}>Error: {r.error as string}</span>
-                    : <>
-                      {r.stillInOffice !== undefined && <div><span style={{ color: '#8b949e' }}>IN OFFICE </span>{r.stillInOffice ? <span style={{ color: '#3fb950' }}>Yes</span> : <span style={{ color: '#f85149' }}>No{r.replacedBy ? ` → ${r.replacedBy}` : ''}</span>}</div>}
-                      {r.currentTitle && <div><span style={{ color: '#8b949e' }}>TITLE </span>{r.currentTitle as string}</div>}
-                      {r.directEmail && <div><span style={{ color: '#8b949e' }}>DIRECT </span>{r.directEmail as string}</div>}
-                      {r.officeEmail && <div><span style={{ color: '#8b949e' }}>OFFICE </span>{r.officeEmail as string}</div>}
-                      {r.changes && r.changes !== 'No changes detected' && <div style={{ color: '#58a6ff' }}><span style={{ color: '#8b949e' }}>CHANGES </span>{r.changes as string}</div>}
-                      {r.flags && <div style={{ color: '#e3b341' }}><span style={{ color: '#8b949e' }}>FLAGS </span>{r.flags as string}</div>}
-                      {r.confidence && <div><span style={{ color: '#8b949e' }}>CONF </span><span style={{ color: r.confidence === 'high' ? '#3fb950' : r.confidence === 'medium' ? '#e3b341' : '#f85149' }}>{(r.confidence as string).toUpperCase()}</span></div>}
-                    </>
-                  }
-                </div>
-              </div>
-            )}
-          </div>
-        );
-      })}
-
-      {allOfficials.length > 0 && (
-        <div style={{ padding: '10px 18px', borderTop: '1px solid #161b22' }}>
-          <button style={btn()} onClick={addManually}>+ Add Manually</button>
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ── ScanTab ───────────────────────────────────────────────────────────────────
-
-interface ScanTabProps {
-  scanStatus: Record<string, ScanState>;
-  scanMeta: Record<string, CSScanMeta>;
-  newOfficials: CSOfficial[];
-  running: boolean;
-  runScan: (id: string) => void;
-  addNew: (o: CSOfficial) => void;
-  dismissNew: (name: string) => void;
-  btn: (v?: 'pri' | 'grn' | 'del' | 'def', d?: boolean) => React.CSSProperties;
-}
-
-function ScanTab({ scanStatus, scanMeta, newOfficials, running, runScan, addNew, dismissNew, btn }: ScanTabProps) {
-  return (
-    <div style={{ padding: '14px 20px' }}>
-      {needsCustomization() && (
-        <div style={{ background: '#1a0e00', border: '1px solid #bb8009', borderRadius: 7, padding: '12px 16px', marginBottom: 14 }}>
-          <div style={{ fontSize: 11, color: '#e3b341', fontWeight: 600, marginBottom: 4 }}>Scan targets need customization before use</div>
-          <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.8 }}>
-            The scan prompts contain placeholder text like <code style={{ color: '#C8A84B' }}>[YOUR STATE]</code> and <code style={{ color: '#C8A84B' }}>[CITY 1]</code>.<br />
-            Edit <code style={{ color: '#C8A84B' }}>src/App.tsx</code> and replace the bracketed placeholders in <code style={{ color: '#C8A84B' }}>SCAN_PROMPTS</code> with your actual state, counties, and city names.
-          </div>
-        </div>
-      )}
-      <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.6, marginBottom: 14 }}>
-        Each scan searches the live web for all officials in that category. New officials not in your list surface as add candidates.
-        Run after each election cycle, then <strong style={{ color: '#f0f6fc' }}>Export → InviteFlow</strong>.
-      </div>
-      {SCAN_TARGETS.map(t => {
-        const st = scanStatus[t.id];
-        const meta = scanMeta[t.id];
-        const fresh = newOfficials.filter(o => o._scanId === t.id);
-        return (
-          <div key={t.id} style={{ marginBottom: 11 }}>
-            <div style={{ background: '#0d1117', border: '1px solid #21262d', borderRadius: 7, padding: '11px 14px' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
-                <div style={{ flex: 1 }}>
-                  <div style={{ fontSize: 11, color: '#f0f6fc', fontWeight: 500 }}>{t.label}</div>
-                  <div style={{ fontSize: 10, color: '#8b949e', marginTop: 2 }}>{t.desc}</div>
-                  {meta && (
-                    <div style={{ fontSize: 10, color: '#8b949e', marginTop: 3 }}>
-                      Found {meta.total} · <span style={{ color: meta.confidence === 'high' ? '#3fb950' : meta.confidence === 'medium' ? '#e3b341' : '#f85149' }}>{meta.confidence}</span>
-                      {meta.notes && <span style={{ color: '#e3b341' }}> · {meta.notes}</span>}
-                    </div>
-                  )}
-                </div>
-                <div style={{ display: 'flex', gap: 5, alignItems: 'center', flexShrink: 0 }}>
-                  {st === 'scanning' && <span style={{ fontSize: 8, padding: '2px 5px', border: '1px solid #f59e0b', color: '#f59e0b', borderRadius: 3, animation: 'cs-pulse 1.4s ease-in-out infinite' }}>SCANNING</span>}
-                  {st === 'done' && <span style={{ fontSize: 8, padding: '2px 5px', border: '1px solid #238636', color: '#3fb950', borderRadius: 3 }}>DONE</span>}
-                  {st === 'error' && <span style={{ fontSize: 8, padding: '2px 5px', border: '1px solid #da3633', color: '#f85149', borderRadius: 3 }}>ERROR</span>}
-                  <button style={btn('pri', running)} onClick={() => runScan(t.id)} disabled={running}>{st === 'done' ? '↻ Re-scan' : '▶ Scan'}</button>
-                </div>
-              </div>
-            </div>
-            {fresh.length > 0 && (
-              <div style={{ margin: '3px 0 0 11px', paddingLeft: 11, borderLeft: '2px solid #1f6feb' }}>
-                <div style={{ fontSize: 9, color: '#58a6ff', letterSpacing: '0.1em', margin: '5px 0 4px' }}>NEW ({fresh.length})</div>
-                {fresh.map(o => (
-                  <div key={o.name} style={{ background: '#0c1a2e', border: '1px solid #1f4f99', borderRadius: 5, padding: '8px 11px', marginBottom: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <div>
-                      <div style={{ fontSize: 11, color: '#f0f6fc', fontWeight: 500 }}>{o.name}</div>
-                      <div style={{ fontSize: 9, color: '#8b949e' }}>{o.title}{o.district ? ` · D${o.district}` : ''}</div>
-                      {(o.directEmail || o.officeEmail) && <div style={{ fontSize: 9, color: '#8b949e' }}>{o.directEmail || o.officeEmail}</div>}
-                    </div>
-                    <div style={{ display: 'flex', gap: 4, marginLeft: 8 }}>
-                      <button style={btn('grn')} onClick={() => addNew(o)}>+ Add</button>
-                      <button style={btn()} onClick={() => dismissNew(o.name)}>✕</button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-            {st === 'done' && fresh.length === 0 && meta && (
-              <div style={{ margin: '3px 0 0 11px', padding: '4px 0 4px 11px', borderLeft: '2px solid #238636', fontSize: 10, color: '#3fb950' }}>
-                ✓ All {meta.total} already in list.
-              </div>
-            )}
-          </div>
-        );
-      })}
     </div>
   );
 }

--- a/src/contact-scout/src/api.ts
+++ b/src/contact-scout/src/api.ts
@@ -1,0 +1,39 @@
+import { CS_APIKEY_SK } from './constants';
+
+export async function callClaude(
+  key: string,
+  sys: string,
+  user: string,
+): Promise<Record<string, unknown>> {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': key,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+    },
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 1500,
+      system: sys,
+      tools: [{ type: 'web_search_20250305', name: 'web_search' }],
+      messages: [{ role: 'user', content: user }],
+    }),
+  });
+
+  if (res.status === 401) {
+    sessionStorage.removeItem(CS_APIKEY_SK);
+    throw new Error('Invalid API key');
+  }
+
+  const d = await res.json() as {
+    content?: Array<{ type: string; text?: string }>;
+    error?: { message: string };
+  };
+
+  if (d.error) throw new Error(d.error.message ?? 'API error');
+  const text = d.content?.find(b => b.type === 'text')?.text ?? '';
+  if (!text) throw new Error('No text response');
+  return JSON.parse(text.replace(/```json|```/g, '').trim()) as Record<string, unknown>;
+}

--- a/src/contact-scout/src/components/ApiKeyModal.tsx
+++ b/src/contact-scout/src/components/ApiKeyModal.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+
+interface Props {
+  apiKey: string;
+  onSave: (key: string) => void;
+  onClose: () => void;
+}
+
+export default function ApiKeyModal({ apiKey, onSave, onClose }: Props) {
+  const [draft, setDraft] = useState(apiKey);
+  const [err, setErr] = useState(false);
+
+  function save() {
+    if (!draft.startsWith('sk-ant-')) { setErr(true); return; }
+    onSave(draft);
+    onClose();
+  }
+
+  return (
+    <div className="cs-modal-backdrop" onClick={onClose}>
+      <div className="cs-modal" onClick={e => e.stopPropagation()}>
+        <div className="cs-modal-title">Claude API Key</div>
+        <div className="cs-modal-sub">
+          Enter your Anthropic API key. Get a free key at{' '}
+          <a href="https://console.anthropic.com/" target="_blank" rel="noreferrer" style={{ color: '#58a6ff' }}>
+            console.anthropic.com
+          </a>{' '}
+          → API Keys → Create Key. Starts with <code>sk-ant-</code>. Stored in session only.
+        </div>
+        <input
+          className={`cs-input${err ? ' err' : ''}`}
+          type="password"
+          placeholder="sk-ant-..."
+          value={draft}
+          onChange={e => { setDraft(e.target.value); setErr(false); }}
+          onKeyDown={e => e.key === 'Enter' && save()}
+          autoFocus
+        />
+        {err && <div style={{ fontSize: 10, color: '#f85149', marginTop: 6 }}>Must start with sk-ant-</div>}
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 12 }}>
+          <button className="cs-btn" onClick={onClose}>Cancel</button>
+          <button className="cs-btn pri" onClick={save}>Save</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/contact-scout/src/components/DiscoverTab.tsx
+++ b/src/contact-scout/src/components/DiscoverTab.tsx
@@ -1,0 +1,121 @@
+import { SCAN_TARGETS } from '../constants';
+import type { CSOfficial, CSScanMeta, CSJurisdiction, ScanState } from '../types';
+
+interface Props {
+  jx: CSJurisdiction;
+  scanStatus: Record<string, ScanState>;
+  scanMeta: Record<string, CSScanMeta>;
+  newOfficials: CSOfficial[];
+  running: boolean;
+  runScan: (id: string) => void;
+  addNew: (o: CSOfficial) => void;
+  dismissNew: (name: string) => void;
+  onConfigureJx: () => void;
+}
+
+export default function DiscoverTab({
+  jx, scanStatus, scanMeta, newOfficials,
+  running, runScan, addNew, dismissNew, onConfigureJx,
+}: Props) {
+  const jxMissing = !jx.state.trim();
+  const anyDone = Object.values(scanStatus).some(s => s === 'done');
+
+  return (
+    <div style={{ padding: '16px 20px' }}>
+      {jxMissing && (
+        <div style={{ background: '#1a0e00', border: '1px solid #bb8009', borderRadius: 7, padding: '12px 16px', marginBottom: 16 }}>
+          <div style={{ fontSize: 11, color: '#e3b341', fontWeight: 600, marginBottom: 4 }}>Scan targets need jurisdiction</div>
+          <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.7, marginBottom: 8 }}>
+            Configure your state, counties, and cities so scans target the right officials.
+          </div>
+          <button className="cs-btn sm" style={{ borderColor: '#bb8009', color: '#e3b341' }} onClick={onConfigureJx}>
+            Configure Jurisdiction
+          </button>
+        </div>
+      )}
+
+      {!jxMissing && newOfficials.length === 0 && !anyDone && (
+        <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.7, marginBottom: 16 }}>
+          Scan each category to discover current officials. New officials not already in your list will surface as add candidates.
+          Run after each election cycle, then head to <strong style={{ color: '#f0f6fc' }}>Officials</strong> to verify,
+          and <strong style={{ color: '#f0f6fc' }}>Export</strong> when ready.
+        </div>
+      )}
+
+      {SCAN_TARGETS.map(t => {
+        const st = scanStatus[t.id];
+        const meta = scanMeta[t.id];
+        const fresh = newOfficials.filter(o => o._scanId === t.id);
+
+        return (
+          <div key={t.id} style={{ marginBottom: 10 }}>
+            <div className="cs-card">
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8 }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 12, color: '#f0f6fc', fontWeight: 500, marginBottom: 2 }}>{t.label}</div>
+                  <div style={{ fontSize: 10, color: '#8b949e' }}>{t.desc}</div>
+                  {meta && (
+                    <div style={{ fontSize: 10, color: '#8b949e', marginTop: 4 }}>
+                      Found {meta.total} ·{' '}
+                      <span style={{ color: meta.confidence === 'high' ? '#3fb950' : meta.confidence === 'medium' ? '#e3b341' : '#f85149' }}>
+                        {meta.confidence}
+                      </span>
+                      {meta.notes && <span style={{ color: '#e3b341' }}> · {meta.notes}</span>}
+                    </div>
+                  )}
+                </div>
+                <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0 }}>
+                  {st === 'scanning' && (
+                    <span className="cs-tag" style={{ borderColor: '#f59e0b', color: '#f59e0b', animation: 'cs-pulse 1.4s ease-in-out infinite' }}>
+                      SCANNING
+                    </span>
+                  )}
+                  {st === 'done'  && <span className="cs-tag" style={{ borderColor: '#238636', color: '#3fb950' }}>DONE</span>}
+                  {st === 'error' && <span className="cs-tag" style={{ borderColor: '#da3633', color: '#f85149' }}>ERROR</span>}
+                  <button
+                    className="cs-btn sm pri"
+                    onClick={() => runScan(t.id)}
+                    disabled={running || jxMissing}
+                  >
+                    {st === 'done' ? '↻ Re-scan' : '▶ Scan'}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {fresh.length > 0 && (
+              <div style={{ margin: '3px 0 0 12px', paddingLeft: 12, borderLeft: '2px solid #1f6feb' }}>
+                <div style={{ fontSize: 9, color: '#58a6ff', letterSpacing: '0.1em', margin: '6px 0 5px' }}>
+                  NEW CANDIDATES ({fresh.length})
+                </div>
+                {fresh.map(o => (
+                  <div className="cs-new-card" key={o.name} style={{ marginBottom: 4 }}>
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ fontSize: 11, color: '#f0f6fc', fontWeight: 500 }}>{o.name}</div>
+                      <div style={{ fontSize: 9, color: '#8b949e' }}>
+                        {o.title}{o.district ? ` · D${o.district}` : ''}
+                      </div>
+                      {(o.directEmail || o.officeEmail) && (
+                        <div style={{ fontSize: 9, color: '#8b949e' }}>{o.directEmail || o.officeEmail}</div>
+                      )}
+                    </div>
+                    <div style={{ display: 'flex', gap: 5, flexShrink: 0 }}>
+                      <button className="cs-btn sm grn" onClick={() => addNew(o)}>+ Add</button>
+                      <button className="cs-btn sm" onClick={() => dismissNew(o.name)}>✕</button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {st === 'done' && fresh.length === 0 && meta && (
+              <div style={{ margin: '3px 0 0 12px', padding: '4px 0 4px 12px', borderLeft: '2px solid #238636', fontSize: 10, color: '#3fb950' }}>
+                ✓ All {meta.total} already in list.
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/contact-scout/src/components/ExportTab.tsx
+++ b/src/contact-scout/src/components/ExportTab.tsx
@@ -1,0 +1,74 @@
+import type { CSOfficial } from '../types';
+
+interface Props {
+  officials: CSOfficial[];
+  exportForInviteFlow: () => void;
+  exportBackup: () => void;
+  exportCSV: () => void;
+  importBackup: () => void;
+  clearAll: () => void;
+}
+
+export default function ExportTab({
+  officials, exportForInviteFlow, exportBackup, exportCSV, importBackup, clearAll,
+}: Props) {
+  const readyCount = officials.filter(
+    o => o.status !== 'left_office' && (o.officeEmail || o.directEmail),
+  ).length;
+
+  return (
+    <div style={{ padding: '16px 20px', maxWidth: 600 }}>
+      {/* InviteFlow export */}
+      <div className="cs-card" style={{ marginBottom: 10 }}>
+        <div style={{ fontSize: 12, color: '#f0f6fc', fontWeight: 600, marginBottom: 4 }}>Export to InviteFlow</div>
+        <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.7, marginBottom: 12 }}>
+          Downloads a JSON file that InviteFlow imports directly. Includes only officials with an
+          email address who are still in office.
+          {officials.length > 0 && (
+            <> <strong style={{ color: readyCount > 0 ? '#a371f7' : '#f85149' }}>
+              {readyCount} of {officials.length}
+            </strong> officials are eligible.</>
+          )}
+        </div>
+        <button className="cs-btn grn" onClick={exportForInviteFlow} disabled={readyCount === 0}>
+          ⬡ Export {readyCount > 0 ? `${readyCount} invitees` : '(no eligible officials)'} → InviteFlow JSON
+        </button>
+      </div>
+
+      {/* CSV */}
+      <div className="cs-card" style={{ marginBottom: 10 }}>
+        <div style={{ fontSize: 12, color: '#f0f6fc', fontWeight: 600, marginBottom: 4 }}>Download CSV</div>
+        <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.7, marginBottom: 12 }}>
+          All {officials.length} officials with full detail columns, suitable for spreadsheet analysis.
+        </div>
+        <button className="cs-btn" onClick={exportCSV} disabled={officials.length === 0}>↓ Download CSV</button>
+      </div>
+
+      {/* Backup / restore */}
+      <div className="cs-card" style={{ marginBottom: 10 }}>
+        <div style={{ fontSize: 12, color: '#f0f6fc', fontWeight: 600, marginBottom: 4 }}>Backup & Restore</div>
+        <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.7, marginBottom: 12 }}>
+          Save the full ContactScout state (officials, scan history, metadata) as JSON.
+          Restore it later or transfer to another device.
+        </div>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <button className="cs-btn" onClick={exportBackup} disabled={officials.length === 0}>↓ Save Backup</button>
+          <button className="cs-btn" onClick={importBackup}>↑ Restore from Backup</button>
+        </div>
+      </div>
+
+      {/* Danger zone */}
+      <div style={{ borderTop: '1px solid #161b22', marginTop: 20, paddingTop: 16 }}>
+        <div className="cs-section-label" style={{ marginBottom: 10 }}>DANGER ZONE</div>
+        <div style={{ background: '#0d1117', border: '1px solid #da3633', borderRadius: 8, padding: '14px 16px' }}>
+          <div style={{ fontSize: 11, color: '#f0f6fc', fontWeight: 500, marginBottom: 4 }}>Clear all data</div>
+          <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.6, marginBottom: 12 }}>
+            Permanently removes all officials, scan history, and results from this browser.
+            Cannot be undone — save a backup first.
+          </div>
+          <button className="cs-btn del" onClick={clearAll}>✕ Clear All ContactScout Data</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/contact-scout/src/components/JurisdictionModal.tsx
+++ b/src/contact-scout/src/components/JurisdictionModal.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { saveJurisdiction } from '../storage';
+import type { CSJurisdiction } from '../types';
+
+interface Props {
+  jx: CSJurisdiction;
+  onSave: (jx: CSJurisdiction) => void;
+  onClose: () => void;
+}
+
+const FIELDS: { key: keyof CSJurisdiction; label: string; placeholder: string }[] = [
+  { key: 'state',    label: 'State name',                 placeholder: 'e.g. California' },
+  { key: 'counties', label: 'Counties (comma-separated)', placeholder: 'e.g. San Francisco, Alameda' },
+  { key: 'city1',    label: 'City 1',                     placeholder: 'e.g. San Francisco' },
+  { key: 'city2',    label: 'City 2 (optional)',          placeholder: 'e.g. Oakland' },
+  { key: 'city3',    label: 'City 3 (optional)',          placeholder: 'e.g. Berkeley' },
+];
+
+export default function JurisdictionModal({ jx, onSave, onClose }: Props) {
+  const [draft, setDraft] = useState(jx);
+
+  function save() {
+    saveJurisdiction(draft);
+    onSave(draft);
+    onClose();
+  }
+
+  return (
+    <div className="cs-modal-backdrop" onClick={onClose}>
+      <div className="cs-modal" onClick={e => e.stopPropagation()}>
+        <div className="cs-modal-title">Jurisdiction Settings</div>
+        <div className="cs-modal-sub">
+          These values replace [YOUR STATE] and [CITY N] placeholders in scan prompts.
+          Saved locally in your browser.
+        </div>
+        {FIELDS.map(f => (
+          <div className="cs-field" key={f.key}>
+            <div className="cs-field-label">{f.label}</div>
+            <input
+              className="cs-input"
+              placeholder={f.placeholder}
+              value={draft[f.key]}
+              onChange={e => setDraft(prev => ({ ...prev, [f.key]: e.target.value }))}
+            />
+          </div>
+        ))}
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 8 }}>
+          <button className="cs-btn" onClick={onClose}>Cancel</button>
+          <button className="cs-btn pri" onClick={save}>Save</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/contact-scout/src/components/LogSidebar.tsx
+++ b/src/contact-scout/src/components/LogSidebar.tsx
@@ -1,0 +1,43 @@
+interface Props {
+  log: string[];
+  show: boolean;
+  onClose: () => void;
+}
+
+export default function LogSidebar({ log, show, onClose }: Props) {
+  return (
+    <div className={`cs-log-sidebar${show ? ' show' : ''}`}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexShrink: 0 }}>
+        <div className="cs-section-label">ACTIVITY LOG</div>
+        <button
+          className="cs-btn sm cs-log-btn"
+          onClick={onClose}
+          style={{ minHeight: 24, padding: '0 8px' }}
+          aria-label="Close log"
+        >
+          ✕
+        </button>
+      </div>
+      {log.length === 0 && (
+        <div style={{ fontSize: 10, color: '#7d8590', fontStyle: 'italic', marginTop: 6 }}>No activity yet.</div>
+      )}
+      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, marginTop: 6 }}>
+        {log.map((entry, i) => (
+          <div
+            key={i}
+            style={{
+              fontSize: 10,
+              color: i === 0 ? '#8b949e' : '#7d8590',
+              marginBottom: 3,
+              lineHeight: 1.5,
+              borderLeft: `2px solid ${i === 0 ? '#1f6feb' : 'transparent'}`,
+              paddingLeft: 5,
+            }}
+          >
+            {entry}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/contact-scout/src/components/OfficialsTab.tsx
+++ b/src/contact-scout/src/components/OfficialsTab.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react';
+import { CATS, STATUS_LABEL, STATUS_COLOR } from '../constants';
+import type { CSOfficial, CSStatus } from '../types';
+
+interface Props {
+  officials: CSOfficial[];
+  allOfficials: CSOfficial[];
+  activeCat: string;
+  setActiveCat: (c: string) => void;
+  selected: Set<string>;
+  toggleSel: (name: string) => void;
+  setSelected: React.Dispatch<React.SetStateAction<Set<string>>>;
+  running: boolean;
+  runVerify: (names: string[]) => void;
+  addManually: () => void;
+  onGoDiscover: () => void;
+}
+
+function tagStyle(status: CSStatus): React.CSSProperties {
+  return {
+    display: 'inline-flex', alignItems: 'center',
+    padding: '2px 7px', borderRadius: 4, border: `1px solid ${STATUS_COLOR[status]}`,
+    color: STATUS_COLOR[status], fontSize: 9, letterSpacing: '0.07em',
+    animation: status === 'checking' ? 'cs-pulse 1.4s ease-in-out infinite' : undefined,
+  };
+}
+
+export default function OfficialsTab({
+  officials, allOfficials, activeCat, setActiveCat,
+  selected, toggleSel, setSelected, running, runVerify, addManually, onGoDiscover,
+}: Props) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const names = officials.map(o => o.name);
+
+  function toggleExpand(name: string) {
+    setExpanded(prev => {
+      const n = new Set(prev);
+      n.has(name) ? n.delete(name) : n.add(name);
+      return n;
+    });
+  }
+
+  if (allOfficials.length === 0) {
+    return (
+      <div className="cs-empty">
+        <div className="cs-empty-title">No officials in your list yet.</div>
+        <div className="cs-empty-sub">Use Discover to scan for officials, then add them here.</div>
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'center', flexWrap: 'wrap' }}>
+          <button className="cs-btn pri" onClick={onGoDiscover}>Go to Discover</button>
+          <button className="cs-btn" onClick={addManually}>+ Add Manually</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Sticky action bar */}
+      <div style={{
+        padding: '8px 16px', borderBottom: '1px solid #161b22',
+        display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap',
+        position: 'sticky', top: 0, background: '#080c10', zIndex: 2,
+      }}>
+        <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', flex: 1, minWidth: 0 }}>
+          {CATS.map(c => (
+            <button
+              key={c}
+              className={`cs-pill${activeCat === c ? ' active' : ''}`}
+              onClick={() => setActiveCat(c)}
+            >
+              {c.toUpperCase()}
+            </button>
+          ))}
+        </div>
+        <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+          <button className="cs-btn sm" onClick={() => setSelected(new Set(names))} disabled={running}>Sel All</button>
+          <button className="cs-btn sm" onClick={() => setSelected(new Set())} disabled={running}>Clear</button>
+          <button className="cs-btn sm pri" onClick={() => runVerify([...selected])} disabled={running || selected.size === 0}>
+            ▶ ({selected.size})
+          </button>
+          <button className="cs-btn sm pri" onClick={() => runVerify(names)} disabled={running}>▶ All</button>
+        </div>
+      </div>
+
+      {officials.length === 0 && (
+        <div style={{ padding: '24px 20px', textAlign: 'center', color: '#8b949e', fontSize: 11 }}>
+          No officials in this category.
+        </div>
+      )}
+
+      {officials.map(o => {
+        const isOpen = expanded.has(o.name);
+        const r = o.result;
+        return (
+          <div key={o.name}>
+            <div className="cs-official-row" onClick={() => toggleExpand(o.name)}>
+              <input
+                type="checkbox"
+                checked={selected.has(o.name)}
+                onClick={e => { e.stopPropagation(); toggleSel(o.name); }}
+                style={{ accentColor: '#1f6feb', marginTop: 2 }}
+                readOnly
+              />
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontSize: 11, fontWeight: 500, color: '#f0f6fc', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {o.name}
+                </div>
+                <div style={{ fontSize: 9, color: '#8b949e' }}>
+                  {o.title}{o.district ? ` · D${o.district}` : ''}{o.county ? ` · ${o.county}` : ''}
+                </div>
+                <div style={{ fontSize: 9, color: '#8b949e', fontStyle: 'italic' }}>
+                  {o.directEmail || o.officeEmail || 'no email'}
+                </div>
+              </div>
+              <div className="cs-official-cat">
+                <span style={{ fontSize: 9, color: '#8b949e' }}>{o.category}</span>
+              </div>
+              <div><span style={tagStyle(o.status)}>{STATUS_LABEL[o.status]}</span></div>
+              <div style={{ fontSize: 10, color: '#30363d' }}>{isOpen ? '▲' : '▼'}</div>
+            </div>
+
+            {isOpen && r && (
+              <div className="cs-official-expand">
+                {r.error
+                  ? <span style={{ color: '#e3b341' }}>Error: {r.error as string}</span>
+                  : <>
+                    {r.stillInOffice !== undefined && (
+                      <div>
+                        <span style={{ color: '#8b949e' }}>IN OFFICE </span>
+                        {r.stillInOffice
+                          ? <span style={{ color: '#3fb950' }}>Yes</span>
+                          : <span style={{ color: '#f85149' }}>No{r.replacedBy ? ` → ${r.replacedBy}` : ''}</span>}
+                      </div>
+                    )}
+                    {r.currentTitle && <div><span style={{ color: '#8b949e' }}>TITLE </span>{r.currentTitle as string}</div>}
+                    {r.directEmail  && <div><span style={{ color: '#8b949e' }}>DIRECT </span>{r.directEmail as string}</div>}
+                    {r.officeEmail  && <div><span style={{ color: '#8b949e' }}>OFFICE </span>{r.officeEmail as string}</div>}
+                    {r.changes && r.changes !== 'No changes detected' && (
+                      <div><span style={{ color: '#8b949e' }}>CHANGES </span><span style={{ color: '#58a6ff' }}>{r.changes as string}</span></div>
+                    )}
+                    {r.flags && (
+                      <div><span style={{ color: '#8b949e' }}>FLAGS </span><span style={{ color: '#e3b341' }}>{r.flags as string}</span></div>
+                    )}
+                    {r.confidence && (
+                      <div>
+                        <span style={{ color: '#8b949e' }}>CONF </span>
+                        <span style={{ color: r.confidence === 'high' ? '#3fb950' : r.confidence === 'medium' ? '#e3b341' : '#f85149' }}>
+                          {(r.confidence as string).toUpperCase()}
+                        </span>
+                      </div>
+                    )}
+                  </>
+                }
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      <div style={{ padding: '10px 18px', borderTop: '1px solid #161b22' }}>
+        <button className="cs-btn sm" onClick={addManually}>+ Add Manually</button>
+      </div>
+    </div>
+  );
+}

--- a/src/contact-scout/src/components/PasswordGate.tsx
+++ b/src/contact-scout/src/components/PasswordGate.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { CSS } from '../css';
+import { SCOUT_PW } from '../constants';
+
+interface Props {
+  onUnlock: () => void;
+}
+
+export default function PasswordGate({ onUnlock }: Props) {
+  const [pw, setPw] = useState('');
+  const [err, setErr] = useState(false);
+
+  function attempt() {
+    if (pw === SCOUT_PW) { onUnlock(); }
+    else { setErr(true); setPw(''); }
+  }
+
+  return (
+    <div style={{ height: '100dvh', background: '#080c10', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: "'Courier New', monospace", padding: 20 }}>
+      <style>{CSS}</style>
+      <div style={{ background: '#0d1117', border: '1px solid #21262d', borderRadius: 10, padding: 32, width: '100%', maxWidth: 380 }}>
+        <div style={{ fontSize: 17, fontWeight: 800, color: '#f0f6fc', letterSpacing: '-0.02em', marginBottom: 2 }}>CONTACT SCOUT</div>
+        <div style={{ fontSize: 9, color: '#8b949e', letterSpacing: '0.12em', marginBottom: 20 }}>by Lenya Chan · ELECTED OFFICIALS DISCOVERY</div>
+        <div style={{ fontSize: 11, color: '#8b949e', lineHeight: 1.7, marginBottom: 16 }}>
+          ContactScout uses Claude AI to discover and verify elected officials. Enter your access code to continue.
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <input
+            className={`cs-input${err ? ' err' : ''}`}
+            type="password"
+            placeholder="Access code"
+            value={pw}
+            onChange={e => { setPw(e.target.value); setErr(false); }}
+            onKeyDown={e => e.key === 'Enter' && attempt()}
+            autoFocus
+            style={{ flex: 1 }}
+          />
+          <button className="cs-btn pri" onClick={attempt}>Unlock</button>
+        </div>
+        {err && <div style={{ fontSize: 10, color: '#f85149', marginTop: 8 }}>Incorrect access code.</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/contact-scout/src/constants.ts
+++ b/src/contact-scout/src/constants.ts
@@ -1,0 +1,36 @@
+import type { CSStatus } from './types';
+
+export const CS_LS_KEY = 'contactscout_state';
+export const CS_JX_KEY = 'contactscout_jurisdiction';
+export const CS_APIKEY_SK = 'cs_api_key';
+export const SCOUT_PW = 'scout2025';
+
+export const SCAN_TARGETS = [
+  { id: 'us-congress',  label: 'US Congress',          desc: 'All current US reps + senators for your state' },
+  { id: 'state-exec',   label: 'State Executive',       desc: 'Governor, Lt. Gov, AG, Treasurer, Auditor, commissioners' },
+  { id: 'state-senate', label: 'State Senate',          desc: 'Full current state senate roster' },
+  { id: 'state-house',  label: 'State House',           desc: 'House members for your tracked counties' },
+  { id: 'city-1',       label: 'City Council — City 1', desc: 'Current mayor and all council members' },
+  { id: 'city-2',       label: 'City Council — City 2', desc: 'Current mayor and all council members' },
+  { id: 'city-3',       label: 'City Council — City 3', desc: 'Current mayor and all council members' },
+] as const;
+
+export const VERIFY_SYS =
+  `Verify this elected official for 2025-2026 using web search. Respond ONLY with valid JSON no markdown:\n` +
+  `{"stillInOffice":true,"currentTitle":"","directEmail":"","officeEmail":"","officePhone":"","changes":"No changes detected","flags":"","replacedBy":"","confidence":"high"}`;
+
+export const SCAN_SYS =
+  `Find all current elected officials for 2025-2026 using web search. Respond ONLY with valid JSON no markdown:\n` +
+  `{"officials":[{"name":"","title":"","district":"","county":"","category":"US Senate|US House|Executive|State Senate|House|City Council","directEmail":"","officeEmail":"","officePhone":""}],"confidence":"high","notes":""}`;
+
+export const CATS = ['All', 'US Senate', 'US House', 'Executive', 'State Senate', 'House', 'City Council'] as const;
+
+export const STATUS_LABEL: Record<CSStatus, string> = {
+  pending: 'PENDING', checking: 'CHECKING', done: 'VERIFIED',
+  changed: 'CHANGED', left_office: 'LEFT OFFICE', error: 'ERROR',
+};
+
+export const STATUS_COLOR: Record<CSStatus, string> = {
+  pending: '#8b949e', checking: '#f59e0b', done: '#3fb950',
+  changed: '#58a6ff', left_office: '#f85149', error: '#e3b341',
+};

--- a/src/contact-scout/src/css.ts
+++ b/src/contact-scout/src/css.ts
@@ -1,0 +1,178 @@
+export const CSS = `
+@keyframes cs-pulse { 0%,100%{opacity:1} 50%{opacity:.35} }
+@keyframes cs-spin   { to{transform:rotate(360deg)} }
+
+.cs-root {
+  height: 100dvh; display: flex; flex-direction: column;
+  background: #080c10; font-family: 'Courier New', monospace;
+  font-size: 11px; overflow: hidden; color: #c9d1d9;
+}
+
+/* ── Buttons ── */
+.cs-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 5px;
+  min-height: 36px; padding: 0 14px; border-radius: 6px;
+  border: 1px solid #30363d; background: transparent; color: #8b949e;
+  font-family: 'Courier New', monospace; font-size: 11px; letter-spacing: .04em;
+  cursor: pointer; white-space: nowrap;
+  transition: border-color .15s, color .15s, background .15s;
+}
+.cs-btn:hover:not(:disabled) { border-color: #58a6ff; color: #f0f6fc; }
+.cs-btn:disabled              { opacity: .4; cursor: not-allowed; }
+.cs-btn:focus-visible         { outline: 2px solid #58a6ff; outline-offset: 2px; }
+
+.cs-btn.pri { background: #1f6feb; border-color: #1f6feb; color: #fff; }
+.cs-btn.pri:hover:not(:disabled) { background: #388bfd; border-color: #388bfd; }
+.cs-btn.grn { background: #238636; border-color: #238636; color: #fff; }
+.cs-btn.grn:hover:not(:disabled) { background: #2ea043; border-color: #2ea043; }
+.cs-btn.del { border-color: #da3633; color: #f85149; }
+.cs-btn.del:hover:not(:disabled) { background: rgba(218,54,51,.1); }
+.cs-btn.sm  { min-height: 28px; padding: 0 10px; font-size: 10px; }
+
+/* ── Input ── */
+.cs-input {
+  width: 100%; background: #010409; border: 1px solid #30363d; border-radius: 5px;
+  color: #c9d1d9; font-family: 'Courier New', monospace; font-size: 11px;
+  padding: 8px 10px; outline: none;
+}
+.cs-input:focus         { border-color: #1f6feb; }
+.cs-input:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
+.cs-input.err           { border-color: #da3633; }
+
+/* ── Layout shell ── */
+.cs-layout { display: flex; flex: 1; overflow: hidden; min-height: 0; }
+.cs-main   { flex: 1; overflow-y: auto; min-height: 0; min-width: 0; }
+
+/* ── Log sidebar (always visible ≥ 1024px) ── */
+.cs-log-sidebar {
+  width: 240px; flex-shrink: 0; overflow-y: auto; padding: 12px 14px;
+  background: #050709; border-left: 1px solid #161b22;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.cs-log-btn { display: none; }
+
+/* ── Tab bar ── */
+.cs-tab-bar {
+  display: flex; border-bottom: 1px solid #21262d; flex-shrink: 0;
+  overflow-x: auto; scrollbar-width: none;
+}
+.cs-tab-bar::-webkit-scrollbar { display: none; }
+.cs-tab {
+  background: none; border: none; border-bottom: 2px solid transparent;
+  padding: 10px 18px; font-family: 'Courier New', monospace;
+  font-size: 10px; letter-spacing: .06em; color: #8b949e; cursor: pointer; white-space: nowrap;
+}
+.cs-tab.active           { color: #f0f6fc; border-bottom-color: #1f6feb; }
+.cs-tab:hover            { color: #c9d1d9; }
+.cs-tab:focus-visible    { outline: 2px solid #58a6ff; outline-offset: -2px; }
+
+/* ── Banners ── */
+.cs-banner {
+  padding: 12px 20px; flex-shrink: 0;
+  display: flex; gap: 12px; flex-wrap: wrap; align-items: flex-start;
+}
+.cs-banner.info { background: #060d1a; border-bottom: 1px solid #1f6feb; }
+.cs-banner.warn { background: #1a0e00; border-bottom: 1px solid #bb8009; }
+.cs-banner-body { flex: 1; min-width: 0; }
+.cs-banner-title { font-size: 11px; font-weight: 600; margin-bottom: 3px; }
+.cs-banner.info .cs-banner-title { color: #58a6ff; }
+.cs-banner.warn .cs-banner-title { color: #e3b341; }
+.cs-banner-text  { font-size: 10px; color: #8b949e; line-height: 1.7; margin-bottom: 8px; }
+
+/* ── Stats bar ── */
+.cs-stats {
+  padding: 5px 20px; border-bottom: 1px solid #161b22;
+  display: flex; gap: 14px; flex-wrap: wrap; align-items: center; flex-shrink: 0;
+}
+.cs-stat        { display: flex; align-items: center; gap: 4px; }
+.cs-stat-dot    { width: 5px; height: 5px; border-radius: 50%; flex-shrink: 0; }
+.cs-stat-label  { font-size: 9px; color: #8b949e; letter-spacing: .1em; }
+.cs-stat-val    { font-size: 12px; font-weight: 500; }
+
+.cs-progress-wrap  { margin-left: auto; display: flex; align-items: center; gap: 6px; }
+.cs-progress-track { width: 90px; height: 3px; background: #21262d; border-radius: 2px; overflow: hidden; }
+.cs-progress-fill  { height: 100%; background: #1f6feb; border-radius: 2px; transition: width .2s; }
+
+/* ── Cards ── */
+.cs-card { background: #0d1117; border: 1px solid #21262d; border-radius: 8px; padding: 14px 16px; }
+
+/* ── Section label ── */
+.cs-section-label { font-size: 9px; color: #8b949e; letter-spacing: .14em; text-transform: uppercase; }
+
+/* ── Category pills ── */
+.cs-pill {
+  display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 20px;
+  border: 1px solid #21262d; background: transparent; color: #8b949e;
+  font-family: 'Courier New', monospace; font-size: 9px; letter-spacing: .07em;
+  cursor: pointer; white-space: nowrap;
+}
+.cs-pill:hover           { border-color: #30363d; color: #c9d1d9; }
+.cs-pill.active          { border-color: #1f6feb; background: #0c2d6b; color: #58a6ff; }
+.cs-pill:focus-visible   { outline: 2px solid #58a6ff; outline-offset: 2px; }
+
+/* ── Status tag ── */
+.cs-tag {
+  display: inline-flex; align-items: center; padding: 2px 7px;
+  border-radius: 4px; border: 1px solid; font-size: 9px; letter-spacing: .07em;
+}
+
+/* ── New-candidate card ── */
+.cs-new-card {
+  background: #0c1a2e; border: 1px solid #1f4f99; border-radius: 6px;
+  padding: 10px 12px; display: flex; justify-content: space-between; align-items: center; gap: 8px;
+}
+
+/* ── Officials list row ── */
+.cs-official-row {
+  display: grid; grid-template-columns: 20px 1fr 105px 90px 14px;
+  gap: 8px; padding: 10px 18px; cursor: pointer;
+  border-bottom: 1px solid #0d1117; align-items: start;
+}
+.cs-official-row:hover   { background: #0d1117; }
+.cs-official-cat         { padding-top: 1px; }
+.cs-official-expand {
+  background: #0d1117; border: 1px solid #21262d; border-radius: 5px;
+  padding: 10px 12px; font-size: 10px; line-height: 1.8;
+  margin: 0 18px 8px 46px;
+}
+
+/* ── Empty state ── */
+.cs-empty       { padding: 48px 24px; text-align: center; }
+.cs-empty-title { font-size: 13px; color: #c9d1d9; margin-bottom: 8px; }
+.cs-empty-sub   { font-size: 11px; color: #8b949e; margin-bottom: 16px; }
+
+/* ── Modal ── */
+.cs-modal-backdrop {
+  position: fixed; inset: 0; background: rgba(0,0,0,.8); z-index: 50;
+  display: flex; align-items: center; justify-content: center; padding: 20px;
+}
+.cs-modal {
+  background: #0d1117; border: 1px solid #30363d; border-radius: 10px;
+  padding: 24px; width: 100%; max-width: 460px; max-height: 90dvh; overflow-y: auto;
+}
+.cs-modal-title { font-size: 13px; color: #f0f6fc; font-weight: 700; margin-bottom: 4px; }
+.cs-modal-sub   { font-size: 10px; color: #8b949e; line-height: 1.7; margin-bottom: 16px; }
+.cs-field       { margin-bottom: 12px; }
+.cs-field-label {
+  font-size: 9px; color: #8b949e; letter-spacing: .14em;
+  text-transform: uppercase; margin-bottom: 5px;
+}
+
+/* ── Responsive ── */
+@media (max-width: 1023px) {
+  .cs-log-sidebar { display: none; }
+  .cs-log-sidebar.show {
+    display: flex; position: fixed; bottom: 0; left: 0; right: 0;
+    width: 100%; height: 50dvh; z-index: 40;
+    border-left: none; border-top: 1px solid #21262d;
+  }
+  .cs-log-btn { display: inline-flex; }
+}
+
+@media (max-width: 767px) {
+  .cs-btn    { min-height: 44px; padding: 0 18px; font-size: 13px; border-radius: 8px; }
+  .cs-btn.sm { min-height: 36px; padding: 0 14px; font-size: 11px; }
+  .cs-official-row { grid-template-columns: 20px 1fr 90px 14px; }
+  .cs-official-cat { display: none; }
+}
+`;

--- a/src/contact-scout/src/storage.ts
+++ b/src/contact-scout/src/storage.ts
@@ -1,0 +1,31 @@
+import { CS_LS_KEY, CS_JX_KEY } from './constants';
+import type { CSPersistedState, CSJurisdiction } from './types';
+
+const EMPTY_STATE: CSPersistedState = { officials: [], newOfficials: [], scanStatus: {}, scanMeta: {} };
+const EMPTY_JX: CSJurisdiction = { state: '', counties: '', city1: '', city2: '', city3: '' };
+
+export function loadCSState(): CSPersistedState {
+  try {
+    const raw = localStorage.getItem(CS_LS_KEY);
+    return raw ? (JSON.parse(raw) as CSPersistedState) : { ...EMPTY_STATE };
+  } catch {
+    return { ...EMPTY_STATE };
+  }
+}
+
+export function saveCSState(s: CSPersistedState) {
+  try { localStorage.setItem(CS_LS_KEY, JSON.stringify(s)); } catch { /* quota */ }
+}
+
+export function loadJurisdiction(): CSJurisdiction {
+  try {
+    const raw = localStorage.getItem(CS_JX_KEY);
+    return raw ? (JSON.parse(raw) as CSJurisdiction) : { ...EMPTY_JX };
+  } catch {
+    return { ...EMPTY_JX };
+  }
+}
+
+export function saveJurisdiction(jx: CSJurisdiction) {
+  try { localStorage.setItem(CS_JX_KEY, JSON.stringify(jx)); } catch { /* quota */ }
+}

--- a/src/contact-scout/src/types.ts
+++ b/src/contact-scout/src/types.ts
@@ -1,6 +1,14 @@
 export type CSStatus = 'pending' | 'checking' | 'done' | 'changed' | 'left_office' | 'error';
 export type ScanState = 'idle' | 'scanning' | 'done' | 'error';
 
+export interface CSJurisdiction {
+  state: string;
+  counties: string;
+  city1: string;
+  city2: string;
+  city3: string;
+}
+
 export interface CSOfficial {
   name: string;
   title: string;

--- a/src/contact-scout/src/utils.ts
+++ b/src/contact-scout/src/utils.ts
@@ -1,0 +1,49 @@
+import type { CSOfficial, CSJurisdiction, InviteeExport } from './types';
+
+export const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+export function officialToInvitee(o: CSOfficial): InviteeExport {
+  const parts = o.name.trim().split(/\s+/);
+  return {
+    firstName: parts[0] ?? '',
+    lastName: parts.slice(1).join(' '),
+    title: o.title,
+    category: o.category,
+    email: o.officeEmail || o.directEmail || '',
+    rsvpLink: '',
+    inviteStatus: 'pending',
+    sentAt: '',
+    rsvpStatus: 'No Response',
+    rsvpDate: '',
+    notes: [o.district, o.county].filter(Boolean).join(' · '),
+  };
+}
+
+export function buildScanPrompts(jx: CSJurisdiction): Record<string, string> {
+  const st = jx.state.trim()    || '[YOUR STATE]';
+  const co = jx.counties.trim() || '[YOUR COUNTIES]';
+  const c1 = jx.city1.trim()    || '[CITY 1]';
+  const c2 = jx.city2.trim()    || '[CITY 2]';
+  const c3 = jx.city3.trim()    || '[CITY 3]';
+  return {
+    'us-congress':  `Search for every current US Congress member for ${st} (119th Congress 2025-2026): all House reps + 2 senators. For each: full name, title, district, official scheduler/contact email.`,
+    'state-exec':   `Search for all current ${st} statewide executive elected officials as of 2025: Governor, Lt. Governor, AG, Treasurer, Auditor, Superintendent of Public Instruction, and other commissioners. Full name, title, email.`,
+    'state-senate': `Search for all current ${st} State Senate members as of 2025. Full name, district, official email.`,
+    'state-house':  `Search for all current ${st} House members for ${co} as of 2025. Full name, district, county, official email.`,
+    'city-1':       `Search for current ${c1} City Council as of 2025. Mayor + every council member: full name, title, official email.`,
+    'city-2':       `Search for current ${c2} City Council as of 2025. Mayor + every council member: full name, title, official email.`,
+    'city-3':       `Search for current ${c3} City Council as of 2025. Mayor + every council member: full name, title, official email.`,
+  };
+}
+
+export function downloadBlob(blob: Blob, filename: string) {
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+export function todaySlug() {
+  return new Date().toISOString().slice(0, 10);
+}


### PR DESCRIPTION
## Summary

- Splits the monolithic 798-line `App.tsx` into 13 focused modules following SRP
- Implements the full ContactScout redesign: mobile-first responsive layout, 3-tab sequential workflow, jurisdiction settings panel (P1 task from TASKS.md)

## Module structure

| File | Responsibility |
|------|---------------|
| `constants.ts` | Static data: SCAN_TARGETS, STATUS_LABEL/COLOR, system prompts |
| `types.ts` | Adds `CSJurisdiction` interface |
| `storage.ts` | `localStorage` load/save for app state and jurisdiction |
| `utils.ts` | Pure helpers: `officialToInvitee`, `buildScanPrompts`, `downloadBlob` |
| `api.ts` | Pure `callClaude(key, sys, user)` — no React dependencies |
| `css.ts` | Full design-system CSS string (references `docs/DESIGN.md`) |
| `components/PasswordGate.tsx` | Password gate screen |
| `components/ApiKeyModal.tsx` | Claude API key entry modal |
| `components/JurisdictionModal.tsx` | Jurisdiction settings form (state / counties / cities) |
| `components/LogSidebar.tsx` | Activity log — fixed sidebar ≥1024px, bottom sheet on mobile |
| `components/DiscoverTab.tsx` | Scan targets + new candidate queue (replaces ScanTab) |
| `components/OfficialsTab.tsx` | Verify officials list (replaces VerifyTab) |
| `components/ExportTab.tsx` | InviteFlow export / CSV / backup / danger zone (new) |
| `App.tsx` | Thin orchestrator: state hooks + callbacks, no inline styles |

## UX changes

- 3-tab sequential workflow: **Discover → Officials → Export**
- Jurisdiction stored in `localStorage` key `contactscout_jurisdiction`; `buildScanPrompts(jx)` replaces hardcoded `[YOUR STATE]` / `[CITY N]` placeholders at runtime
- Mobile-first CSS: 44px touch targets on mobile, log sidebar becomes 50dvh bottom sheet below 1024px, category column hidden below 768px
- Onboarding banners guide first-run (no key → info banner; key set, no jurisdiction → warning banner)
- Export tab consolidates all data actions out of the header

## Test plan

- [ ] `npm run build` passes with zero TypeScript errors
- [ ] Password gate unlocks correctly
- [ ] API Key modal saves to sessionStorage and clears on 401
- [ ] Jurisdiction modal saves to localStorage; scan prompts reflect values
- [ ] Discover tab: scan runs, new candidates appear, Add/Dismiss work
- [ ] Officials tab: category pills filter, Verify Selected / Verify All run, expandable detail rows open
- [ ] Export tab: InviteFlow JSON, CSV, backup download; restore from backup; Clear all with confirm
- [ ] Log sidebar: hidden on mobile, toggled via Log button; always visible ≥ 1024px
- [ ] Layout does not overflow at 375px or 768px viewport

https://claude.ai/code/session_01KUj23kDPTXcT734ECT98nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUj23kDPTXcT734ECT98nC)_