### PR TITLE
Apply ContactScout design language to InviteFlow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "inviteflow-v3",
-  "version": "3.0.0",
+  "name": "inviteflow-v3.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "inviteflow-v3",
-      "version": "3.0.0",
+      "name": "inviteflow-v3.1",
+      "version": "3.1.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.4",
         "@tiptap/react": "^2.11.7",
@@ -925,9 +925,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -940,9 +937,6 @@
       "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -957,9 +951,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -972,9 +963,6 @@
       "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -989,9 +977,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1004,9 +989,6 @@
       "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1021,9 +1003,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1036,9 +1015,6 @@
       "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1053,9 +1029,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1068,9 +1041,6 @@
       "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1085,9 +1055,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1101,9 +1068,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1116,9 +1080,6 @@
       "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1329,9 +1290,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1347,9 +1305,6 @@
       "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1367,9 +1322,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1385,9 +1337,6 @@
       "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2726,9 +2675,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2748,9 +2694,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2772,9 +2715,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2794,9 +2734,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/src/inviteflow/App.tsx
+++ b/src/inviteflow/App.tsx
@@ -10,25 +10,25 @@ import TrackerTab from './tabs/TrackerTab';
 import SyncTab from './tabs/SyncTab';
 
 const TABS: { id: TabId; label: string }[] = [
-  { id: 'events', label: 'Events' },
-  { id: 'setup', label: 'Setup' },
+  { id: 'events',   label: 'Events'   },
+  { id: 'setup',    label: 'Setup'    },
   { id: 'invitees', label: 'Invitees' },
-  { id: 'compose', label: 'Compose' },
-  { id: 'send', label: 'Send' },
-  { id: 'tracker', label: 'Tracker' },
-  { id: 'sync', label: 'Sync' },
+  { id: 'compose',  label: 'Compose'  },
+  { id: 'send',     label: 'Send'     },
+  { id: 'tracker',  label: 'Tracker'  },
+  { id: 'sync',     label: 'Sync'     },
 ];
 
 function TabContent() {
   const { tab } = useAppState();
   switch (tab) {
-    case 'events': return <EventsTab />;
-    case 'setup': return <SetupTab />;
+    case 'events':   return <EventsTab />;
+    case 'setup':    return <SetupTab />;
     case 'invitees': return <InviteesTab />;
-    case 'compose': return <ComposeTab />;
-    case 'send': return <SendTab />;
-    case 'tracker': return <TrackerTab />;
-    case 'sync': return <SyncTab />;
+    case 'compose':  return <ComposeTab />;
+    case 'send':     return <SendTab />;
+    case 'tracker':  return <TrackerTab />;
+    case 'sync':     return <SyncTab />;
   }
 }
 
@@ -45,33 +45,44 @@ function AppInner() {
   }
 
   return (
-    <div className="h-screen font-mono flex flex-col overflow-hidden" style={{ background: 'var(--bg-root)', color: 'var(--text-base)' }}>
+    <div
+      className="h-screen font-mono flex flex-col overflow-hidden"
+      style={{ background: 'var(--bg-root)', color: 'var(--text-base)' }}
+    >
       {/* Header */}
-      <header className="px-4 py-2 flex items-center gap-3 shrink-0" style={{ background: 'var(--bg-surface)', borderBottom: '1px solid var(--border)' }}>
+      <header
+        className="px-4 py-2 flex items-center gap-3 shrink-0"
+        style={{ background: 'var(--bg-surface)', borderBottom: '1px solid var(--border)' }}
+      >
         {/* Left zone */}
-        <span className="font-black text-sm tracking-tight" style={{ color: 'var(--text-heading)' }}>INVITEFLOW</span>
-        <span className="text-[9px] tracking-[0.12em]" style={{ color: 'var(--text-muted)' }}>v3.1</span>
+        <span
+          className="font-black text-sm tracking-tight"
+          style={{ color: 'var(--text-heading)' }}
+        >
+          INVITEFLOW
+        </span>
+        <span
+          className="text-[9px] tracking-[0.12em]"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          v3.1
+        </span>
         {activeEvent && (
-          <span className="text-[10px] text-[#C8A84B] tracking-[0.08em] pl-3 truncate max-w-[160px]" style={{ borderLeft: '1px solid var(--border)' }}>
+          <span
+            className="text-[10px] tracking-[0.08em] pl-3 truncate max-w-[160px]"
+            style={{ color: 'var(--gold)', borderLeft: '1px solid var(--border)' }}
+          >
             {activeEvent.name}
           </span>
         )}
         {state.unsaved && (
-          <span className="text-[9px] tracking-[0.1em]" style={{ color: 'var(--text-muted)' }}>●</span>
+          <span className="text-[9px] tracking-[0.1em]" style={{ color: 'var(--text-muted)' }}>
+            ●
+          </span>
         )}
 
         {/* Right zone */}
-        <div className="ml-auto flex items-center gap-2">
-          {/* Theme toggle */}
-          <button
-            onClick={() => dispatch({ type: 'TOGGLE_DARK' })}
-            aria-label={state.darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-sm rounded"
-            style={{ color: 'var(--text-muted)' }}
-          >
-            {state.darkMode ? '☀' : '☾'}
-          </button>
-
+        <div className="ml-auto flex items-center gap-1">
           {/* Desktop nav */}
           <nav className="hidden md:flex gap-1" role="tablist">
             {TABS.map(t => (
@@ -80,10 +91,7 @@ function AppInner() {
                 role="tab"
                 aria-selected={state.tab === t.id}
                 onClick={() => selectTab(t.id)}
-                className="min-h-[44px] px-2.5 py-1 rounded border text-[10px] font-mono tracking-[0.07em] uppercase cursor-pointer"
-                style={state.tab === t.id
-                  ? { background: 'var(--accent)', borderColor: 'var(--accent)', color: '#fff' }
-                  : { background: 'transparent', borderColor: 'transparent', color: 'var(--text-secondary)' }}
+                className={`if-nav-tab${state.tab === t.id ? ' active' : ''}`}
               >
                 {t.label}
               </button>
@@ -92,8 +100,7 @@ function AppInner() {
 
           {/* Hamburger (mobile only) */}
           <button
-            className="md:hidden min-h-[44px] min-w-[44px] flex items-center justify-center"
-            style={{ color: 'var(--text-secondary)' }}
+            className="md:hidden if-btn sm"
             onClick={() => setDrawerOpen(true)}
             aria-label="Open navigation"
           >
@@ -105,27 +112,28 @@ function AppInner() {
       {/* Mobile drawer */}
       {drawerOpen && (
         <>
-          {/* Backdrop */}
           <div
-            className="fixed inset-0 bg-black/40 z-40 md:hidden"
+            className="fixed inset-0 bg-black/50 z-40 md:hidden"
             onClick={() => setDrawerOpen(false)}
           />
-          {/* Drawer */}
           <div
             role="dialog"
             aria-modal="true"
             aria-label="Navigation"
-            className="fixed inset-y-0 left-0 w-64 z-50 flex flex-col md:hidden motion-safe:transition-transform"
+            className="fixed inset-y-0 left-0 w-56 z-50 flex flex-col md:hidden"
             style={{ background: 'var(--bg-surface)', borderRight: '1px solid var(--border)' }}
           >
-            <div className="flex items-center justify-between px-4 py-3" style={{ borderBottom: '1px solid var(--border)' }}>
-              <span className="font-black text-sm tracking-tight" style={{ color: 'var(--text-heading)' }}>INVITEFLOW</span>
-              <button
-                onClick={() => setDrawerOpen(false)}
-                aria-label="Close navigation"
-                className="min-h-[44px] min-w-[44px] flex items-center justify-center"
-                style={{ color: 'var(--text-muted)' }}
+            <div
+              className="flex items-center justify-between px-4 py-3"
+              style={{ borderBottom: '1px solid var(--border)' }}
+            >
+              <span
+                className="font-black text-sm tracking-tight"
+                style={{ color: 'var(--text-heading)' }}
               >
+                INVITEFLOW
+              </span>
+              <button className="if-btn sm" onClick={() => setDrawerOpen(false)} aria-label="Close">
                 ✕
               </button>
             </div>

--- a/src/inviteflow/main.tsx
+++ b/src/inviteflow/main.tsx
@@ -8,6 +8,7 @@ import 'primeflex/primeflex.css';
 import './styles/primereact-reset.css';
 import './styles/tiptap.css';
 import './theme.css';
+import './styles/if.css';
 import App from './App';
 
 const root = document.getElementById('root');

--- a/src/inviteflow/state/reducer.ts
+++ b/src/inviteflow/state/reducer.ts
@@ -2,7 +2,7 @@ import type { AppState } from '../types';
 import type { Action } from './actions';
 
 function loadDarkPref(): boolean {
-  return localStorage.getItem('inviteflow_theme') === 'dark';
+  return localStorage.getItem('inviteflow_theme') !== 'light';
 }
 
 export const INITIAL_STATE: AppState = {

--- a/src/inviteflow/styles/if.css
+++ b/src/inviteflow/styles/if.css
@@ -1,0 +1,242 @@
+/* InviteFlow design system — mirrors ContactScout dark language */
+
+/* === BUTTONS === */
+.if-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 0 12px;
+  border-radius: 5px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: monospace;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s, color 0.12s;
+  white-space: nowrap;
+}
+.if-btn:hover:not(:disabled) { border-color: var(--text-secondary); color: var(--text-base); }
+.if-btn:disabled { opacity: 0.38; cursor: not-allowed; }
+
+/* Primary — blue */
+.if-btn.pri {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+}
+.if-btn.pri:hover:not(:disabled) { background: #388bfd; border-color: #388bfd; }
+
+/* Green */
+.if-btn.grn {
+  border-color: var(--success-bg);
+  background: var(--success-bg);
+  color: var(--success);
+}
+.if-btn.grn:hover:not(:disabled) { background: #2ea043; border-color: #2ea043; color: #fff; }
+
+/* Destructive */
+.if-btn.del {
+  border-color: var(--danger-dark);
+  background: transparent;
+  color: var(--danger);
+}
+.if-btn.del:hover:not(:disabled) { background: #2d0f0e; }
+
+/* Ghost blue */
+.if-btn.ghost {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+.if-btn.ghost:hover:not(:disabled) { background: rgba(88, 166, 255, 0.08); }
+
+/* Small */
+.if-btn.sm { min-height: 24px; padding: 0 9px; font-size: 9px; }
+
+/* Large (mobile tap target) */
+.if-btn.lg { min-height: 40px; padding: 0 18px; font-size: 11px; }
+
+/* === CARDS === */
+.if-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 18px;
+}
+
+/* === SECTION LABEL === */
+.if-section-label {
+  font-family: monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+/* === PAGE TITLE === */
+.if-page-title {
+  font-family: monospace;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-heading);
+  letter-spacing: 0.08em;
+}
+
+/* === INPUTS === */
+.if-input {
+  width: 100%;
+  background: var(--bg-surface);
+  border: 1px solid #30363d;
+  color: var(--text-base);
+  padding: 5px 8px;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 11px;
+  outline: none;
+  transition: border-color 0.12s;
+}
+.if-input:focus { border-color: var(--blue); }
+.if-input::placeholder { color: var(--text-muted); }
+
+/* === FIELD LABEL === */
+.if-label {
+  font-family: monospace;
+  font-size: 10px;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 4px;
+}
+
+/* === FILTER PILLS === */
+.if-pill {
+  min-height: 26px;
+  padding: 0 10px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: monospace;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+.if-pill:hover:not(.active) { color: var(--text-secondary); border-color: var(--border); }
+.if-pill.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(31, 111, 235, 0.1);
+}
+
+/* === STATUS TAG === */
+.if-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid currentColor;
+  font-family: monospace;
+  font-size: 9px;
+  letter-spacing: 0.07em;
+}
+
+/* === STAT CARD === */
+.if-stat {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 6px;
+  padding: 12px 14px;
+}
+.if-stat-label {
+  font-family: monospace;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+.if-stat-value {
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1;
+  font-family: monospace;
+}
+
+/* === CODE BLOCK === */
+.if-code {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 14px 16px;
+  font-family: monospace;
+  font-size: 10px;
+  color: var(--text-base);
+  overflow-x: auto;
+  line-height: 1.6;
+  white-space: pre;
+}
+
+/* === EMPTY STATE === */
+.if-empty {
+  padding: 48px 20px;
+  text-align: center;
+  color: var(--text-muted);
+  font-family: monospace;
+  font-size: 11px;
+  line-height: 1.7;
+}
+
+/* === INLINE STATUS === */
+.if-status { font-family: monospace; font-size: 10px; }
+.if-status.ok  { color: var(--success); }
+.if-status.err { color: var(--danger); }
+.if-status.info { color: var(--blue); }
+
+/* === NAV TABS === */
+.if-nav-tab {
+  min-height: 36px;
+  padding: 0 10px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: monospace;
+  font-size: 10px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+.if-nav-tab:hover:not(.active) { color: var(--text-base); }
+.if-nav-tab.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+/* === BULK ACTION BAR === */
+.if-bulk-bar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  flex-wrap: wrap;
+}
+
+/* === MOBILE RESPONSIVE === */
+@media (max-width: 767px) {
+  .if-btn     { min-height: 44px; padding: 0 18px; font-size: 12px; border-radius: 8px; }
+  .if-btn.sm  { min-height: 36px; padding: 0 14px; font-size: 10px; }
+  .if-btn.lg  { min-height: 48px; }
+  .if-nav-tab { min-height: 44px; font-size: 11px; }
+  .if-pill    { min-height: 36px; font-size: 10px; }
+}

--- a/src/inviteflow/tabs/ComposeTab.tsx
+++ b/src/inviteflow/tabs/ComposeTab.tsx
@@ -11,20 +11,6 @@ const TOKENS = [
   'VIPStart', 'VIPEnd', 'RSVP_Link', 'Date_Sent',
 ];
 
-const TOKEN_BTN = "px-1.5 py-0.5 rounded border border-gray-300 bg-transparent text-gray-600 text-[9px] font-mono tracking-wide cursor-pointer hover:border-[#C8A84B] hover:text-[#C8A84B] dark:border-[#21262d] dark:text-[#8b949e] dark:hover:border-[#C8A84B] dark:hover:text-[#C8A84B]";
-const FMT_BTN = (active: boolean) =>
-  `min-h-[36px] px-2.5 py-1 rounded border text-[10px] font-mono cursor-pointer ${
-    active
-      ? 'border-[#C8A84B] bg-[#2a1a00] text-[#C8A84B]'
-      : 'border-gray-300 bg-transparent text-gray-600 hover:border-gray-500 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:border-[#484f58]'
-  }`;
-const PANE_BTN = (active: boolean) =>
-  `min-h-[36px] px-3 py-1 rounded border text-[10px] font-mono tracking-wide cursor-pointer ${
-    active
-      ? 'border-blue-600 bg-blue-600 text-white dark:border-[#1f6feb] dark:bg-[#1f6feb]'
-      : 'border-gray-300 bg-transparent text-gray-600 dark:border-[#21262d] dark:text-[#8b949e]'
-  }`;
-
 export default function ComposeTab() {
   const state = useAppState();
   const dispatch = useAppDispatch();
@@ -54,19 +40,20 @@ export default function ComposeTab() {
     dispatch({ type: 'SET_COMPOSE', subject: val, html: state.htmlBody });
   }
 
-  const preview = ev && sample
-    ? personalize(state.htmlBody, sample, ev)
-    : state.htmlBody;
+  const preview = ev && sample ? personalize(state.htmlBody, sample, ev) : state.htmlBody;
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Top bar */}
-      <div className="px-4 py-3 border-b border-gray-200 flex flex-col gap-2.5 shrink-0 dark:border-[#21262d]">
+      <div
+        className="px-4 py-3 flex flex-col gap-2.5 shrink-0"
+        style={{ borderBottom: '1px solid var(--border)' }}
+      >
         {/* Subject */}
         <div className="flex items-center gap-2.5">
-          <span className="text-[10px] text-gray-500 tracking-widest font-mono uppercase shrink-0 dark:text-[#6e7681]">Subject</span>
+          <span className="if-section-label shrink-0">Subject</span>
           <input
-            className="flex-1 min-w-0 bg-white border border-gray-300 text-gray-900 text-xs font-mono px-2.5 py-1.5 rounded outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9] dark:focus:border-[#58a6ff]"
+            className="if-input"
             value={state.textSubject}
             onChange={e => updateSubject(e.target.value)}
             placeholder="You are cordially invited to {{EventName}}"
@@ -75,24 +62,69 @@ export default function ComposeTab() {
 
         {/* Token insert row */}
         <div className="flex gap-1 flex-wrap items-center">
-          <span className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mr-1 dark:text-[#6e7681]">Insert</span>
+          <span className="if-section-label mr-1">Insert</span>
           {TOKENS.map(t => (
-            <button key={t} className={TOKEN_BTN} onClick={() => insertToken(t)}>{`{{${t}}}`}</button>
+            <button
+              key={t}
+              onClick={() => insertToken(t)}
+              style={{
+                padding: '2px 6px',
+                borderRadius: 3,
+                border: '1px solid var(--border)',
+                background: 'transparent',
+                color: 'var(--text-muted)',
+                fontFamily: 'monospace',
+                fontSize: 9,
+                letterSpacing: '0.04em',
+                cursor: 'pointer',
+              }}
+              onMouseEnter={e => {
+                (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--gold)';
+                (e.currentTarget as HTMLButtonElement).style.color = 'var(--gold)';
+              }}
+              onMouseLeave={e => {
+                (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--border)';
+                (e.currentTarget as HTMLButtonElement).style.color = 'var(--text-muted)';
+              }}
+            >
+              {`{{${t}}}`}
+            </button>
           ))}
         </div>
 
         {/* Format bar + mobile pane toggle */}
         <div className="flex items-center justify-between gap-2">
           <div className="flex gap-1">
-            <button className={FMT_BTN(!!editor?.isActive('bold'))} onClick={() => editor?.chain().focus().toggleBold().run()}>B</button>
-            <button className={FMT_BTN(!!editor?.isActive('italic'))} onClick={() => editor?.chain().focus().toggleItalic().run()}>I</button>
-            <button className={FMT_BTN(!!editor?.isActive('bulletList'))} onClick={() => editor?.chain().focus().toggleBulletList().run()}>• List</button>
-            <button className={FMT_BTN(!!editor?.isActive('orderedList'))} onClick={() => editor?.chain().focus().toggleOrderedList().run()}>1. List</button>
+            {[
+              { label: 'B', action: () => editor?.chain().focus().toggleBold().run(),         active: () => !!editor?.isActive('bold') },
+              { label: 'I', action: () => editor?.chain().focus().toggleItalic().run(),       active: () => !!editor?.isActive('italic') },
+              { label: '• List', action: () => editor?.chain().focus().toggleBulletList().run(),  active: () => !!editor?.isActive('bulletList') },
+              { label: '1. List', action: () => editor?.chain().focus().toggleOrderedList().run(), active: () => !!editor?.isActive('orderedList') },
+            ].map(({ label, action, active }) => (
+              <button
+                key={label}
+                className="if-btn sm"
+                style={active() ? { borderColor: 'var(--gold)', color: 'var(--gold)', background: 'var(--gold-bg)' } : {}}
+                onClick={action}
+              >
+                {label}
+              </button>
+            ))}
           </div>
           {/* Pane toggle — mobile only */}
           <div className="flex gap-1 md:hidden">
-            <button className={PANE_BTN(activePane === 'editor')} onClick={() => setActivePane('editor')}>Editor</button>
-            <button className={PANE_BTN(activePane === 'preview')} onClick={() => setActivePane('preview')}>Preview</button>
+            <button
+              className={`if-btn sm${activePane === 'editor' ? ' pri' : ''}`}
+              onClick={() => setActivePane('editor')}
+            >
+              Editor
+            </button>
+            <button
+              className={`if-btn sm${activePane === 'preview' ? ' pri' : ''}`}
+              onClick={() => setActivePane('preview')}
+            >
+              Preview
+            </button>
           </div>
         </div>
       </div>
@@ -100,21 +132,29 @@ export default function ComposeTab() {
       {/* Editor + Preview */}
       <div className="flex-1 overflow-hidden md:grid md:grid-cols-2">
         {/* Editor pane */}
-        <div className={`h-full overflow-auto p-4 border-gray-200 dark:border-[#21262d] md:border-r ${activePane === 'editor' ? 'block' : 'hidden'} md:block`}>
-          <div className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-2 dark:text-[#6e7681]">EDITOR</div>
+        <div
+          className={`h-full overflow-auto p-4 ${activePane === 'editor' ? 'block' : 'hidden'} md:block`}
+          style={{ borderRight: '1px solid var(--border)' }}
+        >
+          <div className="if-section-label mb-2">EDITOR</div>
           <EditorContent
             editor={editor}
-            className="text-gray-900 text-sm leading-relaxed min-h-[200px] dark:text-[#c9d1d9]"
+            className="text-sm leading-relaxed min-h-[200px]"
+            style={{ color: 'var(--text-base)' }}
           />
         </div>
 
         {/* Preview pane */}
-        <div className={`h-full overflow-auto p-4 bg-gray-50 dark:bg-[#080c10] ${activePane === 'preview' ? 'block' : 'hidden'} md:block`}>
-          <div className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-2 dark:text-[#6e7681]">
+        <div
+          className={`h-full overflow-auto p-4 ${activePane === 'preview' ? 'block' : 'hidden'} md:block`}
+          style={{ background: 'var(--bg-subtle)' }}
+        >
+          <div className="if-section-label mb-2">
             PREVIEW {sample ? `(${sample.firstName} ${sample.lastName})` : '(no invitees)'}
           </div>
           <div
-            className="bg-white rounded p-4 text-[#1a1a1a] text-sm leading-relaxed"
+            className="rounded p-4 text-sm leading-relaxed"
+            style={{ background: '#fff', color: '#1a1a1a' }}
             dangerouslySetInnerHTML={{ __html: preview }}
           />
         </div>

--- a/src/inviteflow/tabs/EventsTab.tsx
+++ b/src/inviteflow/tabs/EventsTab.tsx
@@ -85,61 +85,54 @@ export default function EventsTab() {
   return (
     <div className="p-5 max-w-[860px] mx-auto w-full">
       <div className="flex items-center justify-between mb-5">
-        <span className="text-sm font-bold tracking-[0.08em] text-gray-900 dark:text-[#f0f6fc]">EVENTS</span>
+        <span className="if-page-title">EVENTS</span>
         <div className="flex gap-2">
-          <button
-            onClick={loadEvents}
-            disabled={loading}
-            className="min-h-[44px] px-3 py-1 rounded border border-gray-300 bg-transparent text-gray-700 text-xs font-mono tracking-wide cursor-pointer hover:bg-gray-100 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:bg-[#161b22] disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {loading ? 'Loading…' : 'Refresh'}
+          <button className="if-btn" onClick={loadEvents} disabled={loading}>
+            {loading ? 'Loading...' : 'Refresh'}
           </button>
-          <button
-            onClick={createEvent}
-            className="min-h-[44px] px-3 py-1 rounded border border-blue-600 bg-blue-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-700 dark:border-[#1f6feb] dark:bg-[#1f6feb]"
-          >
-            + New Event
-          </button>
+          <button className="if-btn pri" onClick={createEvent}>+ New Event</button>
         </div>
       </div>
 
-      {err && <div className="text-xs text-red-600 mb-3 dark:text-[#f85149]">{err}</div>}
+      {err && <div className="if-status err mb-3">{err}</div>}
 
       {state.events.length === 0 && !loading && (
-        <div className="text-gray-500 text-xs text-center py-10 dark:text-[#6e7681]">
-          No events yet. Click &ldquo;+ New Event&rdquo; to create one.
-        </div>
+        <div className="if-empty">No events yet. Click &ldquo;+ New Event&rdquo; to create one.</div>
       )}
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
         {state.events.map(ev => (
           <div
             key={ev.id}
-            className={[
-              'bg-white border rounded-lg p-4 cursor-pointer transition-colors dark:bg-[#0d1117]',
-              state.activeEventId === ev.id
-                ? 'border-[#C8A84B]'
-                : 'border-gray-200 hover:border-gray-400 dark:border-[#21262d] dark:hover:border-[#484f58]',
-            ].join(' ')}
-            onClick={() => { dispatch({ type: 'SET_ACTIVE_EVENT', id: ev.id }); dispatch({ type: 'SET_TAB', tab: 'setup' }); }}
+            className="if-card cursor-pointer"
+            style={state.activeEventId === ev.id
+              ? { borderColor: 'var(--gold)', cursor: 'pointer' }
+              : { cursor: 'pointer' }}
+            onClick={() => {
+              dispatch({ type: 'SET_ACTIVE_EVENT', id: ev.id });
+              dispatch({ type: 'SET_TAB', tab: 'setup' });
+            }}
           >
-            <div className="text-sm font-bold text-gray-900 mb-1 dark:text-[#f0f6fc]">{ev.name || 'Unnamed Event'}</div>
-            <div className="text-[10px] text-gray-500 mb-3 dark:text-[#6e7681]">
+            <div
+              className="text-sm font-bold mb-1"
+              style={{ color: 'var(--text-heading)', fontFamily: 'monospace' }}
+            >
+              {ev.name || 'Unnamed Event'}
+            </div>
+            <div className="text-[10px] mb-3" style={{ color: 'var(--text-muted)' }}>
               {ev.date || 'No date'} · {ev.venue || 'No venue'}
             </div>
             <div className="flex gap-2" onClick={e => e.stopPropagation()}>
               <button
-                onClick={() => { dispatch({ type: 'SET_ACTIVE_EVENT', id: ev.id }); dispatch({ type: 'SET_TAB', tab: 'setup' }); }}
-                className="min-h-[44px] px-3 py-1 rounded border border-blue-600 bg-blue-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-700 dark:border-[#1f6feb] dark:bg-[#1f6feb]"
+                className="if-btn pri sm"
+                onClick={() => {
+                  dispatch({ type: 'SET_ACTIVE_EVENT', id: ev.id });
+                  dispatch({ type: 'SET_TAB', tab: 'setup' });
+                }}
               >
                 {state.activeEventId === ev.id ? '✓ Active' : 'Activate'}
               </button>
-              <button
-                onClick={() => deleteEvent(ev.id)}
-                className="min-h-[44px] px-3 py-1 rounded border border-red-500 bg-transparent text-red-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-red-50 dark:border-[#f85149] dark:text-[#f85149] dark:hover:bg-[#2d0f0e]"
-              >
-                Delete
-              </button>
+              <button className="if-btn del sm" onClick={() => deleteEvent(ev.id)}>Delete</button>
             </div>
           </div>
         ))}

--- a/src/inviteflow/tabs/InviteesTab.tsx
+++ b/src/inviteflow/tabs/InviteesTab.tsx
@@ -26,13 +26,13 @@ function makeInvitee(partial: Partial<Invitee> = {}): Invitee {
 
 const STATUS_COLORS: Record<string, string> = {
   pending: 'var(--text-muted)',
-  sent: 'var(--success)',
-  failed: 'var(--danger)',
+  sent:    'var(--success)',
+  failed:  'var(--danger)',
 };
 const RSVP_COLORS: Record<string, string> = {
   'No Response': 'var(--text-muted)',
-  Attending: 'var(--success)',
-  Declined: 'var(--danger)',
+  Attending:     'var(--success)',
+  Declined:      'var(--danger)',
 };
 
 export default function InviteesTab() {
@@ -63,16 +63,16 @@ export default function InviteesTab() {
 
       const incoming = data.map(r => makeInvitee({
         firstName: r[ci.fn] ?? '',
-        lastName: r[ci.ln] ?? '',
-        title: r[ci.title] ?? '',
-        category: r[ci.cat] ?? '',
-        email: r[ci.email] ?? '',
-        rsvpLink: r[ci.rsvp] ?? '',
+        lastName:  r[ci.ln] ?? '',
+        title:     r[ci.title] ?? '',
+        category:  r[ci.cat] ?? '',
+        email:     r[ci.email] ?? '',
+        rsvpLink:  r[ci.rsvp] ?? '',
         inviteStatus: r[ci.sent]?.toLowerCase() === 'true' ? 'sent' : 'pending',
-        sentAt: r[ci.sentDate] ?? '',
+        sentAt:    r[ci.sentDate] ?? '',
         rsvpStatus: (['Attending', 'Declined'].includes(r[ci.rsvpStatus]) ? r[ci.rsvpStatus] : 'No Response') as Invitee['rsvpStatus'],
-        rsvpDate: r[ci.rsvpDate] ?? '',
-        notes: r[ci.notes] ?? '',
+        rsvpDate:  r[ci.rsvpDate] ?? '',
+        notes:     r[ci.notes] ?? '',
       })).filter(i => i.email);
 
       const merged = [...state.invitees];
@@ -100,10 +100,10 @@ export default function InviteesTab() {
           const parts = full.split(' ');
           return makeInvitee({
             firstName: r.firstName ?? parts[0] ?? '',
-            lastName: r.lastName ?? parts.slice(1).join(' ') ?? '',
-            title: r.title ?? '',
-            category: r.category ?? '',
-            email: r.email ?? '',
+            lastName:  r.lastName ?? parts.slice(1).join(' ') ?? '',
+            title:     r.title ?? '',
+            category:  r.category ?? '',
+            email:     r.email ?? '',
           });
         }).filter(i => i.email);
         const merged = [...state.invitees];
@@ -121,14 +121,18 @@ export default function InviteesTab() {
   function exportCSV() {
     const header = 'FirstName,LastName,Title,Category,Email,RSVP_Link,InviteSent,InviteSentDate,RSVP_Status,RSVP_Date,Notes';
     const rows = state.invitees.map(i =>
-      [i.firstName, i.lastName, i.title, i.category, i.email, i.rsvpLink, i.inviteStatus === 'sent' ? 'TRUE' : 'FALSE', i.sentAt, i.rsvpStatus, i.rsvpDate, i.notes]
+      [i.firstName, i.lastName, i.title, i.category, i.email, i.rsvpLink,
+       i.inviteStatus === 'sent' ? 'TRUE' : 'FALSE',
+       i.sentAt, i.rsvpStatus, i.rsvpDate, i.notes]
         .map(v => `"${String(v).replace(/"/g, '""')}"`)
         .join(',')
     );
     const blob = new Blob([[header, ...rows].join('\n')], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.href = url; a.download = `invitees-${new Date().toISOString().slice(0, 10)}.csv`; a.click();
+    a.href = url;
+    a.download = `invitees-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
     URL.revokeObjectURL(url);
   }
 
@@ -151,14 +155,18 @@ export default function InviteesTab() {
 
   function bulkMarkSent() {
     const ids = new Set(selected.map(s => s.id));
-    const updated = state.invitees.map(i => ids.has(i.id) ? { ...i, inviteStatus: 'sent' as const, sentAt: new Date().toISOString() } : i);
+    const updated = state.invitees.map(i =>
+      ids.has(i.id) ? { ...i, inviteStatus: 'sent' as const, sentAt: new Date().toISOString() } : i
+    );
     dispatch({ type: 'SET_INVITEES', invitees: updated });
     setSelected([]);
   }
 
   function bulkReset() {
     const ids = new Set(selected.map(s => s.id));
-    const updated = state.invitees.map(i => ids.has(i.id) ? { ...i, inviteStatus: 'pending' as const, sentAt: '' } : i);
+    const updated = state.invitees.map(i =>
+      ids.has(i.id) ? { ...i, inviteStatus: 'pending' as const, sentAt: '' } : i
+    );
     dispatch({ type: 'SET_INVITEES', invitees: updated });
     setSelected([]);
   }
@@ -169,54 +177,65 @@ export default function InviteesTab() {
     setSelected([]);
   }
 
-  const iStyle: React.CSSProperties = {
-    background: 'var(--bg-surface)', border: '1px solid var(--border)', color: 'var(--text-base)',
+  const inputStyle: React.CSSProperties = {
+    background: 'var(--bg-surface)', border: '1px solid #30363d', color: 'var(--text-base)',
     padding: '5px 8px', borderRadius: 4, fontFamily: 'monospace', fontSize: 11, width: '100%',
   };
-  const btn = (color = 'var(--text-secondary)', bg = 'transparent'): React.CSSProperties => ({
-    border: `1px solid ${color}`, background: bg, color, padding: '4px 10px',
-    borderRadius: 4, cursor: 'pointer', fontFamily: 'monospace', fontSize: 10, letterSpacing: '0.05em',
-  });
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', padding: '16px 20px', gap: 12 }}>
       {/* Toolbar */}
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-        <span style={{ fontSize: 13, color: 'var(--text-heading)', fontWeight: 700, letterSpacing: '0.08em', marginRight: 8 }}>
-          INVITEES <span style={{ fontSize: 10, color: 'var(--text-muted)' }}>({state.invitees.length})</span>
+        <span className="if-page-title" style={{ marginRight: 4 }}>
+          INVITEES{' '}
+          <span style={{ fontSize: 10, color: 'var(--text-muted)', fontWeight: 400 }}>
+            ({state.invitees.length})
+          </span>
         </span>
-        <button style={btn('var(--success)', 'var(--success-bg)')} onClick={() => setShowAdd(true)}>+ Add</button>
-        <button style={btn()} onClick={exportCSV}>Export CSV</button>
-        <button style={btn()} onClick={generateAllRsvpLinks}>Gen RSVP Links</button>
-        <input ref={fileRef} type="file" accept=".json" style={{ display: 'none' }} onChange={e => e.target.files?.[0] && importJSON(e.target.files[0])} />
-        <button style={btn()} onClick={() => fileRef.current?.click()}>Import JSON</button>
+        <button className="if-btn grn sm" onClick={() => setShowAdd(true)}>+ Add</button>
+        <button className="if-btn sm" onClick={exportCSV}>Export CSV</button>
+        <button className="if-btn sm" onClick={generateAllRsvpLinks}>Gen RSVP Links</button>
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".json"
+          style={{ display: 'none' }}
+          onChange={e => e.target.files?.[0] && importJSON(e.target.files[0])}
+        />
+        <button className="if-btn sm" onClick={() => fileRef.current?.click()}>Import JSON</button>
       </div>
 
       {/* Sheets import row */}
       <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
         <input
-          style={{ ...iStyle, flex: 1, minWidth: 200 }}
-          placeholder="Paste Google Sheets URL to import…"
+          className="if-input"
+          style={{ flex: 1, minWidth: 200 }}
+          placeholder="Paste Google Sheets URL to import..."
           value={sheetsUrl}
           onChange={e => setSheetsUrl(e.target.value)}
         />
-        <button style={btn('var(--blue)')} onClick={importFromSheets} disabled={importing}>
-          {importing ? 'Importing…' : 'Import Sheets'}
+        <button className="if-btn ghost sm" onClick={importFromSheets} disabled={importing}>
+          {importing ? 'Importing...' : 'Import Sheets'}
         </button>
-        {importStatus && <span style={{ fontSize: 10, color: importStatus.startsWith('Error') ? 'var(--danger)' : 'var(--success)' }}>{importStatus}</span>}
+        {importStatus && (
+          <span className={`if-status ${importStatus.startsWith('Error') ? 'err' : 'ok'}`}>
+            {importStatus}
+          </span>
+        )}
       </div>
 
-      {/* Bulk actions — visible when rows selected */}
+      {/* Bulk actions */}
       {selected.length > 0 && (
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center', background: 'var(--bg-surface)', border: '1px solid var(--border)', borderRadius: 6, padding: '8px 12px' }}>
-          <span style={{ fontSize: 10, color: 'var(--gold)' }}>{selected.length} selected</span>
-          <button style={btn('var(--success)')} onClick={bulkMarkSent}>Mark Sent</button>
-          <button style={btn('var(--text-muted)')} onClick={bulkReset}>Reset Status</button>
-          <button
-            style={btn('var(--success)')}
-            onClick={() => { dispatch({ type: 'SET_TAB', tab: 'send' }); }}
-          >Send Selected →</button>
-          <button style={btn('var(--danger)')} onClick={bulkDelete}>Delete</button>
+        <div className="if-bulk-bar">
+          <span style={{ fontSize: 10, color: 'var(--gold)', fontFamily: 'monospace' }}>
+            {selected.length} selected
+          </span>
+          <button className="if-btn grn sm" onClick={bulkMarkSent}>Mark Sent</button>
+          <button className="if-btn sm" onClick={bulkReset}>Reset Status</button>
+          <button className="if-btn pri sm" onClick={() => dispatch({ type: 'SET_TAB', tab: 'send' })}>
+            Send Selected →
+          </button>
+          <button className="if-btn del sm" onClick={bulkDelete}>Delete</button>
         </div>
       )}
 
@@ -239,33 +258,48 @@ export default function InviteesTab() {
           editMode="row"
         >
           <Column selectionMode="multiple" style={{ width: 40 }} />
-          <Column field="firstName" header="First" sortable filter filterPlaceholder="Search" style={{ minWidth: 90 }} />
-          <Column field="lastName" header="Last" sortable filter filterPlaceholder="Search" style={{ minWidth: 90 }} />
-          <Column field="title" header="Title" sortable style={{ minWidth: 120 }} />
-          <Column field="category" header="Category" sortable filter filterPlaceholder="Filter" style={{ minWidth: 100 }} />
-          <Column field="email" header="Email" sortable style={{ minWidth: 160 }} />
+          <Column field="firstName" header="First"    sortable filter filterPlaceholder="Search" style={{ minWidth: 90 }} />
+          <Column field="lastName"  header="Last"     sortable filter filterPlaceholder="Search" style={{ minWidth: 90 }} />
+          <Column field="title"     header="Title"    sortable style={{ minWidth: 120 }} />
+          <Column field="category"  header="Category" sortable filter filterPlaceholder="Filter" style={{ minWidth: 100 }} />
+          <Column field="email"     header="Email"    sortable style={{ minWidth: 160 }} />
           <Column
             field="inviteStatus"
             header="Status"
-            sortable
-            filter
-            filterPlaceholder="Filter"
+            sortable filter filterPlaceholder="Filter"
             style={{ minWidth: 90 }}
-            body={(r: Invitee) => <span style={{ color: STATUS_COLORS[r.inviteStatus] ?? 'var(--text-muted)', fontSize: 10, letterSpacing: '0.07em' }}>{r.inviteStatus.toUpperCase()}</span>}
+            body={(r: Invitee) => (
+              <span style={{ color: STATUS_COLORS[r.inviteStatus] ?? 'var(--text-muted)', fontSize: 10, letterSpacing: '0.07em', fontFamily: 'monospace' }}>
+                {r.inviteStatus.toUpperCase()}
+              </span>
+            )}
           />
-          <Column field="sentAt" header="Sent At" sortable style={{ minWidth: 110 }} body={(r: Invitee) => r.sentAt ? new Date(r.sentAt).toLocaleDateString() : '—'} />
+          <Column
+            field="sentAt"
+            header="Sent At"
+            sortable
+            style={{ minWidth: 110 }}
+            body={(r: Invitee) => r.sentAt ? new Date(r.sentAt).toLocaleDateString() : '—'}
+          />
           <Column
             field="rsvpStatus"
             header="RSVP"
-            sortable
-            filter
-            filterPlaceholder="Filter"
+            sortable filter filterPlaceholder="Filter"
             style={{ minWidth: 110 }}
-            body={(r: Invitee) => <span style={{ color: RSVP_COLORS[r.rsvpStatus] ?? 'var(--text-muted)', fontSize: 10 }}>{r.rsvpStatus}</span>}
+            body={(r: Invitee) => (
+              <span style={{ color: RSVP_COLORS[r.rsvpStatus] ?? 'var(--text-muted)', fontSize: 10, fontFamily: 'monospace' }}>
+                {r.rsvpStatus}
+              </span>
+            )}
           />
-          <Column field="notes" header="Notes" style={{ minWidth: 140 }} editor={(opts) => (
-            <input style={iStyle} value={opts.value} onChange={e => opts.editorCallback?.(e.target.value)} />
-          )} />
+          <Column
+            field="notes"
+            header="Notes"
+            style={{ minWidth: 140 }}
+            editor={(opts) => (
+              <input style={inputStyle} value={opts.value} onChange={e => opts.editorCallback?.(e.target.value)} />
+            )}
+          />
           <Column rowEditor style={{ width: 70 }} />
         </DataTable>
       </div>
@@ -273,17 +307,21 @@ export default function InviteesTab() {
       {/* Add manually modal */}
       {showAdd && (
         <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,.85)', zIndex: 300, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <div style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)', borderRadius: 8, padding: '24px 28px', width: 400 }}>
-            <div style={{ fontSize: 12, color: 'var(--text-heading)', fontWeight: 700, marginBottom: 16 }}>ADD INVITEE</div>
+          <div className="if-card" style={{ width: 400 }}>
+            <div className="if-page-title mb-4">ADD INVITEE</div>
             {(['firstName', 'lastName', 'title', 'category', 'email'] as const).map(k => (
               <div key={k} style={{ marginBottom: 10 }}>
-                <label style={{ fontSize: 10, color: 'var(--text-muted)', display: 'block', marginBottom: 4 }}>{k.toUpperCase()}</label>
-                <input style={iStyle} value={String(draft[k] ?? '')} onChange={e => setDraft(d => ({ ...d, [k]: e.target.value }))} />
+                <label className="if-label">{k.toUpperCase()}</label>
+                <input
+                  className="if-input"
+                  value={String(draft[k] ?? '')}
+                  onChange={e => setDraft(d => ({ ...d, [k]: e.target.value }))}
+                />
               </div>
             ))}
             <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
-              <button style={btn('var(--success)', 'var(--success-bg)')} onClick={addManually}>Add</button>
-              <button style={btn()} onClick={() => { setShowAdd(false); setDraft({}); }}>Cancel</button>
+              <button className="if-btn grn" onClick={addManually}>Add</button>
+              <button className="if-btn" onClick={() => { setShowAdd(false); setDraft({}); }}>Cancel</button>
             </div>
           </div>
         </div>

--- a/src/inviteflow/tabs/SendTab.tsx
+++ b/src/inviteflow/tabs/SendTab.tsx
@@ -8,13 +8,6 @@ type Filter = 'all' | 'pending' | 'failed';
 const BATCH_SIZE = 80;
 const BATCH_DELAY_MS = 61000;
 
-const FILTER_BTN = (active: boolean) =>
-  `min-h-[36px] px-3 py-1 rounded border text-[10px] font-mono tracking-wide cursor-pointer ${
-    active
-      ? 'border-blue-600 bg-blue-600 text-white dark:border-[#1f6feb] dark:bg-[#1f6feb]'
-      : 'border-gray-300 bg-transparent text-gray-600 hover:border-gray-500 dark:border-[#21262d] dark:text-[#8b949e] dark:hover:border-[#484f58]'
-  }`;
-
 export default function SendTab() {
   const state = useAppState();
   const dispatch = useAppDispatch();
@@ -46,7 +39,7 @@ export default function SendTab() {
 
     for (let i = 0; i < filtered.length; i++) {
       const inv = filtered[i];
-      const personalizedHtml = personalize(state.htmlBody, inv, ev);
+      const personalizedHtml    = personalize(state.htmlBody, inv, ev);
       const personalizedSubject = personalize(state.textSubject, inv, ev);
       const raw = buildMimeRaw(from, inv.email, personalizedSubject, personalizedHtml);
 
@@ -76,34 +69,50 @@ export default function SendTab() {
 
   return (
     <div className="p-5 max-w-[800px] mx-auto w-full">
-      <div className="text-sm font-bold tracking-[0.08em] text-gray-900 mb-4 dark:text-[#f0f6fc]">SEND</div>
+      <div className="if-page-title mb-4">SEND</div>
 
       {/* Filter + Send controls */}
       <div className="flex flex-wrap gap-2 items-center mb-4">
-        <span className="text-[10px] text-gray-500 tracking-widest font-mono uppercase dark:text-[#6e7681]">Filter</span>
+        <span className="if-section-label">Filter</span>
         {(['all', 'pending', 'failed'] as Filter[]).map(f => (
-          <button key={f} className={FILTER_BTN(filter === f)} onClick={() => setFilter(f)}>{f.toUpperCase()}</button>
+          <button
+            key={f}
+            className={`if-pill${filter === f ? ' active' : ''}`}
+            onClick={() => setFilter(f)}
+          >
+            {f.toUpperCase()}
+          </button>
         ))}
-        <span className="text-[10px] text-gray-500 font-mono ml-2 dark:text-[#6e7681]">{filtered.length} invitees</span>
+        <span style={{ fontSize: 10, color: 'var(--text-muted)', fontFamily: 'monospace', marginLeft: 4 }}>
+          {filtered.length} invitees
+        </span>
         <button
-          className="min-h-[36px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-[10px] font-mono tracking-wide cursor-pointer hover:bg-green-700 ml-auto disabled:opacity-50 disabled:cursor-not-allowed dark:border-[#238636] dark:bg-[#238636]"
+          className="if-btn grn ml-auto"
           onClick={sendBulk}
           disabled={state.sending}
         >
-          {state.sending ? 'Sending…' : `Send to ${filtered.length} →`}
+          {state.sending ? 'Sending...' : `Send to ${filtered.length} →`}
         </button>
       </div>
 
-      {err && <div className="text-xs text-red-600 mb-3 dark:text-[#f85149]">{err}</div>}
+      {err && <div className="if-status err mb-3">{err}</div>}
 
       {/* Progress bar */}
       {state.sending && (
         <div className="mb-4">
-          <div className="text-[10px] text-gray-500 mb-1.5 dark:text-[#6e7681]">
+          <div style={{ fontSize: 10, color: 'var(--text-muted)', fontFamily: 'monospace', marginBottom: 6 }}>
             {state.sendProgress.current} / {state.sendProgress.total} sent ({progress}%)
           </div>
-          <div className="h-1 bg-gray-200 rounded overflow-hidden dark:bg-[#161b22]">
-            <div className="h-full bg-[#C8A84B] rounded transition-[width] duration-300" style={{ width: `${progress}%` }} />
+          <div style={{ height: 3, background: 'var(--bg-subtle)', borderRadius: 2, overflow: 'hidden' }}>
+            <div
+              style={{
+                height: '100%',
+                background: 'var(--gold)',
+                borderRadius: 2,
+                transition: 'width 0.3s',
+                width: `${progress}%`,
+              }}
+            />
           </div>
         </div>
       )}
@@ -111,16 +120,34 @@ export default function SendTab() {
       {/* Send log */}
       {state.sendLog.length > 0 && (
         <div>
-          <div className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-2 dark:text-[#6e7681]">SEND LOG</div>
-          <div className="max-h-96 overflow-y-auto border border-gray-200 rounded-lg dark:border-[#21262d]">
+          <div className="if-section-label mb-2">SEND LOG</div>
+          <div
+            style={{
+              maxHeight: 384,
+              overflowY: 'auto',
+              border: '1px solid var(--border)',
+              borderRadius: 6,
+            }}
+          >
             {state.sendLog.map(entry => (
-              <div key={entry.id} className="flex gap-2.5 items-baseline px-3 py-1.5 border-b border-gray-100 text-xs last:border-0 dark:border-[#161b22]">
-                <span className={`min-w-[40px] text-[10px] tracking-[0.07em] font-mono ${entry.status === 'sent' ? 'text-green-600 dark:text-[#3fb950]' : 'text-red-600 dark:text-[#f85149]'}`}>
+              <div
+                key={entry.id}
+                style={{
+                  display: 'flex',
+                  gap: 10,
+                  alignItems: 'baseline',
+                  padding: '6px 12px',
+                  borderBottom: '1px solid var(--bg-subtle)',
+                  fontFamily: 'monospace',
+                  fontSize: 11,
+                }}
+              >
+                <span style={{ minWidth: 40, fontSize: 10, letterSpacing: '0.07em', color: entry.status === 'sent' ? 'var(--success)' : 'var(--danger)' }}>
                   {entry.status.toUpperCase()}
                 </span>
-                <span className="text-gray-900 min-w-[160px] dark:text-[#c9d1d9]">{entry.name}</span>
-                <span className="text-gray-500 flex-1 dark:text-[#6e7681]">{entry.email}</span>
-                {entry.error && <span className="text-[10px] text-red-600 dark:text-[#f85149]">{entry.error}</span>}
+                <span style={{ color: 'var(--text-base)', minWidth: 160 }}>{entry.name}</span>
+                <span style={{ color: 'var(--text-muted)', flex: 1 }}>{entry.email}</span>
+                {entry.error && <span style={{ fontSize: 10, color: 'var(--danger)' }}>{entry.error}</span>}
               </div>
             ))}
           </div>
@@ -128,9 +155,7 @@ export default function SendTab() {
       )}
 
       {state.sendLog.length === 0 && !state.sending && (
-        <div className="text-gray-500 text-xs text-center py-10 dark:text-[#6e7681]">
-          No sends yet. Choose a filter and click Send.
-        </div>
+        <div className="if-empty">No sends yet. Choose a filter and click Send.</div>
       )}
     </div>
   );

--- a/src/inviteflow/tabs/SetupTab.tsx
+++ b/src/inviteflow/tabs/SetupTab.tsx
@@ -5,24 +5,20 @@ import { updateAppDataFile } from '../api/drive';
 import type { AppEvent } from '../types';
 
 const FIELDS: Array<{ key: keyof AppEvent; label: string; type?: string; placeholder?: string }> = [
-  { key: 'name', label: 'Event Name', placeholder: 'Greater Triangle Dragon Boat Festival' },
-  { key: 'date', label: 'Event Date', type: 'date' },
-  { key: 'venue', label: 'Venue', placeholder: 'Jordan Lake State Recreation Area' },
-  { key: 'orgName', label: 'Organization Name', placeholder: 'Asian Focus NC' },
-  { key: 'contactName', label: 'Contact Name', placeholder: 'Lenya Chan' },
-  { key: 'contactEmail', label: 'Contact Email', type: 'email', placeholder: 'contact@org.com' },
-  { key: 'vipStart', label: 'VIP Start Time', placeholder: '10:00 AM' },
-  { key: 'vipEnd', label: 'VIP End Time', placeholder: '12:00 PM' },
-  { key: 'formUrl', label: 'Google Form Base URL', placeholder: 'https://docs.google.com/forms/d/e/…/viewform' },
-  { key: 'entryEmail', label: 'Form Email Entry ID', placeholder: 'entry.123456789' },
+  { key: 'name',            label: 'Event Name',            placeholder: 'Greater Triangle Dragon Boat Festival' },
+  { key: 'date',            label: 'Event Date',            type: 'date' },
+  { key: 'venue',           label: 'Venue',                 placeholder: 'Jordan Lake State Recreation Area' },
+  { key: 'orgName',         label: 'Organization Name',     placeholder: 'Asian Focus NC' },
+  { key: 'contactName',     label: 'Contact Name',          placeholder: 'Lenya Chan' },
+  { key: 'contactEmail',    label: 'Contact Email',         type: 'email', placeholder: 'contact@org.com' },
+  { key: 'vipStart',        label: 'VIP Start Time',        placeholder: '10:00 AM' },
+  { key: 'vipEnd',          label: 'VIP End Time',          placeholder: '12:00 PM' },
+  { key: 'formUrl',         label: 'Google Form Base URL',  placeholder: 'https://docs.google.com/forms/d/e/…/viewform' },
+  { key: 'entryEmail',      label: 'Form Email Entry ID',   placeholder: 'entry.123456789' },
   { key: 'rsvpResponseUrl', label: 'RSVP Response Sheet URL', placeholder: 'https://docs.google.com/spreadsheets/d/…' },
-  { key: 'masterSheetUrl', label: 'Master Sheet URL', placeholder: 'https://docs.google.com/spreadsheets/d/…' },
-  { key: 'imgEmblemUrl', label: 'Emblem Image URL', placeholder: 'https://drive.google.com/…' },
+  { key: 'masterSheetUrl',  label: 'Master Sheet URL',      placeholder: 'https://docs.google.com/spreadsheets/d/…' },
+  { key: 'imgEmblemUrl',    label: 'Emblem Image URL',      placeholder: 'https://drive.google.com/…' },
 ];
-
-const INPUT = "w-full bg-white border border-gray-300 text-gray-900 text-xs font-mono px-2.5 py-1.5 rounded outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9] dark:focus:border-[#58a6ff]";
-const LABEL = "text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-1 block dark:text-[#6e7681]";
-const SECTION = "text-[10px] text-gray-500 tracking-widest font-mono uppercase mt-5 mb-2.5 border-b border-gray-200 pb-1.5 dark:text-[#6e7681] dark:border-[#21262d]";
 
 export default function SetupTab() {
   const state = useAppState();
@@ -35,13 +31,13 @@ export default function SetupTab() {
 
   if (!ev) {
     return (
-      <div className="p-10 text-gray-500 text-xs text-center dark:text-[#6e7681]">
-        No active event. Go to{' '}
+      <div className="if-empty">
+        No active event.{' '}
         <button
-          className="text-blue-600 bg-transparent border-none cursor-pointer font-mono text-xs dark:text-[#58a6ff]"
+          style={{ color: 'var(--blue)', background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'monospace', fontSize: 11 }}
           onClick={() => dispatch({ type: 'SET_TAB', tab: 'events' })}
         >
-          Events
+          Go to Events
         </button>{' '}
         to create or activate one.
       </div>
@@ -81,54 +77,43 @@ export default function SetupTab() {
   return (
     <div className="p-5 max-w-[640px] mx-auto w-full">
       <div className="flex items-center justify-between mb-4">
-        <span className="text-sm font-bold tracking-[0.08em] text-gray-900 dark:text-[#f0f6fc]">SETUP</span>
-        <button
-          onClick={save}
-          disabled={saving}
-          className="min-h-[44px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-green-700 dark:border-[#238636] dark:bg-[#238636] disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {saving ? 'Saving…' : 'Save'}
+        <span className="if-page-title">SETUP</span>
+        <button className="if-btn grn" onClick={save} disabled={saving}>
+          {saving ? 'Saving...' : 'Save'}
         </button>
       </div>
 
       {status && (
-        <div className={`text-xs mb-3 ${status.startsWith('Error') ? 'text-red-600 dark:text-[#f85149]' : 'text-green-600 dark:text-[#3fb950]'}`}>
-          {status}
-        </div>
+        <div className={`if-status mb-3 ${status.startsWith('Error') ? 'err' : 'ok'}`}>{status}</div>
       )}
 
-      <div className={SECTION}>GOOGLE OAUTH</div>
+      <div className="if-section-label mt-5 mb-2.5 border-b pb-1.5" style={{ borderColor: 'var(--border)' }}>
+        GOOGLE OAUTH
+      </div>
       <div className="mb-3">
-        <label className={LABEL}>Google Client ID</label>
+        <label className="if-label">Google Client ID</label>
         <input
-          className={INPUT}
+          className="if-input"
           value={clientIdDraft}
           onChange={e => setClientIdDraft(e.target.value)}
           placeholder="123456789-abc.apps.googleusercontent.com"
         />
       </div>
       <div className="flex flex-wrap gap-2 mb-5">
-        <button
-          className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c]"
-          onClick={() => authorize('spreadsheets')}
-        >Authorize Sheets</button>
-        <button
-          className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c]"
-          onClick={() => authorize('gmail.send')}
-        >Authorize Gmail</button>
-        <button
-          className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c]"
-          onClick={() => authorize('drive.appdata')}
-        >Authorize Drive</button>
+        <button className="if-btn ghost" onClick={() => authorize('spreadsheets')}>Authorize Sheets</button>
+        <button className="if-btn ghost" onClick={() => authorize('gmail.send')}>Authorize Gmail</button>
+        <button className="if-btn ghost" onClick={() => authorize('drive.appdata')}>Authorize Drive</button>
       </div>
 
-      <div className={SECTION}>EVENT DETAILS</div>
+      <div className="if-section-label mt-5 mb-2.5 border-b pb-1.5" style={{ borderColor: 'var(--border)' }}>
+        EVENT DETAILS
+      </div>
       <div className="grid gap-3">
         {FIELDS.map(f => (
           <div key={f.key}>
-            <label className={LABEL}>{f.label}</label>
+            <label className="if-label">{f.label}</label>
             <input
-              className={INPUT}
+              className="if-input"
               type={f.type ?? 'text'}
               value={String(ev[f.key] ?? '')}
               onChange={e => update(f.key, e.target.value)}

--- a/src/inviteflow/tabs/SyncTab.tsx
+++ b/src/inviteflow/tabs/SyncTab.tsx
@@ -45,8 +45,6 @@ function onFormSubmit(e) {
   }
 }`;
 
-const SECTION = "text-[10px] text-gray-500 tracking-widest font-mono uppercase mt-5 mb-2.5 border-b border-gray-200 pb-1.5 dark:text-[#6e7681] dark:border-[#21262d]";
-
 export default function SyncTab() {
   const state = useAppState();
   const dispatch = useAppDispatch();
@@ -88,9 +86,9 @@ export default function SyncTab() {
       const rows = await sheetsGet(token, id, 'Sheet1!A:K');
       if (rows.length < 2) { setStatus('RSVP sheet appears empty.'); return; }
       const [header, ...data] = rows;
-      const emailCol = header.findIndex(h => h.toLowerCase().includes('email'));
+      const emailCol  = header.findIndex(h => h.toLowerCase().includes('email'));
       const statusCol = header.findIndex(h => h.toLowerCase().includes('attend') || h.toLowerCase().includes('rsvp'));
-      const dateCol = header.findIndex(h => h.toLowerCase().includes('date'));
+      const dateCol   = header.findIndex(h => h.toLowerCase().includes('date'));
       if (emailCol < 0) { setStatus('Cannot find Email column in RSVP sheet.'); return; }
 
       let updated = 0;
@@ -98,11 +96,12 @@ export default function SyncTab() {
         const match = data.find(r => r[emailCol]?.toLowerCase() === inv.email.toLowerCase());
         if (!match) return inv;
         const rawStatus = match[statusCol] ?? '';
-        const rsvpStatus: Invitee['rsvpStatus'] = rawStatus.toLowerCase().includes('yes') || rawStatus.toLowerCase().includes('attend')
-          ? 'Attending'
-          : rawStatus.toLowerCase().includes('no') || rawStatus.toLowerCase().includes('declin')
-            ? 'Declined'
-            : 'No Response';
+        const rsvpStatus: Invitee['rsvpStatus'] =
+          rawStatus.toLowerCase().includes('yes') || rawStatus.toLowerCase().includes('attend')
+            ? 'Attending'
+            : rawStatus.toLowerCase().includes('no') || rawStatus.toLowerCase().includes('declin')
+              ? 'Declined'
+              : 'No Response';
         const rsvpDate = dateCol >= 0 ? (match[dateCol] ?? '') : new Date().toISOString().slice(0, 10);
         updated++;
         return { ...inv, rsvpStatus, rsvpDate };
@@ -118,70 +117,65 @@ export default function SyncTab() {
 
   return (
     <div className="p-5 max-w-[760px] mx-auto w-full">
-      <div className="text-sm font-bold tracking-[0.08em] text-gray-900 mb-4 dark:text-[#f0f6fc]">SYNC</div>
+      <div className="if-page-title mb-4">SYNC</div>
 
       {status && (
-        <div className={`text-xs mb-4 ${status.startsWith('Error') ? 'text-red-600 dark:text-[#f85149]' : 'text-green-600 dark:text-[#3fb950]'}`}>
-          {status}
-        </div>
+        <div className={`if-status mb-4 ${status.startsWith('Error') ? 'err' : 'ok'}`}>{status}</div>
       )}
 
       {/* Action cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-7">
         {/* Push card */}
-        <div className="bg-white border border-gray-200 rounded-lg p-5 dark:bg-[#0d1117] dark:border-[#21262d]">
-          <div className={SECTION}>PUSH TO MASTER SHEET</div>
-          <p className="text-xs text-gray-500 mb-4 leading-relaxed dark:text-[#6e7681]">
+        <div className="if-card">
+          <div className="if-section-label mb-2.5 pb-1.5 border-b" style={{ borderColor: 'var(--border)' }}>
+            PUSH TO MASTER SHEET
+          </div>
+          <p style={{ fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.7, marginBottom: 12, fontFamily: 'monospace' }}>
             Clears and rewrites all {state.invitees.length} invitees to your master Google Sheet.
           </p>
           {ev?.masterSheetUrl
-            ? <a href={ev.masterSheetUrl} target="_blank" rel="noreferrer" className="text-[10px] text-blue-600 dark:text-[#58a6ff] mb-3 block">Open sheet ↗</a>
-            : <span className="text-[10px] text-red-600 dark:text-[#f85149] mb-3 block">Master Sheet URL not set in Setup.</span>
+            ? <a href={ev.masterSheetUrl} target="_blank" rel="noreferrer" style={{ fontSize: 10, color: 'var(--blue)', display: 'block', marginBottom: 10 }}>Open sheet &uarr;</a>
+            : <span style={{ fontSize: 10, color: 'var(--danger)', display: 'block', marginBottom: 10 }}>Master Sheet URL not set in Setup.</span>
           }
-          <button
-            className="min-h-[44px] px-3 py-1 rounded border border-green-600 bg-green-600 text-white text-xs font-mono tracking-wide cursor-pointer hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed dark:border-[#238636] dark:bg-[#238636]"
-            onClick={pushToSheets}
-            disabled={pushing}
-          >
-            {pushing ? 'Pushing…' : `Push ${state.invitees.length} rows`}
+          <button className="if-btn grn" onClick={pushToSheets} disabled={pushing}>
+            {pushing ? 'Pushing...' : `Push ${state.invitees.length} rows`}
           </button>
         </div>
 
         {/* Pull card */}
-        <div className="bg-white border border-gray-200 rounded-lg p-5 dark:bg-[#0d1117] dark:border-[#21262d]">
-          <div className={SECTION}>PULL RSVP RESPONSES</div>
-          <p className="text-xs text-gray-500 mb-4 leading-relaxed dark:text-[#6e7681]">
+        <div className="if-card">
+          <div className="if-section-label mb-2.5 pb-1.5 border-b" style={{ borderColor: 'var(--border)' }}>
+            PULL RSVP RESPONSES
+          </div>
+          <p style={{ fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.7, marginBottom: 12, fontFamily: 'monospace' }}>
             Reads RSVP statuses from your response sheet and updates invitee records.
           </p>
           {ev?.rsvpResponseUrl
-            ? <a href={ev.rsvpResponseUrl} target="_blank" rel="noreferrer" className="text-[10px] text-blue-600 dark:text-[#58a6ff] mb-3 block">Open sheet ↗</a>
-            : <span className="text-[10px] text-red-600 dark:text-[#f85149] mb-3 block">RSVP Response Sheet URL not set in Setup.</span>
+            ? <a href={ev.rsvpResponseUrl} target="_blank" rel="noreferrer" style={{ fontSize: 10, color: 'var(--blue)', display: 'block', marginBottom: 10 }}>Open sheet &uarr;</a>
+            : <span style={{ fontSize: 10, color: 'var(--danger)', display: 'block', marginBottom: 10 }}>RSVP Response Sheet URL not set in Setup.</span>
           }
-          <button
-            className="min-h-[44px] px-3 py-1 rounded border border-blue-400 bg-transparent text-blue-600 text-xs font-mono tracking-wide cursor-pointer hover:bg-blue-50 disabled:opacity-50 disabled:cursor-not-allowed dark:border-[#58a6ff] dark:text-[#58a6ff] dark:hover:bg-[#0d1f3c]"
-            onClick={pullRsvp}
-            disabled={pulling}
-          >
-            {pulling ? 'Pulling…' : 'Pull RSVP Responses'}
+          <button className="if-btn ghost" onClick={pullRsvp} disabled={pulling}>
+            {pulling ? 'Pulling...' : 'Pull RSVP Responses'}
           </button>
         </div>
       </div>
 
       {/* GAS section */}
-      <div className={SECTION}>GAS RSVP INGEST TRIGGER</div>
-      <p className="text-xs text-gray-500 leading-relaxed mb-3 dark:text-[#6e7681]">
-        Paste this script into your Google Form's Apps Script project. Add a trigger on{' '}
-        <code className="bg-gray-100 px-1 rounded text-[10px] dark:bg-[#161b22]">onFormSubmit</code>{' '}
+      <div className="if-section-label mb-2.5 pb-1.5 border-b" style={{ borderColor: 'var(--border)' }}>
+        GAS RSVP INGEST TRIGGER
+      </div>
+      <p style={{ fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.7, marginBottom: 10, fontFamily: 'monospace' }}>
+        Paste this script into your Google Form&apos;s Apps Script project. Add a trigger on{' '}
+        <code style={{ background: 'var(--bg-subtle)', padding: '1px 4px', borderRadius: 3, fontSize: 10 }}>onFormSubmit</code>{' '}
         (Form Submit event). Set script property{' '}
-        <code className="bg-gray-100 px-1 rounded text-[10px] dark:bg-[#161b22]">MASTER_SHEET_URL</code>{' '}
+        <code style={{ background: 'var(--bg-subtle)', padding: '1px 4px', borderRadius: 3, fontSize: 10 }}>MASTER_SHEET_URL</code>{' '}
         to your master sheet URL.
       </p>
-      <div className="relative">
-        <pre className="bg-gray-50 border border-gray-200 rounded-lg p-4 text-[10px] text-gray-800 overflow-x-auto leading-relaxed dark:bg-[#0d1117] dark:border-[#21262d] dark:text-[#c9d1d9]">
-          {GAS_CODE}
-        </pre>
+      <div style={{ position: 'relative' }}>
+        <pre className="if-code">{GAS_CODE}</pre>
         <button
-          className="absolute top-2 right-2 min-h-[32px] px-2.5 py-1 rounded border border-gray-300 bg-white text-gray-600 text-[10px] font-mono cursor-pointer hover:border-gray-500 dark:bg-[#161b22] dark:border-[#21262d] dark:text-[#8b949e]"
+          className="if-btn sm"
+          style={{ position: 'absolute', top: 8, right: 8 }}
           onClick={() => { navigator.clipboard.writeText(GAS_CODE); setStatus('Copied GAS code to clipboard.'); }}
         >
           Copy

--- a/src/inviteflow/tabs/TrackerTab.tsx
+++ b/src/inviteflow/tabs/TrackerTab.tsx
@@ -9,35 +9,35 @@ interface CategoryRow {
   noResponse: number;
 }
 
-const STAT_COLORS: Record<string, string> = {
-  TOTAL: 'border-l-gray-400 dark:border-l-[#8b949e]',
-  PENDING: 'border-l-gray-400 dark:border-l-[#6e7681]',
-  SENT: 'border-l-green-500 dark:border-l-[#3fb950]',
-  FAILED: 'border-l-red-500 dark:border-l-[#f85149]',
-  ATTENDING: 'border-l-[#C8A84B]',
-  DECLINED: 'border-l-red-500 dark:border-l-[#f85149]',
-  'NO RESPONSE': 'border-l-gray-400 dark:border-l-[#6e7681]',
+const STAT_BORDER: Record<string, string> = {
+  TOTAL:       'var(--text-secondary)',
+  PENDING:     'var(--text-muted)',
+  SENT:        'var(--success)',
+  FAILED:      'var(--danger)',
+  ATTENDING:   'var(--gold)',
+  DECLINED:    'var(--danger)',
+  'NO RESPONSE': 'var(--text-muted)',
 };
-const STAT_VALUE_COLORS: Record<string, string> = {
-  TOTAL: 'text-gray-500 dark:text-[#8b949e]',
-  PENDING: 'text-gray-500 dark:text-[#6e7681]',
-  SENT: 'text-green-600 dark:text-[#3fb950]',
-  FAILED: 'text-red-600 dark:text-[#f85149]',
-  ATTENDING: 'text-[#C8A84B]',
-  DECLINED: 'text-red-600 dark:text-[#f85149]',
-  'NO RESPONSE': 'text-gray-400 dark:text-[#6e7681]',
+const STAT_VALUE: Record<string, string> = {
+  TOTAL:       'var(--text-secondary)',
+  PENDING:     'var(--text-muted)',
+  SENT:        'var(--success)',
+  FAILED:      'var(--danger)',
+  ATTENDING:   'var(--gold)',
+  DECLINED:    'var(--danger)',
+  'NO RESPONSE': 'var(--text-muted)',
 };
 
 export default function TrackerTab() {
   const state = useAppState();
   const inv = state.invitees;
 
-  const total = inv.length;
-  const sent = inv.filter(i => i.inviteStatus === 'sent').length;
-  const pending = inv.filter(i => i.inviteStatus === 'pending').length;
-  const failed = inv.filter(i => i.inviteStatus === 'failed').length;
-  const attending = inv.filter(i => i.rsvpStatus === 'Attending').length;
-  const declined = inv.filter(i => i.rsvpStatus === 'Declined').length;
+  const total      = inv.length;
+  const sent       = inv.filter(i => i.inviteStatus === 'sent').length;
+  const pending    = inv.filter(i => i.inviteStatus === 'pending').length;
+  const failed     = inv.filter(i => i.inviteStatus === 'failed').length;
+  const attending  = inv.filter(i => i.rsvpStatus === 'Attending').length;
+  const declined   = inv.filter(i => i.rsvpStatus === 'Declined').length;
   const noResponse = inv.filter(i => i.rsvpStatus === 'No Response').length;
 
   const stats: [string, number][] = [
@@ -49,36 +49,33 @@ export default function TrackerTab() {
   const byCategory: CategoryRow[] = cats.map(cat => {
     const rows = inv.filter(i => i.category === cat);
     return {
-      category: cat,
-      total: rows.length,
-      sent: rows.filter(i => i.inviteStatus === 'sent').length,
-      attending: rows.filter(i => i.rsvpStatus === 'Attending').length,
-      declined: rows.filter(i => i.rsvpStatus === 'Declined').length,
+      category:   cat,
+      total:      rows.length,
+      sent:       rows.filter(i => i.inviteStatus === 'sent').length,
+      attending:  rows.filter(i => i.rsvpStatus === 'Attending').length,
+      declined:   rows.filter(i => i.rsvpStatus === 'Declined').length,
       noResponse: rows.filter(i => i.rsvpStatus === 'No Response').length,
     };
   });
 
   if (total === 0) {
-    return (
-      <div className="p-10 text-gray-500 text-xs text-center dark:text-[#6e7681]">
-        No invitees yet. Add them in the Invitees tab.
-      </div>
-    );
+    return <div className="if-empty">No invitees yet. Add them in the Invitees tab.</div>;
   }
 
   return (
     <div className="p-5 max-w-[900px] mx-auto w-full">
-      <div className="text-sm font-bold tracking-[0.08em] text-gray-900 mb-5 dark:text-[#f0f6fc]">TRACKER</div>
+      <div className="if-page-title mb-5">TRACKER</div>
 
       {/* Stat cards */}
       <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-2.5 mb-7">
         {stats.map(([label, value]) => (
           <div
             key={label}
-            className={`bg-white border border-gray-200 border-l-4 rounded-lg px-4 py-3 dark:bg-[#0d1117] dark:border-[#21262d] ${STAT_COLORS[label]}`}
+            className="if-stat"
+            style={{ borderLeftColor: STAT_BORDER[label] }}
           >
-            <div className="text-[9px] text-gray-500 tracking-[0.12em] font-mono mb-1.5 dark:text-[#6e7681]">{label}</div>
-            <div className={`text-2xl font-bold ${STAT_VALUE_COLORS[label]}`}>{value}</div>
+            <div className="if-stat-label">{label}</div>
+            <div className="if-stat-value" style={{ color: STAT_VALUE[label] }}>{value}</div>
           </div>
         ))}
       </div>
@@ -86,14 +83,21 @@ export default function TrackerTab() {
       {/* By category table */}
       {byCategory.length > 0 && (
         <>
-          <div className="text-[10px] text-gray-500 tracking-widest font-mono uppercase mb-2.5 dark:text-[#6e7681]">BY CATEGORY</div>
-          <div className="border border-gray-200 rounded-lg overflow-hidden dark:border-[#21262d]">
+          <div className="if-section-label mb-2.5">BY CATEGORY</div>
+          <div style={{ border: '1px solid var(--border)', borderRadius: 6, overflow: 'hidden' }}>
             <div className="overflow-x-auto" role="region" aria-label="Category breakdown" tabIndex={0}>
-              <table className="w-full border-collapse">
+              <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'monospace' }}>
                 <thead>
                   <tr>
                     {['Category', 'Total', 'Sent', 'Attending', 'Declined', 'No Response'].map(h => (
-                      <th key={h} className="text-[10px] text-gray-500 tracking-widest font-mono uppercase text-left px-3 py-2 border-b border-gray-200 dark:text-[#6e7681] dark:border-[#21262d]">
+                      <th
+                        key={h}
+                        style={{
+                          fontSize: 10, color: 'var(--text-muted)', letterSpacing: '0.1em',
+                          textTransform: 'uppercase', textAlign: 'left', padding: '6px 12px',
+                          borderBottom: '1px solid var(--border)',
+                        }}
+                      >
                         {h}
                       </th>
                     ))}
@@ -101,13 +105,13 @@ export default function TrackerTab() {
                 </thead>
                 <tbody>
                   {byCategory.map(row => (
-                    <tr key={row.category} className="border-b border-gray-100 last:border-0 dark:border-[#161b22]">
-                      <td className="text-xs text-gray-900 px-3 py-1.5 dark:text-[#c9d1d9]">{row.category}</td>
-                      <td className="text-xs text-gray-700 px-3 py-1.5 dark:text-[#c9d1d9]">{row.total}</td>
-                      <td className="text-xs text-green-600 px-3 py-1.5 dark:text-[#3fb950]">{row.sent}</td>
-                      <td className="text-xs text-[#C8A84B] px-3 py-1.5">{row.attending}</td>
-                      <td className="text-xs text-red-600 px-3 py-1.5 dark:text-[#f85149]">{row.declined}</td>
-                      <td className="text-xs text-gray-500 px-3 py-1.5 dark:text-[#6e7681]">{row.noResponse}</td>
+                    <tr key={row.category} style={{ borderBottom: '1px solid var(--bg-subtle)' }}>
+                      <td style={{ fontSize: 11, color: 'var(--text-base)', padding: '5px 12px' }}>{row.category}</td>
+                      <td style={{ fontSize: 11, color: 'var(--text-secondary)', padding: '5px 12px' }}>{row.total}</td>
+                      <td style={{ fontSize: 11, color: 'var(--success)', padding: '5px 12px' }}>{row.sent}</td>
+                      <td style={{ fontSize: 11, color: 'var(--gold)', padding: '5px 12px' }}>{row.attending}</td>
+                      <td style={{ fontSize: 11, color: 'var(--danger)', padding: '5px 12px' }}>{row.declined}</td>
+                      <td style={{ fontSize: 11, color: 'var(--text-muted)', padding: '5px 12px' }}>{row.noResponse}</td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
## Summary

- Creates `src/inviteflow/styles/if.css` — a design system mirroring the ContactScout `.cs-*` vocabulary (`.if-btn`, `.if-card`, `.if-section-label`, `.if-input`, `.if-pill`, `.if-stat`, `.if-code`, `.if-empty`, `.if-nav-tab`, etc.) built on the CSS variable palette already defined in `theme.css`
- Updates all seven tabs to use the new CSS classes, replacing scattered Tailwind `dark:` variant strings and inline style objects with consistent named tokens
- Defaults to dark mode unless the user has explicitly saved a light preference (was defaulting to light on first visit)
- Removes the theme toggle from the header (dark-only, matching ContactScout)

## Visual alignment

Both apps now share the same dark GitHub-style palette, button shapes, card treatment, section label typography, and input styling. The key design tokens (`--bg-root`, `--bg-surface`, `--border`, `--text-heading`, `--accent`, `--success`, `--danger`, `--gold`) are already identical between the two apps via `theme.css` — this PR wires every component up to those tokens consistently.

## Test plan

- [ ] Open InviteFlow — confirm dark mode on first load
- [ ] Check Events tab: cards, primary/delete buttons
- [ ] Check Setup tab: section labels, input fields, ghost auth buttons, save button
- [ ] Check Invitees tab: toolbar buttons, bulk action bar, DataTable styling, Add modal
- [ ] Check Compose tab: token buttons, format bar, editor/preview panes
- [ ] Check Send tab: filter pills, progress bar, send log
- [ ] Check Tracker tab: stat cards with colored left borders, category table
- [ ] Check Sync tab: action cards, GAS code block, copy button
- [ ] Resize to 900px — confirm no layout breakage
- [ ] Resize to 375px — confirm buttons meet 44px tap targets

https://claude.ai/code/session_01KUj23kDPTXcT734ECT98nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUj23kDPTXcT734ECT98nC)_