### PR TITLE
Switch ContactScout to Gemini 2.5 Flash (free forever)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,109 @@
+# Handoff — ContactScout Tech Overhaul
+
+**Date:** 2026-04-28
+**Branch:** `claude/contactscout-tech-overhaul-QbbSS`
+**PR:** https://github.com/lychan110/rsvp-automation/pull/26 (draft, open, clean merge)
+**Commit:** `943bda9`
+**Author:** Lenya Chan
+
+---
+
+## What was done this session
+
+Full overhaul of ContactScout (`src/contact-scout/src/`) triggered by an exploration report on government contact discovery for Dragon Boat Festival / Asia Fest 2026. The report proposed deterministic scrapers; the session challenged that approach (CORS blocks direct fetches in a browser app) and instead delivered:
+
+### 1. Extended data model (`types.ts`)
+Four new fields on `CSOfficial`:
+- `schedulerName: string` — name of the official's scheduler / chief-of-staff
+- `schedulerEmail: string` — scheduler's email (highest-priority contact for event invitations)
+- `appearanceFormUrl: string` — web form URL for offices that don't accept email requests
+- `emailSource: 'scanned' | 'inferred' | 'manual'` — provenance tracking for the direct email
+
+Two new type aliases: `EmailSource`, `ContactMethod`.
+
+### 2. Deterministic email inference engine (`emailPatterns.ts` — new file)
+- Federal House: `FirstName.LastName@mail.house.gov`
+- Federal Senate: `FirstName.LastName@{surname}.senate.gov`
+- NC state legislature: `FirstName.LastName@ncleg.gov`
+- Handles diacritics via NFD decomposition
+- `bestEmail(o)` helper: `schedulerEmail || directEmail || officeEmail || ''`
+- `applyEmailInference()` batch-fills officials post-scan
+- Inferred emails are marked `emailSource: 'inferred'` and shown with an INFERRED badge in the UI; they rank below scanned/scheduler in export priority
+
+### 3. API layer improvements (`api.ts`, `constants.ts`)
+- Model upgraded to `claude-sonnet-4-6`; model IDs in `MODEL_SCAN` / `MODEL_VERIFY` constants
+- Exponential backoff on 429: 2s → 4s → 8s
+- Robust JSON extraction with object-boundary fallback
+- `max_tokens` raised to 2000
+- `callClaude()` now takes `model` as a parameter (not hardcoded)
+
+### 4. Prompt improvements (`constants.ts`, `utils.ts`)
+- `SCAN_SYS` and `VERIFY_SYS` now ask Claude to find scheduler name, scheduler email, and appearance form URL for each official
+- Every scan prompt appends a scheduler-discovery instruction
+- Verify prompt sends existing scheduler data for confirmation/update
+
+### 5. `AddOfficialModal.tsx` (new component)
+- Replaces three chained `prompt()` browser dialogs with a proper form modal
+- All fields including scheduler + form URL
+- Live email inference preview updates as name/category is typed
+
+### 6. UI updates
+- **OfficialsTab**: new contact-method column (SCHED / DIRECT / INFERRED / OFFICE / FORM / NO EMAIL); email source badge; scheduler section + form URL in expanded row; "Infer Emails" button
+- **DiscoverTab**: candidates show scheduler email in gold or inferred badge; scan card shows count with scheduler found
+- **ExportTab**: contact-method breakdown table (scheduler / direct / inferred / office / form-only / no-contact counts); warning for inferred emails; CSV gains 4 new columns
+- **Stats bar** (App.tsx): gold SCHEDULER dot counting officials with a known scheduler email
+
+### 7. localStorage migration (`App.tsx`)
+`normaliseOfficial()` fills new fields with safe defaults on load — existing data upgrades silently, no reset required.
+
+---
+
+## Current state
+
+| Item | Status |
+|------|--------|
+| TypeScript build | Clean (0 errors) |
+| Vite production build | Clean (190 kB JS, 7.6 kB CSS) |
+| PR #26 | Draft, open, no CI checks configured for repo |
+| Review comments | None |
+| Merge conflicts | None (mergeable: clean) |
+
+---
+
+## Pending / next steps
+
+1. **Mark PR ready for review** when Lenya is satisfied with the implementation and has tested manually per the PR test plan.
+
+2. **Manual testing checklist** (from PR description):
+   - Load with existing localStorage — verify no data loss, new fields default empty
+   - Run a scan — confirm scheduler fields appear in candidate cards
+   - Run "Infer Emails" on a list with federal officials — verify INFERRED badge and address pattern
+   - Add official manually via modal — confirm inference preview updates live
+   - Run verify — confirm scheduler fields update from Claude result
+   - Export tab — confirm breakdown table matches Officials list
+   - Download CSV — confirm new columns present
+   - Trigger 429 (rapid scans) — confirm backoff delay logged
+
+3. **CLAUDE.md update** (not yet done): document `emailPatterns.ts`, the new `CSOfficial` fields, updated `callClaude()` signature, and `MODEL_SCAN`/`MODEL_VERIFY` constants.
+
+4. **`docs/TASKS.md`** — the P2 "smarter rate-limit backoff" item is now resolved; mark complete.
+
+5. **Jurisdiction customization**: `App.tsx` `SCAN_PROMPTS` still contain `[YOUR STATE]`, `[YOUR COUNTIES]`, `[CITY 1/2/3]` placeholders that must be replaced before first real scan. The `needsCustomization()` guard detects them and shows a warning banner.
+
+---
+
+## File inventory (changed this session)
+
+| File | Change |
+|------|--------|
+| `src/contact-scout/src/types.ts` | 4 new fields, 2 new types |
+| `src/contact-scout/src/constants.ts` | Model constants, updated SCAN_SYS/VERIFY_SYS prompts |
+| `src/contact-scout/src/emailPatterns.ts` | NEW — inference engine |
+| `src/contact-scout/src/api.ts` | Backoff, model param, robust JSON extraction |
+| `src/contact-scout/src/utils.ts` | bestEmail in export, scheduler in scan prompts |
+| `src/contact-scout/src/App.tsx` | normaliseOfficial, inferMissing, AddOfficialModal wiring, stats bar |
+| `src/contact-scout/src/components/AddOfficialModal.tsx` | NEW — replaces prompt() dialogs |
+| `src/contact-scout/src/components/OfficialsTab.tsx` | Contact-method column, source badge, expanded scheduler row |
+| `src/contact-scout/src/components/DiscoverTab.tsx` | Scheduler count, gold email in candidates |
+| `src/contact-scout/src/components/ExportTab.tsx` | Breakdown table, inferred warning, CSV columns |
+| `src/contact-scout/src/styles.css` | 6-col grid, mobile breakpoint fix |

--- a/docs/superpowers/plans/2026-04-29-gemini-migration.md
+++ b/docs/superpowers/plans/2026-04-29-gemini-migration.md
@@ -1,0 +1,175 @@
+# ContactScout: Gemini Migration Plan
+Author: Lenya Chan
+Date: 2026-04-29
+
+## Context
+
+ContactScout currently calls the Anthropic Claude API (`claude-sonnet-4-6`) with the
+`web_search_20250305` tool directly from the browser. This costs money. The app is for
+personal/non-profit use, so we are switching to Google Gemini 2.5 Flash with Search
+Grounding, which is free forever with no credit card required (Google AI Studio free tier).
+
+---
+
+## Task 3: Migration Plan
+
+### Chosen provider: Google Gemini 2.5 Flash + Google Search Grounding
+
+- Endpoint: `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={apiKey}`
+- Search: `tools: [{ "google_search": {} }]` (first-party Google Search grounding, built-in)
+- Free tier: 15 RPM, 1000 RPD (no credit card)
+- Browser-direct: API key in URL query param; no CORS proxy needed
+- Keys from: https://aistudio.google.com/ → Get API key; format starts with `AIza`
+
+### Constraint: JSON mode is incompatible with Search Grounding
+
+`responseMimeType: "application/json"` cannot be combined with the `google_search` tool
+(Google API returns 400). This is not a blocker because the current codebase already
+uses the text-parse approach: system prompts instruct the model to output raw JSON,
+and `extractJson()` strips any markdown fences. This same approach works with Gemini.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `src/api.ts` | Replace `callClaude()` with `callGemini()` using Gemini REST endpoint |
+| `src/constants.ts` | `MODEL_SCAN` and `MODEL_VERIFY` → `"gemini-2.5-flash"` |
+| `src/components/ApiKeyModal.tsx` | Update key format validation (`AIza`), instructions, and link to AI Studio |
+| `src/App.tsx` | Rename import (`callClaude` → `callGemini`); fix inter-call delay (700ms → 4500ms) |
+| `src/contact-scout/CLAUDE.md` | Update API setup section |
+
+### Rate limit fix (critical)
+
+Gemini 2.5 Flash free tier: **15 RPM** = 1 request every 4 seconds.
+Current verify loop delay: **700ms** — this will cause immediate 429s during bulk verify.
+Fix: increase delay to **4500ms** (safe margin below 4000ms per call).
+
+Impact: verifying 100 officials takes ~7.5 minutes. Acceptable for an infrequent batch operation.
+
+### Gemini API request shape
+
+```json
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={apiKey}
+
+{
+  "system_instruction": { "parts": [{ "text": "<SCAN_SYS or VERIFY_SYS>" }] },
+  "contents": [{ "role": "user", "parts": [{ "text": "<scan or verify prompt>" }] }],
+  "tools": [{ "google_search": {} }]
+}
+```
+
+Response path: `candidates[0].content.parts[0].text` → run through `extractJson()`.
+
+Error handling:
+- HTTP 400 with `"API key not valid"` → clear key, throw `"Invalid API key"`
+- HTTP 429 → retry with 2s/4s/8s exponential backoff (same as current)
+- `data.error` present → throw `data.error.message`
+
+---
+
+## Task 4: LLM Usage Critique
+
+### Current LLM usage in ContactScout
+
+Two operations use the LLM:
+1. **Scan** — discover all current officials in a category (e.g., "all NC state senators")
+2. **Verify** — re-check a known official's status and update their contact details
+
+### Angle 1: Is the LLM essential?
+
+**Scan:** Yes. There is no free structured API that returns "all current elected officials for
+a given US state with their emails and schedulers" in a single call. Google Civic API is
+deprecated. Ballotpedia has no free tier. OpenSecrets is read-only for contributions. The
+LLM with web search is the only viable path to discovering officials without a paid data feed.
+
+**Verify:** Partially. The "still in office" check genuinely requires live web search — LLM
+training data is 6-18 months stale relative to election cycles. However, verifying email
+addresses for officials whose status hasn't changed is of marginal value and wastes quota.
+
+**Verdict:** LLM is essential for scan. Verify is useful post-election but expensive for
+stable rosters. The `lastVerifiedAt` pattern (skip re-verify if checked < 30 days ago) would
+cut verify quota usage by 80% in steady state.
+
+### Angle 2: Is it effective?
+
+**Strong:** Federal officials (Congress, state executive). Well-indexed, stable roles, clear
+email patterns. Email inference (`emailPatterns.ts`) covers the majority of federal contacts
+without any LLM call.
+
+**Moderate:** State legislature. Large bodies (50+ seats) risk partial results if the LLM
+response gets long. A 50-seat senate returned in one JSON object can hit max_tokens silently.
+
+**Weak:** City councils. Local data is less indexed; hallucination risk is highest. Results
+should be treated as starting-point candidates, not ground truth.
+
+**Scheduler discovery:** The highest-value differentiator. No structured data source exists
+for scheduler names/emails. LLM web search is the only practical source. This feature is
+worth protecting even if other parts are simplified.
+
+### Angle 3: Does the current architecture over-rely on LLM?
+
+Yes, in one specific way: the scan prompt asks for official email AND scheduler email in a
+single call. For large bodies (state senate/house), bundling scheduler lookup with basic
+discovery overloads the response. The LLM may return partial scheduler info or truncate the
+official list.
+
+A two-pass approach would be more reliable:
+- Pass 1 (scan): official name, title, district, category only
+- Pass 2 (verify): contact details including scheduler
+
+However, this doubles API calls per official and hits the 1000 RPD limit faster. The
+current bundled approach is a deliberate trade-off: one call with some scheduler gaps vs.
+two calls with better completeness. Given the RPD constraint, the bundled approach is
+**correct for this use case**. Do not change it.
+
+### Angle 4: What email inference already eliminates
+
+`emailPatterns.ts` infers correct emails for:
+- All US House members (`firstname.lastname@mail.house.gov`)
+- All US Senators (`firstname.lastname@lastname.senate.gov`)
+- NC General Assembly (`firstname.lastname@ncleg.gov`)
+
+These cover the most frequently contacted officials. For these categories, the LLM's email
+search is redundant and the inferred address is more reliable. The LLM's value for these
+categories is exclusively for scheduler discovery.
+
+Opportunity: expand `emailPatterns.ts` to additional state legislatures with known patterns.
+This reduces LLM dependency without degrading quality.
+
+### Angle 5: Rate limit sustainability
+
+With 1000 RPD on Gemini free tier:
+- 7 scan targets = 7 calls (one per target)
+- ~100 official verifications = 100 calls
+- Total: 107 calls per full cycle
+
+This fits in one day but leaves minimal buffer. In practice:
+- Scans run once per election cycle (2x/year)
+- Verifications run monthly or post-election
+- Daily use is typically 0-5 verify calls (checking new or changed officials)
+
+Verdict: 1000 RPD is sufficient for the actual usage pattern.
+
+### Decisions
+
+| Finding | Action |
+|---------|--------|
+| 700ms delay breaks at Gemini 15 RPM | Fix delay to 4500ms |
+| Bundled scan+scheduler prompt is correct | Keep as-is |
+| Email inference reduces LLM calls | Keep and note for future expansion |
+| Verify wastes quota on stable officials | Note `lastVerifiedAt` as future improvement |
+| City council results unreliable | Document in UI (low-confidence warning already exists via `confidence` field) |
+| Key validation rejects Google keys | Fix in ApiKeyModal |
+
+---
+
+## What is NOT changing
+
+- The scan prompt content and JSON schema
+- The verify prompt content
+- The `extractJson()` parser
+- The `emailPatterns.ts` inference layer
+- The two-pass scan → verify workflow
+- The export schema contract with InviteFlow
+- Local storage persistence
+- The password gate

--- a/src/contactscout/CLAUDE.md
+++ b/src/contactscout/CLAUDE.md
@@ -102,25 +102,28 @@ package.json
 ## Persistence
 
 - `localStorage` key: `contactscout_state` — stores `{ officials, newOfficials, scanStatus, scanMeta }`
-- `sessionStorage` key: `cs_api_key` — stores Claude API key for this browser session
+- `sessionStorage` key: `cs_api_key` — stores Google AI Studio API key for this browser session
 - `sessionStorage` key: `cs_unlocked` — set to `'1'` after password gate is passed
 
 ---
 
-## Claude API key setup
+## Google AI Studio API key setup
 
-ContactScout calls the Anthropic API directly from the browser. No backend required.
+ContactScout calls the Gemini API directly from the browser. No backend required.
+Provider: Google Gemini 2.5 Flash with Google Search Grounding (free forever, no credit card).
 
-1. Go to https://console.anthropic.com/ → API Keys → Create Key.
-2. Copy the key (starts with `sk-ant-`).
-3. In the app, click **⚙ Key** in the header and paste the key.
+1. Go to https://aistudio.google.com/ → Get API key → Create API key.
+2. Copy the key (starts with `AIza`).
+3. In the app, click **Key** in the header and paste the key.
 4. The key is stored in `sessionStorage` only — it is never persisted to `localStorage`
-   or sent anywhere except `https://api.anthropic.com/v1/messages`.
+   or sent anywhere except `https://generativelanguage.googleapis.com/`.
 
-Required header: `anthropic-dangerous-direct-browser-access: true` (Anthropic allowlist for
-browser-direct usage).
+Endpoint: `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={apiKey}`
+Tool: `google_search` grounding (first-party, free up to ~1500 req/day).
+Free tier limits: 15 RPM, 1000 RPD. Verify loop uses 4500ms delay to stay safely under the RPM cap.
 
-Model used: `claude-sonnet-4-20250514` with the `web_search_20250305` tool.
+Note: `responseMimeType` JSON mode is incompatible with `google_search` grounding. The system
+prompt instructs the model to return raw JSON, and `extractJson()` in `api.ts` handles parsing.
 
 ---
 

--- a/src/contactscout/src/App.tsx
+++ b/src/contactscout/src/App.tsx
@@ -1,10 +1,15 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { CS_APIKEY_SK, VERIFY_SYS, SCAN_SYS, SCAN_TARGETS } from './constants';
+import {
+  CS_APIKEY_SK, VERIFY_SYS, SCAN_SYS, SCAN_TARGETS,
+  MODEL_SCAN, MODEL_VERIFY,
+} from './constants';
 import { loadCSState, saveCSState, loadJurisdiction } from './storage';
 import { sleep, officialToInvitee, buildScanPrompts, downloadBlob, todaySlug } from './utils';
+import { applyEmailInference } from './emailPatterns';
 import { callClaude } from './api';
 import ApiKeyModal from './components/ApiKeyModal';
 import JurisdictionModal from './components/JurisdictionModal';
+import AddOfficialModal from './components/AddOfficialModal';
 import LogSidebar from './components/LogSidebar';
 import DiscoverTab from './components/DiscoverTab';
 import OfficialsTab from './components/OfficialsTab';
@@ -17,29 +22,58 @@ export default function App() {
   return <ContactScoutInner />;
 }
 
+// ── Blank official used for new entries ───────────────────────────────────────
+
+function blankOfficial(): CSOfficial {
+  return {
+    name: '', title: '', district: '', county: '', category: '',
+    directEmail: '', officeEmail: '', officePhone: '',
+    schedulerName: '', schedulerEmail: '', appearanceFormUrl: '',
+    emailSource: 'manual',
+    status: 'pending', result: null,
+  };
+}
+
+/** Normalises an official coming from the API, filling in any missing new fields. */
+function normaliseOfficial(o: CSOfficial): CSOfficial {
+  return {
+    ...blankOfficial(),
+    ...o,
+    schedulerName:      o.schedulerName      ?? '',
+    schedulerEmail:     o.schedulerEmail     ?? '',
+    appearanceFormUrl:  o.appearanceFormUrl  ?? '',
+    emailSource:        o.emailSource        ?? 'scanned',
+  };
+}
+
 // ── Inner component (all app state lives here) ─────────────────────────────────
 
 function ContactScoutInner() {
   const init = loadCSState();
-  const [officials,    setOfficials]    = useState<CSOfficial[]>(init.officials);
-  const [newOfficials, setNewOfficials] = useState<CSOfficial[]>(init.newOfficials);
+  const [officials,    setOfficials]    = useState<CSOfficial[]>(
+    init.officials.map(normaliseOfficial),
+  );
+  const [newOfficials, setNewOfficials] = useState<CSOfficial[]>(
+    init.newOfficials.map(normaliseOfficial),
+  );
   const [scanStatus,   setScanStatus]   = useState<Record<string, ScanState>>(init.scanStatus);
   const [scanMeta,     setScanMeta]     = useState<CSPersistedState['scanMeta']>(init.scanMeta);
 
-  const [tab,          setTab]          = useState<0 | 1 | 2>(0);
-  const [activeCat,    setActiveCat]    = useState('All');
-  const [selected,     setSelected]     = useState<Set<string>>(new Set());
-  const [running,      setRunning]      = useState(false);
-  const [progress,     setProgress]     = useState({ done: 0, total: 0 });
-  const [log,          setLog]          = useState<string[]>([]);
-  const [apiKey,       setApiKey]       = useState(() => sessionStorage.getItem(CS_APIKEY_SK) || '');
-  const [jx,           setJx]           = useState<CSJurisdiction>(loadJurisdiction);
-  const [showKeyModal, setShowKeyModal] = useState(false);
-  const [showJxModal,  setShowJxModal]  = useState(false);
-  const [showLog,      setShowLog]      = useState(false);
+  const [tab,           setTab]          = useState<0 | 1 | 2>(0);
+  const [activeCat,     setActiveCat]    = useState('All');
+  const [selected,      setSelected]     = useState<Set<string>>(new Set());
+  const [running,       setRunning]      = useState(false);
+  const [progress,      setProgress]     = useState({ done: 0, total: 0 });
+  const [log,           setLog]          = useState<string[]>([]);
+  const [apiKey,        setApiKey]       = useState(() => sessionStorage.getItem(CS_APIKEY_SK) || '');
+  const [jx,            setJx]           = useState<CSJurisdiction>(loadJurisdiction);
+  const [showKeyModal,  setShowKeyModal]  = useState(false);
+  const [showJxModal,   setShowJxModal]   = useState(false);
+  const [showAddModal,  setShowAddModal]  = useState(false);
+  const [showLog,       setShowLog]       = useState(false);
 
-  const abortRef     = useRef(false);
-  const pendingRef   = useRef<(() => void) | null>(null);
+  const abortRef      = useRef(false);
+  const pendingRef    = useRef<(() => void) | null>(null);
   const importFileRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -48,10 +82,10 @@ function ContactScoutInner() {
 
   const addLog = useCallback((msg: string) => {
     const ts = new Date().toLocaleTimeString();
-    setLog(prev => [`[${ts}] ${msg}`, ...prev.slice(0, 99)]);
+    setLog(prev => [`[${ts}] ${msg}`, ...prev.slice(0, 199)]);
   }, []);
 
-  // ── API call wrapper (handles missing key + invalid key) ───────────────────
+  // ── API key flow ───────────────────────────────────────────────────────────
 
   function openKeyModal(onSave?: () => void) {
     pendingRef.current = onSave ?? null;
@@ -66,14 +100,18 @@ function ContactScoutInner() {
     cb?.();
   }
 
-  async function apiCall(sys: string, user: string): Promise<Record<string, unknown>> {
+  async function apiCall(
+    model: string,
+    sys: string,
+    user: string,
+  ): Promise<Record<string, unknown>> {
     if (!apiKey) {
       return new Promise((resolve, reject) => {
-        openKeyModal(() => apiCall(sys, user).then(resolve).catch(reject));
+        openKeyModal(() => apiCall(model, sys, user).then(resolve).catch(reject));
       });
     }
     try {
-      return await callClaude(apiKey, sys, user);
+      return await callClaude(apiKey, model, sys, user);
     } catch (e) {
       if (String(e).includes('Invalid API key')) setApiKey('');
       throw e;
@@ -95,23 +133,52 @@ function ContactScoutInner() {
       if (!off) continue;
 
       addLog(`Verifying ${name}…`);
-      setOfficials(prev => prev.map(o => o.name === name ? { ...o, status: 'checking' } : o));
+      setOfficials(prev =>
+        prev.map(o => o.name === name ? { ...o, status: 'checking' } : o),
+      );
 
       try {
-        const prompt = `Verify for 2025-2026:\nName: ${off.name}\nTitle: ${off.title}\nCategory: ${off.category}\nDistrict: ${off.district || 'N/A'}\nEmail: ${off.directEmail || off.officeEmail || 'none'}`;
-        const r = await apiCall(VERIFY_SYS, prompt);
+        const prompt =
+          `Verify for 2025-2026:\n` +
+          `Name: ${off.name}\nTitle: ${off.title}\nCategory: ${off.category}\n` +
+          `District: ${off.district || 'N/A'}\n` +
+          `Direct email: ${off.directEmail || 'none'}\n` +
+          `Office email: ${off.officeEmail || 'none'}\n` +
+          `Scheduler: ${off.schedulerName || 'unknown'} <${off.schedulerEmail || 'none'}>\n` +
+          `Appearance form: ${off.appearanceFormUrl || 'none'}`;
+
+        const r = await apiCall(MODEL_VERIFY, VERIFY_SYS, prompt);
+
         const changed = !r.stillInOffice || r.changes !== 'No changes detected' || r.flags;
-        const newStatus: CSStatus = !r.stillInOffice ? 'left_office' : changed ? 'changed' : 'done';
-        setOfficials(prev => prev.map(o => o.name === name ? {
-          ...o, status: newStatus, result: r as Record<string, string | boolean>,
-          directEmail: (r.directEmail as string) || o.directEmail,
-          officeEmail:  (r.officeEmail  as string) || o.officeEmail,
-          officePhone:  (r.officePhone  as string) || o.officePhone,
-          title:        (r.currentTitle as string) || o.title,
-        } : o));
-        addLog(`✓ ${name}: ${r.stillInOffice ? 'In office' : '⚠ LEFT OFFICE'} — ${r.changes}`);
+        const newStatus: CSStatus = !r.stillInOffice
+          ? 'left_office'
+          : changed ? 'changed' : 'done';
+
+        setOfficials(prev => prev.map(o => {
+          if (o.name !== name) return o;
+          return {
+            ...o,
+            status:           newStatus,
+            result:           r as Record<string, string | boolean>,
+            directEmail:      (r.directEmail as string)     || o.directEmail,
+            officeEmail:      (r.officeEmail as string)     || o.officeEmail,
+            officePhone:      (r.officePhone as string)     || o.officePhone,
+            schedulerName:    (r.schedulerName as string)   || o.schedulerName,
+            schedulerEmail:   (r.schedulerEmail as string)  || o.schedulerEmail,
+            appearanceFormUrl:(r.appearanceFormUrl as string) || o.appearanceFormUrl,
+            title:            (r.currentTitle as string)    || o.title,
+            emailSource:      (r.directEmail || r.officeEmail) ? 'scanned' : o.emailSource,
+          };
+        }));
+
+        const sched = (r.schedulerName as string) ? ` · sched: ${r.schedulerName as string}` : '';
+        addLog(`✓ ${name}: ${r.stillInOffice ? 'In office' : '⚠ LEFT OFFICE'} — ${r.changes as string}${sched}`);
       } catch (e) {
-        setOfficials(prev => prev.map(o => o.name === name ? { ...o, status: 'error', result: { error: String(e) } } : o));
+        setOfficials(prev =>
+          prev.map(o => o.name === name
+            ? { ...o, status: 'error', result: { error: String(e) } }
+            : o),
+        );
         addLog(`✗ ${name}: ${String(e)}`);
       }
 
@@ -120,7 +187,7 @@ function ContactScoutInner() {
     }
 
     setRunning(false);
-    addLog(`Done — ${names.length} checked.`);
+    addLog(`Done — ${names.length} verified.`);
   }
 
   // ── Scan ───────────────────────────────────────────────────────────────────
@@ -134,29 +201,36 @@ function ContactScoutInner() {
     addLog(`Scanning: ${SCAN_TARGETS.find(t => t.id === id)?.label}…`);
 
     try {
-      const r = await apiCall(SCAN_SYS, buildScanPrompts(jx)[id]);
+      const r = await apiCall(MODEL_SCAN, SCAN_SYS, buildScanPrompts(jx)[id]);
       const currentNames = new Set(officials.map(o => o.name.toLowerCase().trim()));
-      const found = (r.officials as CSOfficial[]) ?? [];
+      const found = ((r.officials as CSOfficial[]) ?? []).map(normaliseOfficial);
       const fresh = found.filter(o => !currentNames.has(o.name.toLowerCase().trim()));
 
-      setScanStatus(prev => ({ ...prev, [id]: 'done' }));
-      setScanMeta(prev => ({ ...prev, [id]: { total: found.length, confidence: r.confidence as string, notes: r.notes as string } }));
+      // Apply email inference to fresh officials that have no scanned email
+      const { officials: inferredFresh, inferredCount } = applyEmailInference(fresh, jx);
 
-      if (fresh.length > 0) {
+      setScanStatus(prev => ({ ...prev, [id]: 'done' }));
+      setScanMeta(prev => ({
+        ...prev,
+        [id]: { total: found.length, confidence: r.confidence as string, notes: r.notes as string },
+      }));
+
+      if (inferredFresh.length > 0) {
         setNewOfficials(prev => {
           const ex = new Set(prev.map(x => x.name.toLowerCase()));
           return [
             ...prev,
-            ...fresh
+            ...inferredFresh
               .filter(x => !ex.has(x.name.toLowerCase()))
-              .map(x => ({ ...x, _scanId: id, status: 'pending' as CSStatus, result: null })),
+              .map(x => ({ ...x, _scanId: id, status: 'pending' as CSStatus })),
           ];
         });
-        addLog(`✓ ${fresh.length} new found.`);
+        const infMsg = inferredCount > 0 ? `, ${inferredCount} emails inferred` : '';
+        addLog(`✓ ${inferredFresh.length} new found${infMsg}.`);
       } else {
         addLog(`✓ All ${found.length} already in list.`);
       }
-      if (r.notes) addLog(`ℹ ${r.notes}`);
+      if (r.notes) addLog(`ℹ ${r.notes as string}`);
     } catch (e) {
       setScanStatus(prev => ({ ...prev, [id]: 'error' }));
       addLog(`✗ Scan: ${String(e)}`);
@@ -168,13 +242,20 @@ function ContactScoutInner() {
   // ── Officials management ───────────────────────────────────────────────────
 
   function addNew(o: CSOfficial) {
-    setOfficials(prev => [...prev, { ...o, status: 'pending', result: null }]);
+    setOfficials(prev => [...prev, normaliseOfficial({ ...o, status: 'pending', result: null })]);
     setNewOfficials(prev => prev.filter(x => x.name !== o.name));
-    addLog(`+ Added ${o.name}`);
+    const sched = o.schedulerEmail ? ` (sched: ${o.schedulerEmail})` : '';
+    addLog(`+ Added ${o.name}${sched}`);
   }
 
   function dismissNew(name: string) {
     setNewOfficials(prev => prev.filter(x => x.name !== name));
+  }
+
+  function addManual(o: CSOfficial) {
+    setOfficials(prev => [...prev, normaliseOfficial(o)]);
+    const sched = o.schedulerEmail ? ` · sched: ${o.schedulerEmail}` : '';
+    addLog(`+ Manually added ${o.name}${sched}`);
   }
 
   function toggleSel(name: string) {
@@ -185,28 +266,30 @@ function ContactScoutInner() {
     });
   }
 
-  function addManually() {
-    const name = prompt('Full name:');
-    if (!name) return;
-    const title = prompt('Title:', '') ?? '';
-    const email = prompt('Email:', '') ?? '';
-    const cat   = prompt('Category (US Senate/US House/Executive/State Senate/House/City Council):', 'City Council') ?? 'City Council';
-    setOfficials(prev => [...prev, {
-      name, title, directEmail: email, officeEmail: '', officePhone: '',
-      district: '', county: '', category: cat, status: 'pending', result: null,
-    }]);
-    addLog(`+ Added ${name}`);
+  // ── Infer emails for all officials missing one ─────────────────────────────
+
+  function inferMissing() {
+    const { officials: updated, inferredCount } = applyEmailInference(officials, jx);
+    setOfficials(updated);
+    if (inferredCount > 0) {
+      addLog(`✓ Inferred ${inferredCount} email${inferredCount !== 1 ? 's' : ''} from name patterns.`);
+    } else {
+      addLog('ℹ No new emails could be inferred — all officials already have an email or no pattern applies.');
+    }
   }
 
   // ── Export / import ────────────────────────────────────────────────────────
 
   function exportForInviteFlow() {
     const invitees = officials
-      .filter(o => o.status !== 'left_office' && (o.officeEmail || o.directEmail))
+      .filter(o => o.status !== 'left_office' && (o.officeEmail || o.directEmail || o.schedulerEmail))
       .map(officialToInvitee);
-    if (invitees.length === 0) { addLog('No officials with email to export.'); return; }
+    if (invitees.length === 0) { addLog('No officials with an email to export.'); return; }
     downloadBlob(
-      new Blob([JSON.stringify({ exportedAt: new Date().toISOString(), source: 'ContactScout', count: invitees.length, invitees }, null, 2)], { type: 'application/json' }),
+      new Blob(
+        [JSON.stringify({ exportedAt: new Date().toISOString(), source: 'ContactScout', count: invitees.length, invitees }, null, 2)],
+        { type: 'application/json' },
+      ),
       `contactscout-invitees-${todaySlug()}.json`,
     );
     addLog(`✓ Exported ${invitees.length} invitees for InviteFlow.`);
@@ -214,21 +297,35 @@ function ContactScoutInner() {
 
   function exportBackup() {
     downloadBlob(
-      new Blob([JSON.stringify({ exportedAt: new Date().toISOString(), source: 'ContactScout', officials, newOfficials, scanStatus, scanMeta }, null, 2)], { type: 'application/json' }),
+      new Blob(
+        [JSON.stringify({ exportedAt: new Date().toISOString(), source: 'ContactScout', officials, newOfficials, scanStatus, scanMeta }, null, 2)],
+        { type: 'application/json' },
+      ),
       `contactscout-backup-${todaySlug()}.json`,
     );
     addLog(`✓ Backup saved (${officials.length} officials).`);
   }
 
   function exportCSV() {
-    const h = ['Name','Title','District','County','Category','Direct Email','Office Email','Phone','Status','Changes','Flags','Replaced By','Confidence'];
+    const h = [
+      'Name','Title','District','County','Category',
+      'Direct Email','Office Email','Phone',
+      'Scheduler Name','Scheduler Email','Appearance Form URL',
+      'Email Source','Status','Changes','Flags','Replaced By','Confidence',
+    ];
     const rows = officials.map(o => [
       o.name, o.title, o.district, o.county, o.category,
-      o.directEmail, o.officeEmail, o.officePhone, o.status,
-      o.result?.changes as string || '', o.result?.flags as string || '',
-      o.result?.replacedBy as string || '', o.result?.confidence as string || '',
+      o.directEmail, o.officeEmail, o.officePhone,
+      o.schedulerName, o.schedulerEmail, o.appearanceFormUrl,
+      o.emailSource, o.status,
+      o.result?.changes as string || '',
+      o.result?.flags as string || '',
+      o.result?.replacedBy as string || '',
+      o.result?.confidence as string || '',
     ]);
-    const csv = [h, ...rows].map(r => r.map(c => `"${(c || '').replace(/"/g, '""')}"`).join(',')).join('\n');
+    const csv = [h, ...rows]
+      .map(r => r.map(c => `"${(c || '').replace(/"/g, '""')}"`).join(','))
+      .join('\n');
     downloadBlob(new Blob([csv], { type: 'text/csv' }), `contactscout-officials-${todaySlug()}.csv`);
     addLog('✓ CSV exported.');
   }
@@ -238,8 +335,8 @@ function ContactScoutInner() {
     reader.onload = () => {
       try {
         const d = JSON.parse(reader.result as string) as Partial<CSPersistedState>;
-        if (d.officials)    setOfficials(d.officials.map(o => ({ ...o, result: o.result || null })));
-        if (d.newOfficials) setNewOfficials(d.newOfficials);
+        if (d.officials)    setOfficials(d.officials.map(normaliseOfficial));
+        if (d.newOfficials) setNewOfficials(d.newOfficials.map(normaliseOfficial));
         if (d.scanStatus)   setScanStatus(d.scanStatus);
         if (d.scanMeta)     setScanMeta(d.scanMeta);
         addLog('✓ Backup loaded.');
@@ -257,15 +354,23 @@ function ContactScoutInner() {
 
   // ── Derived state ──────────────────────────────────────────────────────────
 
-  const filtered = activeCat === 'All' ? officials : officials.filter(o => o.category === activeCat);
+  const filtered = activeCat === 'All'
+    ? officials
+    : officials.filter(o => o.category === activeCat);
+
   const stats = {
-    total:   officials.length,
-    done:    officials.filter(o => o.status === 'done').length,
-    changed: officials.filter(o => o.status === 'changed').length,
-    left:    officials.filter(o => o.status === 'left_office').length,
-    ready:   officials.filter(o => o.status !== 'left_office' && (o.officeEmail || o.directEmail)).length,
+    total:    officials.length,
+    done:     officials.filter(o => o.status === 'done').length,
+    changed:  officials.filter(o => o.status === 'changed').length,
+    left:     officials.filter(o => o.status === 'left_office').length,
+    ready:    officials.filter(o =>
+      o.status !== 'left_office' &&
+      (o.schedulerEmail || o.officeEmail || o.directEmail),
+    ).length,
+    withSched: officials.filter(o => !!o.schedulerEmail).length,
   };
-  const pct       = progress.total ? Math.round(progress.done / progress.total * 100) : 0;
+
+  const pct     = progress.total ? Math.round(progress.done / progress.total * 100) : 0;
   const jxMissing = !jx.state.trim();
 
   const TABS = [
@@ -275,11 +380,12 @@ function ContactScoutInner() {
   ] as const;
 
   const STAT_ROWS = [
-    ['TOTAL',        stats.total,   '#8b949e'],
-    ['VERIFIED',     stats.done,    '#3fb950'],
-    ['CHANGED',      stats.changed, '#58a6ff'],
-    ['LEFT OFFICE',  stats.left,    '#f85149'],
-    ['READY',        stats.ready,   '#a371f7'],
+    ['TOTAL',     stats.total,     '#8b949e'],
+    ['VERIFIED',  stats.done,      '#3fb950'],
+    ['CHANGED',   stats.changed,   '#58a6ff'],
+    ['LEFT',      stats.left,      '#f85149'],
+    ['READY',     stats.ready,     '#a371f7'],
+    ['SCHEDULER', stats.withSched, '#C8A84B'],
   ] as const;
 
   // ── Render ─────────────────────────────────────────────────────────────────
@@ -292,17 +398,17 @@ function ContactScoutInner() {
       />
 
       {/* Header */}
-      <div style={{ padding: '8px 16px', borderBottom: '1px solid #21262d', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+      <div style={{ padding: '8px 16px', borderBottom: '1px solid var(--border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, flexShrink: 0 }}>
         <div>
-          <span style={{ fontWeight: 800, fontSize: 15, color: '#f0f6fc', letterSpacing: '-0.02em' }}>CONTACT SCOUT</span>
-          <div style={{ fontSize: 9, color: '#7d8590', letterSpacing: '0.1em', marginTop: 1 }}>by Lenya Chan</div>
+          <span style={{ fontWeight: 800, fontSize: 15, color: 'var(--text-heading)', letterSpacing: '-0.02em' }}>CONTACT SCOUT</span>
+          <div style={{ fontSize: 9, color: 'var(--text-muted)', letterSpacing: '0.1em', marginTop: 1 }}>by Lenya Chan</div>
         </div>
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
           <button className="if-btn sm if-log-btn" onClick={() => setShowLog(v => !v)}>☰ Log</button>
           <button
             className="if-btn sm"
             onClick={() => setShowJxModal(true)}
-            style={jxMissing ? { borderColor: '#bb8009', color: '#e3b341' } : {}}
+            style={jxMissing ? { borderColor: 'var(--warning-border)', color: 'var(--warning)' } : {}}
             title={jxMissing ? 'Configure jurisdiction' : `Jurisdiction: ${jx.state}`}
           >
             ⊙ {jxMissing ? 'Jurisdiction' : jx.state}
@@ -325,7 +431,7 @@ function ContactScoutInner() {
           <div className="if-banner-body">
             <div className="if-banner-title">Welcome to ContactScout</div>
             <div className="if-banner-text">
-              Add your Claude API key to start discovering officials.
+              Add your Claude API key to start discovering officials and their schedulers.
               Get a free key at console.anthropic.com → API Keys → Create Key.
             </div>
             <button className="if-btn pri sm" onClick={() => openKeyModal()}>Add Claude API Key</button>
@@ -339,7 +445,11 @@ function ContactScoutInner() {
             <div className="if-banner-text">
               Configure your state, counties, and cities so scan prompts target the right officials.
             </div>
-            <button className="if-btn sm" style={{ borderColor: '#bb8009', color: '#e3b341' }} onClick={() => setShowJxModal(true)}>
+            <button
+              className="if-btn sm"
+              style={{ borderColor: 'var(--warning-border)', color: 'var(--warning)' }}
+              onClick={() => setShowJxModal(true)}
+            >
               Configure Jurisdiction
             </button>
           </div>
@@ -361,7 +471,7 @@ function ContactScoutInner() {
               <div className="if-progress-track">
                 <div className="if-progress-fill" style={{ width: `${pct}%` }} />
               </div>
-              <span style={{ fontSize: 10, color: '#58a6ff' }}>{progress.done}/{progress.total}</span>
+              <span style={{ fontSize: 10, color: 'var(--blue)' }}>{progress.done}/{progress.total}</span>
             </div>
           )}
         </div>
@@ -407,7 +517,8 @@ function ContactScoutInner() {
               setSelected={setSelected}
               running={running}
               runVerify={runVerify}
-              addManually={addManually}
+              onAddManually={() => setShowAddModal(true)}
+              onInferEmails={inferMissing}
               onGoDiscover={() => setTab(0)}
             />
           )}
@@ -439,6 +550,13 @@ function ContactScoutInner() {
           jx={jx}
           onSave={updated => setJx(updated)}
           onClose={() => setShowJxModal(false)}
+        />
+      )}
+      {showAddModal && (
+        <AddOfficialModal
+          jx={jx}
+          onAdd={addManual}
+          onClose={() => setShowAddModal(false)}
         />
       )}
     </div>

--- a/src/contactscout/src/App.tsx
+++ b/src/contactscout/src/App.tsx
@@ -6,7 +6,7 @@ import {
 import { loadCSState, saveCSState, loadJurisdiction } from './storage';
 import { sleep, officialToInvitee, buildScanPrompts, downloadBlob, todaySlug } from './utils';
 import { applyEmailInference } from './emailPatterns';
-import { callClaude } from './api';
+import { callGemini } from './api';
 import ApiKeyModal from './components/ApiKeyModal';
 import JurisdictionModal from './components/JurisdictionModal';
 import AddOfficialModal from './components/AddOfficialModal';
@@ -111,7 +111,7 @@ function ContactScoutInner() {
       });
     }
     try {
-      return await callClaude(apiKey, model, sys, user);
+      return await callGemini(apiKey, model, sys, user);
     } catch (e) {
       if (String(e).includes('Invalid API key')) setApiKey('');
       throw e;
@@ -183,7 +183,7 @@ function ContactScoutInner() {
       }
 
       setProgress({ done: i + 1, total: names.length });
-      if (i < names.length - 1) await sleep(700);
+      if (i < names.length - 1) await sleep(4500);
     }
 
     setRunning(false);
@@ -431,10 +431,10 @@ function ContactScoutInner() {
           <div className="if-banner-body">
             <div className="if-banner-title">Welcome to ContactScout</div>
             <div className="if-banner-text">
-              Add your Claude API key to start discovering officials and their schedulers.
-              Get a free key at console.anthropic.com → API Keys → Create Key.
+              Add your Google Gemini API key to start discovering officials and their schedulers.
+              Get a free key at aistudio.google.com (no credit card required).
             </div>
-            <button className="if-btn pri sm" onClick={() => openKeyModal()}>Add Claude API Key</button>
+            <button className="if-btn pri sm" onClick={() => openKeyModal()}>Add Gemini API Key</button>
           </div>
         </div>
       )}

--- a/src/contactscout/src/api.ts
+++ b/src/contactscout/src/api.ts
@@ -1,39 +1,81 @@
 import { CS_APIKEY_SK } from './constants';
 
+const API_URL = 'https://api.anthropic.com/v1/messages';
+
+/** Extracts JSON from a Claude response that may contain markdown fences or prose. */
+function extractJson(text: string): Record<string, unknown> {
+  // Strip markdown fences first
+  let clean = text.replace(/```json\s*/gi, '').replace(/```\s*/g, '').trim();
+
+  // Try direct parse
+  try { return JSON.parse(clean) as Record<string, unknown>; } catch { /* fall through */ }
+
+  // Try finding the outermost JSON object
+  const start = clean.indexOf('{');
+  const end   = clean.lastIndexOf('}');
+  if (start !== -1 && end > start) {
+    try { return JSON.parse(clean.slice(start, end + 1)) as Record<string, unknown>; } catch { /* fall through */ }
+  }
+
+  throw new Error(`No valid JSON in response: ${clean.slice(0, 120)}`);
+}
+
+/**
+ * Calls the Anthropic Messages API with web_search tool enabled.
+ * Retries up to 3 times on 429 (rate limit) with exponential backoff.
+ * Throws on 401 (invalid key) and unrecoverable errors.
+ */
 export async function callClaude(
   key: string,
+  model: string,
   sys: string,
   user: string,
 ): Promise<Record<string, unknown>> {
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': key,
-      'anthropic-version': '2023-06-01',
-      'anthropic-dangerous-direct-browser-access': 'true',
-    },
-    body: JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 1500,
-      system: sys,
-      tools: [{ type: 'web_search_20250305', name: 'web_search' }],
-      messages: [{ role: 'user', content: user }],
-    }),
-  });
+  const delays = [2000, 4000, 8000];
 
-  if (res.status === 401) {
-    sessionStorage.removeItem(CS_APIKEY_SK);
-    throw new Error('Invalid API key');
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    const res = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': key,
+        'anthropic-version': '2023-06-01',
+        'anthropic-dangerous-direct-browser-access': 'true',
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 2000,
+        system: sys,
+        tools: [{ type: 'web_search_20250305', name: 'web_search' }],
+        messages: [{ role: 'user', content: user }],
+      }),
+    });
+
+    if (res.status === 401) {
+      sessionStorage.removeItem(CS_APIKEY_SK);
+      throw new Error('Invalid API key');
+    }
+
+    if (res.status === 429) {
+      const wait = delays[attempt];
+      if (wait === undefined) throw new Error('Rate limited — too many requests, try again later');
+      await new Promise(r => setTimeout(r, wait));
+      continue;
+    }
+
+    const d = await res.json() as {
+      content?: Array<{ type: string; text?: string }>;
+      error?: { message: string };
+    };
+
+    if (d.error) throw new Error(d.error.message ?? 'API error');
+
+    const text = d.content?.find(b => b.type === 'text')?.text ?? '';
+    if (!text) throw new Error('No text response from model');
+
+    return extractJson(text);
   }
 
-  const d = await res.json() as {
-    content?: Array<{ type: string; text?: string }>;
-    error?: { message: string };
-  };
-
-  if (d.error) throw new Error(d.error.message ?? 'API error');
-  const text = d.content?.find(b => b.type === 'text')?.text ?? '';
-  if (!text) throw new Error('No text response');
-  return JSON.parse(text.replace(/```json|```/g, '').trim()) as Record<string, unknown>;
+  // Unreachable but satisfies TypeScript
+  throw new Error('callClaude: exhausted retry loop unexpectedly');
 }

--- a/src/contactscout/src/api.ts
+++ b/src/contactscout/src/api.ts
@@ -1,8 +1,8 @@
 import { CS_APIKEY_SK } from './constants';
 
-const API_URL = 'https://api.anthropic.com/v1/messages';
+const API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
 
-/** Extracts JSON from a Claude response that may contain markdown fences or prose. */
+/** Extracts JSON from a Gemini response that may contain markdown fences or prose. */
 function extractJson(text: string): Record<string, unknown> {
   // Strip markdown fences first
   let clean = text.replace(/```json\s*/gi, '').replace(/```\s*/g, '').trim();
@@ -21,11 +21,14 @@ function extractJson(text: string): Record<string, unknown> {
 }
 
 /**
- * Calls the Anthropic Messages API with web_search tool enabled.
+ * Calls the Gemini API with Google Search Grounding enabled.
  * Retries up to 3 times on 429 (rate limit) with exponential backoff.
- * Throws on 401 (invalid key) and unrecoverable errors.
+ * Throws on invalid key and unrecoverable errors.
+ *
+ * Note: responseMimeType JSON mode is incompatible with google_search grounding,
+ * so we instruct the model via system prompt and parse the text response.
  */
-export async function callClaude(
+export async function callGemini(
   key: string,
   model: string,
   sys: string,
@@ -34,27 +37,15 @@ export async function callClaude(
   const delays = [2000, 4000, 8000];
 
   for (let attempt = 0; attempt <= delays.length; attempt++) {
-    const res = await fetch(API_URL, {
+    const res = await fetch(`${API_BASE}/${model}:generateContent?key=${key}`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': key,
-        'anthropic-version': '2023-06-01',
-        'anthropic-dangerous-direct-browser-access': 'true',
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        model,
-        max_tokens: 2000,
-        system: sys,
-        tools: [{ type: 'web_search_20250305', name: 'web_search' }],
-        messages: [{ role: 'user', content: user }],
+        system_instruction: { parts: [{ text: sys }] },
+        contents: [{ role: 'user', parts: [{ text: user }] }],
+        tools: [{ google_search: {} }],
       }),
     });
-
-    if (res.status === 401) {
-      sessionStorage.removeItem(CS_APIKEY_SK);
-      throw new Error('Invalid API key');
-    }
 
     if (res.status === 429) {
       const wait = delays[attempt];
@@ -64,18 +55,25 @@ export async function callClaude(
     }
 
     const d = await res.json() as {
-      content?: Array<{ type: string; text?: string }>;
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
       error?: { message: string };
     };
 
-    if (d.error) throw new Error(d.error.message ?? 'API error');
+    if (d.error) {
+      const msg = d.error.message ?? 'API error';
+      if (msg.toLowerCase().includes('api key not valid') || res.status === 401) {
+        sessionStorage.removeItem(CS_APIKEY_SK);
+        throw new Error('Invalid API key');
+      }
+      throw new Error(msg);
+    }
 
-    const text = d.content?.find(b => b.type === 'text')?.text ?? '';
+    const text = d.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
     if (!text) throw new Error('No text response from model');
 
     return extractJson(text);
   }
 
   // Unreachable but satisfies TypeScript
-  throw new Error('callClaude: exhausted retry loop unexpectedly');
+  throw new Error('callGemini: exhausted retry loop unexpectedly');
 }

--- a/src/contactscout/src/components/AddOfficialModal.tsx
+++ b/src/contactscout/src/components/AddOfficialModal.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import { inferEmail } from '../emailPatterns';
+import { CATS } from '../constants';
+import type { CSOfficial, CSJurisdiction } from '../types';
+
+interface Props {
+  jx: CSJurisdiction;
+  onAdd: (o: CSOfficial) => void;
+  onClose: () => void;
+}
+
+type Draft = Omit<CSOfficial, 'status' | 'result' | '_scanId'>;
+
+const EMPTY: Draft = {
+  name: '', title: '', district: '', county: '', category: 'City Council',
+  directEmail: '', officeEmail: '', officePhone: '',
+  schedulerName: '', schedulerEmail: '', appearanceFormUrl: '',
+  emailSource: 'manual',
+};
+
+const CATEGORY_OPTS = CATS.filter(c => c !== 'All') as string[];
+
+export default function AddOfficialModal({ jx, onAdd, onClose }: Props) {
+  const [d, setD] = useState<Draft>(EMPTY);
+  const [err, setErr] = useState('');
+
+  // Auto-infer email when name + category change and direct email is empty
+  function handleNameOrCat(patch: Partial<Draft>) {
+    setD(prev => {
+      const next = { ...prev, ...patch };
+      if (!next.directEmail) {
+        const inf = inferEmail(
+          { ...next, status: 'pending', result: null } as CSOfficial,
+          jx,
+        );
+        if (inf) {
+          return { ...next, directEmail: inf, emailSource: 'inferred' as const };
+        }
+      }
+      return next;
+    });
+  }
+
+  function field<K extends keyof Draft>(key: K, value: Draft[K]) {
+    if (key === 'name' || key === 'category') {
+      handleNameOrCat({ [key]: value } as Partial<Draft>);
+    } else {
+      setD(prev => ({ ...prev, [key]: value }));
+    }
+    setErr('');
+  }
+
+  function save() {
+    if (!d.name.trim()) { setErr('Name is required.'); return; }
+    const official: CSOfficial = { ...d, status: 'pending', result: null };
+    onAdd(official);
+    onClose();
+  }
+
+  const inf = !d.directEmail
+    ? inferEmail({ ...d, status: 'pending', result: null } as CSOfficial, jx)
+    : '';
+
+  return (
+    <div className="if-modal-backdrop" onClick={onClose}>
+      <div className="if-modal" style={{ maxWidth: 520 }} onClick={e => e.stopPropagation()}>
+        <div className="if-modal-title">Add Official Manually</div>
+        <div className="if-modal-sub">
+          All fields except Name are optional. Email is inferred from name + category
+          where a standard pattern exists (federal, NC state legislature).
+        </div>
+
+        {err && (
+          <div style={{ fontSize: 10, color: 'var(--danger)', marginBottom: 10, padding: '6px 10px', background: 'rgba(218,54,51,0.08)', border: '1px solid var(--danger-dark)', borderRadius: 5 }}>
+            {err}
+          </div>
+        )}
+
+        {/* Row 1: Name + Category */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 160px', gap: 10, marginBottom: 10 }}>
+          <div className="if-field">
+            <div className="if-field-label">Full name *</div>
+            <input className="if-input" placeholder="Jane Doe" value={d.name}
+              onChange={e => field('name', e.target.value)} autoFocus />
+          </div>
+          <div className="if-field">
+            <div className="if-field-label">Category</div>
+            <select className="if-input" value={d.category}
+              onChange={e => field('category', e.target.value)}
+              style={{ appearance: 'none' }}>
+              {CATEGORY_OPTS.map(c => <option key={c} value={c}>{c}</option>)}
+            </select>
+          </div>
+        </div>
+
+        {/* Row 2: Title + District + County */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 80px 100px', gap: 10, marginBottom: 10 }}>
+          <div className="if-field">
+            <div className="if-field-label">Title</div>
+            <input className="if-input" placeholder="Mayor / Senator / Rep." value={d.title}
+              onChange={e => field('title', e.target.value)} />
+          </div>
+          <div className="if-field">
+            <div className="if-field-label">District</div>
+            <input className="if-input" placeholder="12" value={d.district}
+              onChange={e => field('district', e.target.value)} />
+          </div>
+          <div className="if-field">
+            <div className="if-field-label">County</div>
+            <input className="if-input" placeholder="Wake" value={d.county}
+              onChange={e => field('county', e.target.value)} />
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div style={{ borderTop: '1px solid var(--border-subtle)', margin: '4px 0 12px', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span className="if-section-label" style={{ paddingTop: 10 }}>Contact info</span>
+        </div>
+
+        {/* Row 3: Direct email + Office email */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginBottom: 10 }}>
+          <div className="if-field">
+            <div className="if-field-label">Direct email</div>
+            <input className="if-input" placeholder={inf || 'jane.doe@mail.house.gov'} value={d.directEmail}
+              onChange={e => {
+                setD(prev => ({ ...prev, directEmail: e.target.value, emailSource: 'manual' }));
+                setErr('');
+              }} />
+            {inf && !d.directEmail && (
+              <div style={{ fontSize: 9, color: 'var(--text-muted)', marginTop: 3 }}>
+                Will be inferred: <span style={{ color: 'var(--blue)' }}>{inf}</span>
+              </div>
+            )}
+          </div>
+          <div className="if-field">
+            <div className="if-field-label">Office email</div>
+            <input className="if-input" placeholder="office@example.gov" value={d.officeEmail}
+              onChange={e => field('officeEmail', e.target.value)} />
+          </div>
+        </div>
+
+        {/* Row 4: Phone + Appearance form */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginBottom: 10 }}>
+          <div className="if-field">
+            <div className="if-field-label">Office phone</div>
+            <input className="if-input" placeholder="(919) 555-0100" value={d.officePhone}
+              onChange={e => field('officePhone', e.target.value)} />
+          </div>
+          <div className="if-field">
+            <div className="if-field-label">Appearance request form</div>
+            <input className="if-input" placeholder="https://example.house.gov/contact" value={d.appearanceFormUrl}
+              onChange={e => field('appearanceFormUrl', e.target.value)} />
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div style={{ borderTop: '1px solid var(--border-subtle)', margin: '4px 0 12px', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span className="if-section-label" style={{ paddingTop: 10 }}>Scheduler / Staff</span>
+          <span style={{ paddingTop: 10, fontSize: 9, color: 'var(--text-muted)' }}>— the person who handles event invitations</span>
+        </div>
+
+        {/* Row 5: Scheduler name + email */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginBottom: 16 }}>
+          <div className="if-field">
+            <div className="if-field-label">Scheduler name</div>
+            <input className="if-input" placeholder="Mary Smith" value={d.schedulerName}
+              onChange={e => field('schedulerName', e.target.value)} />
+          </div>
+          <div className="if-field">
+            <div className="if-field-label">Scheduler email</div>
+            <input className="if-input" placeholder="mary.smith@doe.senate.gov" value={d.schedulerEmail}
+              onChange={e => field('schedulerEmail', e.target.value)} />
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button className="if-btn" onClick={onClose}>Cancel</button>
+          <button className="if-btn pri" onClick={save}>Add to List</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/contactscout/src/components/ApiKeyModal.tsx
+++ b/src/contactscout/src/components/ApiKeyModal.tsx
@@ -11,7 +11,7 @@ export default function ApiKeyModal({ apiKey, onSave, onClose }: Props) {
   const [err, setErr] = useState(false);
 
   function save() {
-    if (!draft.startsWith('sk-ant-')) { setErr(true); return; }
+    if (!draft.startsWith('AIza')) { setErr(true); return; }
     onSave(draft);
     onClose();
   }
@@ -19,24 +19,24 @@ export default function ApiKeyModal({ apiKey, onSave, onClose }: Props) {
   return (
     <div className="if-modal-backdrop" onClick={onClose}>
       <div className="if-modal" onClick={e => e.stopPropagation()}>
-        <div className="if-modal-title">Claude API Key</div>
+        <div className="if-modal-title">Google AI Studio API Key</div>
         <div className="if-modal-sub">
-          Enter your Anthropic API key. Get a free key at{' '}
-          <a href="https://console.anthropic.com/" target="_blank" rel="noreferrer" style={{ color: '#58a6ff' }}>
-            console.anthropic.com
+          Get a free key at{' '}
+          <a href="https://aistudio.google.com/" target="_blank" rel="noreferrer" style={{ color: '#58a6ff' }}>
+            aistudio.google.com
           </a>{' '}
-          → API Keys → Create Key. Starts with <code>sk-ant-</code>. Stored in session only.
+          → Get API key → Create API key. Starts with <code>AIza</code>. Stored in session only.
         </div>
         <input
           className={`if-input${err ? ' err' : ''}`}
           type="password"
-          placeholder="sk-ant-..."
+          placeholder="AIza..."
           value={draft}
           onChange={e => { setDraft(e.target.value); setErr(false); }}
           onKeyDown={e => e.key === 'Enter' && save()}
           autoFocus
         />
-        {err && <div style={{ fontSize: 10, color: '#f85149', marginTop: 6 }}>Must start with sk-ant-</div>}
+        {err && <div style={{ fontSize: 10, color: '#f85149', marginTop: 6 }}>Must start with AIza</div>}
         <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 12 }}>
           <button className="if-btn" onClick={onClose}>Cancel</button>
           <button className="if-btn pri" onClick={save}>Save</button>

--- a/src/contactscout/src/components/DiscoverTab.tsx
+++ b/src/contactscout/src/components/DiscoverTab.tsx
@@ -1,4 +1,5 @@
 import { SCAN_TARGETS } from '../constants';
+import { bestEmail } from '../emailPatterns';
 import type { CSOfficial, CSScanMeta, CSJurisdiction, ScanState } from '../types';
 
 interface Props {
@@ -18,60 +19,66 @@ export default function DiscoverTab({
   running, runScan, addNew, dismissNew, onConfigureJx,
 }: Props) {
   const jxMissing = !jx.state.trim();
-  const anyDone = Object.values(scanStatus).some(s => s === 'done');
+  const anyDone   = Object.values(scanStatus).some(s => s === 'done');
 
   return (
     <div style={{ padding: '16px 20px' }}>
+      {/* Jurisdiction missing */}
       {jxMissing && (
-        <div style={{ background: '#1a0e00', border: '1px solid #bb8009', borderRadius: 7, padding: '12px 16px', marginBottom: 16 }}>
-          <div style={{ fontSize: 11, color: '#e3b341', fontWeight: 600, marginBottom: 4 }}>Scan targets need jurisdiction</div>
-          <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.7, marginBottom: 8 }}>
+        <div style={{ background: 'var(--bg-warn-tint)', border: '1px solid var(--warning-border)', borderRadius: 7, padding: '12px 16px', marginBottom: 16 }}>
+          <div style={{ fontSize: 11, color: 'var(--warning)', fontWeight: 600, marginBottom: 4 }}>Scan targets need jurisdiction</div>
+          <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.7, marginBottom: 8 }}>
             Configure your state, counties, and cities so scans target the right officials.
           </div>
-          <button className="if-btn sm" style={{ borderColor: '#bb8009', color: '#e3b341' }} onClick={onConfigureJx}>
+          <button className="if-btn sm" style={{ borderColor: 'var(--warning-border)', color: 'var(--warning)' }} onClick={onConfigureJx}>
             Configure Jurisdiction
           </button>
         </div>
       )}
 
+      {/* Intro text */}
       {!jxMissing && newOfficials.length === 0 && !anyDone && (
-        <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.7, marginBottom: 16 }}>
-          Scan each category to discover current officials. New officials not already in your list will surface as add candidates.
-          Run after each election cycle, then head to <strong style={{ color: '#f0f6fc' }}>Officials</strong> to verify,
-          and <strong style={{ color: '#f0f6fc' }}>Export</strong> when ready.
+        <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.8, marginBottom: 16, maxWidth: 600 }}>
+          Scan each category to find current officials and their schedulers.
+          New contacts surface below each scan card as candidates.
+          Accept them to move to <strong style={{ color: 'var(--text-heading)' }}>Officials</strong>,
+          then verify and <strong style={{ color: 'var(--text-heading)' }}>Export</strong> when ready.
+          Emails are inferred automatically for federal and NC state officials who have no scanned address.
         </div>
       )}
 
       {SCAN_TARGETS.map(t => {
-        const st = scanStatus[t.id];
-        const meta = scanMeta[t.id];
+        const st    = scanStatus[t.id];
+        const meta  = scanMeta[t.id];
         const fresh = newOfficials.filter(o => o._scanId === t.id);
+        const withSched = fresh.filter(o => !!o.schedulerEmail).length;
 
         return (
           <div key={t.id} style={{ marginBottom: 10 }}>
+            {/* Scan card */}
             <div className="if-card">
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8 }}>
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontSize: 12, color: '#f0f6fc', fontWeight: 500, marginBottom: 2 }}>{t.label}</div>
-                  <div style={{ fontSize: 10, color: '#8b949e' }}>{t.desc}</div>
+                  <div style={{ fontSize: 12, color: 'var(--text-heading)', fontWeight: 500, marginBottom: 2 }}>{t.label}</div>
+                  <div style={{ fontSize: 10, color: 'var(--text-secondary)' }}>{t.desc}</div>
                   {meta && (
-                    <div style={{ fontSize: 10, color: '#8b949e', marginTop: 4 }}>
+                    <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginTop: 4 }}>
                       Found {meta.total} ·{' '}
-                      <span style={{ color: meta.confidence === 'high' ? '#3fb950' : meta.confidence === 'medium' ? '#e3b341' : '#f85149' }}>
+                      <span style={{ color: meta.confidence === 'high' ? 'var(--success)' : meta.confidence === 'medium' ? 'var(--warning)' : 'var(--danger)' }}>
                         {meta.confidence}
                       </span>
-                      {meta.notes && <span style={{ color: '#e3b341' }}> · {meta.notes}</span>}
+                      {meta.notes && <span style={{ color: 'var(--warning)' }}> · {meta.notes}</span>}
                     </div>
                   )}
                 </div>
                 <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0 }}>
                   {st === 'scanning' && (
-                    <span className="if-tag" style={{ borderColor: '#f59e0b', color: '#f59e0b', animation: 'cs-pulse 1.4s ease-in-out infinite' }}>
+                    <span className="if-tag" style={{ borderColor: 'var(--amber)', color: 'var(--amber)', animation: 'if-pulse 1.4s ease-in-out infinite' }}>
                       SCANNING
                     </span>
                   )}
-                  {st === 'done'  && <span className="if-tag" style={{ borderColor: '#238636', color: '#3fb950' }}>DONE</span>}
-                  {st === 'error' && <span className="if-tag" style={{ borderColor: '#da3633', color: '#f85149' }}>ERROR</span>}
+                  {st === 'done'  && <span className="if-tag" style={{ borderColor: 'var(--success-bg)', color: 'var(--success)' }}>DONE</span>}
+                  {st === 'error' && <span className="if-tag" style={{ borderColor: 'var(--danger-dark)', color: 'var(--danger)' }}>ERROR</span>}
                   <button
                     className="if-btn sm pri"
                     onClick={() => runScan(t.id)}
@@ -83,33 +90,58 @@ export default function DiscoverTab({
               </div>
             </div>
 
+            {/* New candidates */}
             {fresh.length > 0 && (
-              <div style={{ margin: '3px 0 0 12px', paddingLeft: 12, borderLeft: '2px solid #1f6feb' }}>
-                <div style={{ fontSize: 9, color: '#58a6ff', letterSpacing: '0.1em', margin: '6px 0 5px' }}>
-                  NEW CANDIDATES ({fresh.length})
+              <div style={{ margin: '3px 0 0 12px', paddingLeft: 12, borderLeft: '2px solid var(--accent)' }}>
+                <div style={{ fontSize: 9, color: 'var(--accent-highlight)', letterSpacing: '0.1em', margin: '6px 0 5px', display: 'flex', gap: 10, alignItems: 'center' }}>
+                  <span>NEW CANDIDATES ({fresh.length})</span>
+                  {withSched > 0 && (
+                    <span style={{ color: '#C8A84B' }}>★ {withSched} with scheduler</span>
+                  )}
                 </div>
-                {fresh.map(o => (
-                  <div className="if-new-card" key={o.name} style={{ marginBottom: 4 }}>
-                    <div style={{ minWidth: 0 }}>
-                      <div style={{ fontSize: 11, color: '#f0f6fc', fontWeight: 500 }}>{o.name}</div>
-                      <div style={{ fontSize: 9, color: '#8b949e' }}>
-                        {o.title}{o.district ? ` · D${o.district}` : ''}
+                {fresh.map(o => {
+                  const email = bestEmail(o);
+                  const isInferred = !o.schedulerEmail && o.emailSource === 'inferred' && !!o.directEmail;
+
+                  return (
+                    <div className="if-new-card" key={o.name} style={{ marginBottom: 4 }}>
+                      <div style={{ minWidth: 0, flex: 1 }}>
+                        <div style={{ fontSize: 11, color: 'var(--text-heading)', fontWeight: 500 }}>{o.name}</div>
+                        <div style={{ fontSize: 9, color: 'var(--text-secondary)' }}>
+                          {o.title}{o.district ? ` · D${o.district}` : ''}
+                        </div>
+                        {/* Scheduler info — highest priority contact */}
+                        {o.schedulerEmail ? (
+                          <div style={{ fontSize: 9, color: '#C8A84B', marginTop: 2 }}>
+                            ★ {o.schedulerName || 'Scheduler'}: {o.schedulerEmail}
+                          </div>
+                        ) : email ? (
+                          <div style={{ fontSize: 9, color: 'var(--text-muted)', display: 'flex', alignItems: 'center', gap: 4 }}>
+                            <span>{email}</span>
+                            {isInferred && (
+                              <span style={{ border: '1px solid var(--blue)', color: 'var(--blue)', borderRadius: 3, padding: '0 3px', fontSize: 8 }}>
+                                INFERRED
+                              </span>
+                            )}
+                          </div>
+                        ) : o.appearanceFormUrl ? (
+                          <div style={{ fontSize: 9, color: '#a371f7' }}>⧉ form available</div>
+                        ) : (
+                          <div style={{ fontSize: 9, color: 'var(--danger)', fontStyle: 'italic' }}>no email found</div>
+                        )}
                       </div>
-                      {(o.directEmail || o.officeEmail) && (
-                        <div style={{ fontSize: 9, color: '#8b949e' }}>{o.directEmail || o.officeEmail}</div>
-                      )}
+                      <div style={{ display: 'flex', gap: 5, flexShrink: 0 }}>
+                        <button className="if-btn sm grn" onClick={() => addNew(o)}>+ Add</button>
+                        <button className="if-btn sm" onClick={() => dismissNew(o.name)}>✕</button>
+                      </div>
                     </div>
-                    <div style={{ display: 'flex', gap: 5, flexShrink: 0 }}>
-                      <button className="if-btn sm grn" onClick={() => addNew(o)}>+ Add</button>
-                      <button className="if-btn sm" onClick={() => dismissNew(o.name)}>✕</button>
-                    </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
 
             {st === 'done' && fresh.length === 0 && meta && (
-              <div style={{ margin: '3px 0 0 12px', padding: '4px 0 4px 12px', borderLeft: '2px solid #238636', fontSize: 10, color: '#3fb950' }}>
+              <div style={{ margin: '3px 0 0 12px', padding: '4px 0 4px 12px', borderLeft: '2px solid var(--success-bg)', fontSize: 10, color: 'var(--success)' }}>
                 ✓ All {meta.total} already in list.
               </div>
             )}

--- a/src/contactscout/src/components/ExportTab.tsx
+++ b/src/contactscout/src/components/ExportTab.tsx
@@ -1,4 +1,5 @@
 import type { CSOfficial } from '../types';
+import { bestEmail } from '../emailPatterns';
 
 interface Props {
   officials: CSOfficial[];
@@ -9,25 +10,79 @@ interface Props {
   clearAll: () => void;
 }
 
+interface ContactBreakdown {
+  scheduler: number;
+  direct: number;
+  inferred: number;
+  office: number;
+  formOnly: number;
+  noContact: number;
+}
+
+function getBreakdown(officials: CSOfficial[]): ContactBreakdown {
+  const eligible = officials.filter(o => o.status !== 'left_office');
+  return {
+    scheduler: eligible.filter(o => !!o.schedulerEmail).length,
+    direct:    eligible.filter(o => !o.schedulerEmail && !!o.directEmail && o.emailSource !== 'inferred').length,
+    inferred:  eligible.filter(o => !o.schedulerEmail && o.emailSource === 'inferred' && !!o.directEmail).length,
+    office:    eligible.filter(o => !o.schedulerEmail && !o.directEmail && !!o.officeEmail).length,
+    formOnly:  eligible.filter(o => !bestEmail(o) && !!o.appearanceFormUrl).length,
+    noContact: eligible.filter(o => !bestEmail(o) && !o.appearanceFormUrl).length,
+  };
+}
+
+function BreakdownRow({ label, n, color, note }: { label: string; n: number; color: string; note?: string }) {
+  if (n === 0) return null;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0', borderBottom: '1px solid var(--border-subtle)' }}>
+      <span style={{ fontSize: 9, color: 'var(--text-secondary)', width: 90, letterSpacing: '0.07em', flexShrink: 0 }}>{label}</span>
+      <span style={{ fontSize: 13, fontWeight: 600, color, width: 28, textAlign: 'right', flexShrink: 0 }}>{n}</span>
+      {note && <span style={{ fontSize: 9, color: 'var(--text-muted)', lineHeight: 1.5 }}>{note}</span>}
+    </div>
+  );
+}
+
 export default function ExportTab({
   officials, exportForInviteFlow, exportBackup, exportCSV, importBackup, clearAll,
 }: Props) {
+  const bd = getBreakdown(officials);
   const readyCount = officials.filter(
-    o => o.status !== 'left_office' && (o.officeEmail || o.directEmail),
+    o => o.status !== 'left_office' && (o.schedulerEmail || o.directEmail || o.officeEmail),
   ).length;
 
   return (
     <div style={{ padding: '16px 20px', maxWidth: 600 }}>
+
+      {/* Contact method breakdown */}
+      {officials.length > 0 && (
+        <div className="if-card" style={{ marginBottom: 10 }}>
+          <div style={{ fontSize: 12, color: 'var(--text-heading)', fontWeight: 600, marginBottom: 8 }}>Contact Method Breakdown</div>
+          <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.7, marginBottom: 10 }}>
+            For each active official, the best available contact path is used when exporting.
+            Priority: scheduler email → direct email → office email.
+          </div>
+          <BreakdownRow label="SCHEDULER"  n={bd.scheduler} color="#C8A84B" note="invitation goes to the official's scheduler — most effective for event requests" />
+          <BreakdownRow label="DIRECT"     n={bd.direct}    color="#3fb950" note="official's own email address (scanned from web)" />
+          <BreakdownRow label="INFERRED"   n={bd.inferred}  color="#58a6ff" note="email derived from name pattern (federal/NC state) — verify before sending" />
+          <BreakdownRow label="OFFICE"     n={bd.office}    color="#8b949e" note="general office inbox" />
+          <BreakdownRow label="FORM ONLY"  n={bd.formOnly}  color="#a371f7" note="appearance request form found — export note includes URL; manual step required" />
+          <BreakdownRow label="NO CONTACT" n={bd.noContact} color="#f85149" note="no email or form found — verify manually or call the office" />
+        </div>
+      )}
+
       {/* InviteFlow export */}
       <div className="if-card" style={{ marginBottom: 10 }}>
-        <div style={{ fontSize: 12, color: '#f0f6fc', fontWeight: 600, marginBottom: 4 }}>Export to InviteFlow</div>
-        <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.7, marginBottom: 12 }}>
-          Downloads a JSON file that InviteFlow imports directly. Includes only officials with an
-          email address who are still in office.
+        <div style={{ fontSize: 12, color: 'var(--text-heading)', fontWeight: 600, marginBottom: 4 }}>Export to InviteFlow</div>
+        <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.7, marginBottom: 12 }}>
+          Downloads a JSON file for direct import into InviteFlow.
+          Includes only active officials with at least one contact email.
           {officials.length > 0 && (
-            <> <strong style={{ color: readyCount > 0 ? '#a371f7' : '#f85149' }}>
-              {readyCount} of {officials.length}
+            <> <strong style={{ color: readyCount > 0 ? '#a371f7' : 'var(--danger)' }}>
+              {readyCount} of {officials.filter(o => o.status !== 'left_office').length} active
             </strong> officials are eligible.</>
+          )}
+          {bd.inferred > 0 && (
+            <> <span style={{ color: '#58a6ff' }}>{bd.inferred} use inferred emails</span> — confirm addresses before sending.</>
           )}
         </div>
         <button className="if-btn grn" onClick={exportForInviteFlow} disabled={readyCount === 0}>
@@ -37,18 +92,19 @@ export default function ExportTab({
 
       {/* CSV */}
       <div className="if-card" style={{ marginBottom: 10 }}>
-        <div style={{ fontSize: 12, color: '#f0f6fc', fontWeight: 600, marginBottom: 4 }}>Download CSV</div>
-        <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.7, marginBottom: 12 }}>
-          All {officials.length} officials with full detail columns, suitable for spreadsheet analysis.
+        <div style={{ fontSize: 12, color: 'var(--text-heading)', fontWeight: 600, marginBottom: 4 }}>Download CSV</div>
+        <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.7, marginBottom: 12 }}>
+          All {officials.length} officials with full columns including scheduler name, scheduler email,
+          appearance form URL, and email source — suitable for spreadsheet review.
         </div>
         <button className="if-btn" onClick={exportCSV} disabled={officials.length === 0}>↓ Download CSV</button>
       </div>
 
       {/* Backup / restore */}
       <div className="if-card" style={{ marginBottom: 10 }}>
-        <div style={{ fontSize: 12, color: '#f0f6fc', fontWeight: 600, marginBottom: 4 }}>Backup & Restore</div>
-        <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.7, marginBottom: 12 }}>
-          Save the full ContactScout state (officials, scan history, metadata) as JSON.
+        <div style={{ fontSize: 12, color: 'var(--text-heading)', fontWeight: 600, marginBottom: 4 }}>Backup & Restore</div>
+        <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.7, marginBottom: 12 }}>
+          Save the full ContactScout state — officials, scan history, scheduler data — as JSON.
           Restore it later or transfer to another device.
         </div>
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
@@ -58,12 +114,12 @@ export default function ExportTab({
       </div>
 
       {/* Danger zone */}
-      <div style={{ borderTop: '1px solid #161b22', marginTop: 20, paddingTop: 16 }}>
+      <div style={{ borderTop: '1px solid var(--border-subtle)', marginTop: 20, paddingTop: 16 }}>
         <div className="if-section-label" style={{ marginBottom: 10 }}>DANGER ZONE</div>
-        <div style={{ background: '#0d1117', border: '1px solid #da3633', borderRadius: 8, padding: '14px 16px' }}>
-          <div style={{ fontSize: 11, color: '#f0f6fc', fontWeight: 500, marginBottom: 4 }}>Clear all data</div>
-          <div style={{ fontSize: 10, color: '#8b949e', lineHeight: 1.6, marginBottom: 12 }}>
-            Permanently removes all officials, scan history, and results from this browser.
+        <div style={{ background: 'var(--bg-surface)', border: '1px solid var(--danger-dark)', borderRadius: 8, padding: '14px 16px' }}>
+          <div style={{ fontSize: 11, color: 'var(--text-heading)', fontWeight: 500, marginBottom: 4 }}>Clear all data</div>
+          <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.6, marginBottom: 12 }}>
+            Permanently removes all officials, scheduler contacts, scan history, and results.
             Cannot be undone — save a backup first.
           </div>
           <button className="if-btn del" onClick={clearAll}>✕ Clear All ContactScout Data</button>

--- a/src/contactscout/src/components/OfficialsTab.tsx
+++ b/src/contactscout/src/components/OfficialsTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { CATS, STATUS_LABEL, STATUS_COLOR } from '../constants';
-import type { CSOfficial, CSStatus } from '../types';
+import { bestEmail } from '../emailPatterns';
+import type { CSOfficial, CSStatus, EmailSource } from '../types';
 
 interface Props {
   officials: CSOfficial[];
@@ -12,7 +13,8 @@ interface Props {
   setSelected: React.Dispatch<React.SetStateAction<Set<string>>>;
   running: boolean;
   runVerify: (names: string[]) => void;
-  addManually: () => void;
+  onAddManually: () => void;
+  onInferEmails: () => void;
   onGoDiscover: () => void;
 }
 
@@ -21,13 +23,61 @@ function tagStyle(status: CSStatus): React.CSSProperties {
     display: 'inline-flex', alignItems: 'center',
     padding: '2px 7px', borderRadius: 4, border: `1px solid ${STATUS_COLOR[status]}`,
     color: STATUS_COLOR[status], fontSize: 9, letterSpacing: '0.07em',
-    animation: status === 'checking' ? 'cs-pulse 1.4s ease-in-out infinite' : undefined,
+    animation: status === 'checking' ? 'if-pulse 1.4s ease-in-out infinite' : undefined,
   };
+}
+
+const SOURCE_COLOR: Record<EmailSource, string> = {
+  scanned:  '#3fb950',
+  inferred: '#58a6ff',
+  manual:   '#8b949e',
+};
+
+function EmailSourceBadge({ source }: { source: EmailSource }) {
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center',
+      padding: '1px 5px', borderRadius: 3,
+      border: `1px solid ${SOURCE_COLOR[source]}`,
+      color: SOURCE_COLOR[source],
+      fontSize: 8, letterSpacing: '0.07em',
+    }}>
+      {source.toUpperCase()}
+    </span>
+  );
+}
+
+/** Shows which contact path will be used when exporting to InviteFlow. */
+function ContactMethodBadge({ o }: { o: CSOfficial }) {
+  if (o.appearanceFormUrl && !o.schedulerEmail && !o.directEmail && !o.officeEmail) {
+    return (
+      <span style={{ fontSize: 9, color: '#a371f7' }} title={o.appearanceFormUrl}>
+        ⧉ FORM
+      </span>
+    );
+  }
+  if (o.schedulerEmail) {
+    return (
+      <span style={{ fontSize: 9, color: '#C8A84B' }} title={`Scheduler: ${o.schedulerName || o.schedulerEmail}`}>
+        ★ SCHED
+      </span>
+    );
+  }
+  if (o.directEmail) {
+    const label = o.emailSource === 'inferred' ? '~ INFERRED' : '✉ DIRECT';
+    const color = o.emailSource === 'inferred' ? '#58a6ff' : '#3fb950';
+    return <span style={{ fontSize: 9, color }} title={o.directEmail}>{label}</span>;
+  }
+  if (o.officeEmail) {
+    return <span style={{ fontSize: 9, color: '#8b949e' }} title={o.officeEmail}>✉ OFFICE</span>;
+  }
+  return <span style={{ fontSize: 9, color: '#f85149' }}>✗ NO EMAIL</span>;
 }
 
 export default function OfficialsTab({
   officials, allOfficials, activeCat, setActiveCat,
-  selected, toggleSel, setSelected, running, runVerify, addManually, onGoDiscover,
+  selected, toggleSel, setSelected, running, runVerify,
+  onAddManually, onInferEmails, onGoDiscover,
 }: Props) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const names = officials.map(o => o.name);
@@ -44,10 +94,10 @@ export default function OfficialsTab({
     return (
       <div className="if-empty">
         <div className="if-empty-title">No officials in your list yet.</div>
-        <div className="if-empty-sub">Use Discover to scan for officials, then add them here.</div>
+        <div className="if-empty-sub">Scan for officials in the Discover tab, or add one manually.</div>
         <div style={{ display: 'flex', gap: 8, justifyContent: 'center', flexWrap: 'wrap' }}>
           <button className="if-btn pri" onClick={onGoDiscover}>Go to Discover</button>
-          <button className="if-btn" onClick={addManually}>+ Add Manually</button>
+          <button className="if-btn" onClick={onAddManually}>+ Add Manually</button>
         </div>
       </div>
     );
@@ -57,9 +107,9 @@ export default function OfficialsTab({
     <div>
       {/* Sticky action bar */}
       <div style={{
-        padding: '8px 16px', borderBottom: '1px solid #161b22',
+        padding: '8px 16px', borderBottom: '1px solid var(--border-subtle)',
         display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap',
-        position: 'sticky', top: 0, background: '#080c10', zIndex: 2,
+        position: 'sticky', top: 0, background: 'var(--bg-root)', zIndex: 2,
       }}>
         <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', flex: 1, minWidth: 0 }}>
           {CATS.map(c => (
@@ -72,18 +122,26 @@ export default function OfficialsTab({
             </button>
           ))}
         </div>
-        <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+        <div style={{ display: 'flex', gap: 4, flexShrink: 0, flexWrap: 'wrap' }}>
+          <button className="if-btn sm" onClick={onInferEmails} disabled={running} title="Fill missing emails using federal/state name patterns">
+            ⟳ Infer Emails
+          </button>
           <button className="if-btn sm" onClick={() => setSelected(new Set(names))} disabled={running}>Sel All</button>
           <button className="if-btn sm" onClick={() => setSelected(new Set())} disabled={running}>Clear</button>
-          <button className="if-btn sm pri" onClick={() => runVerify([...selected])} disabled={running || selected.size === 0}>
-            ▶ ({selected.size})
+          <button
+            className="if-btn sm pri"
+            onClick={() => runVerify([...selected])}
+            disabled={running || selected.size === 0}
+            title={`Verify ${selected.size} selected officials`}
+          >
+            ▶ Verify ({selected.size})
           </button>
           <button className="if-btn sm pri" onClick={() => runVerify(names)} disabled={running}>▶ All</button>
         </div>
       </div>
 
       {officials.length === 0 && (
-        <div style={{ padding: '24px 20px', textAlign: 'center', color: '#8b949e', fontSize: 11 }}>
+        <div style={{ padding: '24px 20px', textAlign: 'center', color: 'var(--text-secondary)', fontSize: 11 }}>
           No officials in this category.
         </div>
       )}
@@ -91,63 +149,130 @@ export default function OfficialsTab({
       {officials.map(o => {
         const isOpen = expanded.has(o.name);
         const r = o.result;
+        const email = bestEmail(o);
+
         return (
           <div key={o.name}>
-            <div className="if-official-row" onClick={() => toggleExpand(o.name)}>
+            {/* Row */}
+            <div
+              className="if-official-row"
+              style={{ gridTemplateColumns: '20px 1fr 100px 86px 90px 14px' }}
+              onClick={() => toggleExpand(o.name)}
+            >
               <input
                 type="checkbox"
                 checked={selected.has(o.name)}
                 onClick={e => { e.stopPropagation(); toggleSel(o.name); }}
-                style={{ accentColor: '#1f6feb', marginTop: 2 }}
+                style={{ accentColor: 'var(--accent)', marginTop: 2 }}
                 readOnly
               />
+              {/* Name + subtitle */}
               <div style={{ minWidth: 0 }}>
-                <div style={{ fontSize: 11, fontWeight: 500, color: '#f0f6fc', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--text-heading)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                   {o.name}
                 </div>
-                <div style={{ fontSize: 9, color: '#8b949e' }}>
+                <div style={{ fontSize: 9, color: 'var(--text-secondary)' }}>
                   {o.title}{o.district ? ` · D${o.district}` : ''}{o.county ? ` · ${o.county}` : ''}
                 </div>
-                <div style={{ fontSize: 9, color: '#8b949e', fontStyle: 'italic' }}>
-                  {o.directEmail || o.officeEmail || 'no email'}
+                <div style={{ fontSize: 9, color: 'var(--text-muted)', fontStyle: email ? 'normal' : 'italic', display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}>
+                  {email
+                    ? <><span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 200 }}>{email}</span>
+                      <EmailSourceBadge source={o.schedulerEmail ? 'scanned' : o.emailSource} />
+                    </>
+                    : 'no email found'}
                 </div>
               </div>
-              <div className="if-official-cat">
-                <span style={{ fontSize: 9, color: '#8b949e' }}>{o.category}</span>
+              {/* Contact method */}
+              <div style={{ paddingTop: 1 }}>
+                <ContactMethodBadge o={o} />
               </div>
+              {/* Category */}
+              <div className="if-official-cat">
+                <span style={{ fontSize: 9, color: 'var(--text-secondary)' }}>{o.category}</span>
+              </div>
+              {/* Status */}
               <div><span style={tagStyle(o.status)}>{STATUS_LABEL[o.status]}</span></div>
-              <div style={{ fontSize: 10, color: '#30363d' }}>{isOpen ? '▲' : '▼'}</div>
+              {/* Chevron */}
+              <div style={{ fontSize: 10, color: 'var(--border-input)' }}>{isOpen ? '▲' : '▼'}</div>
             </div>
 
-            {isOpen && r && (
+            {/* Expanded detail */}
+            {isOpen && (
               <div className="if-official-expand">
-                {r.error
-                  ? <span style={{ color: '#e3b341' }}>Error: {r.error as string}</span>
+                {r?.error
+                  ? <span style={{ color: 'var(--warning)' }}>Error: {r.error as string}</span>
                   : <>
-                    {r.stillInOffice !== undefined && (
+                    {/* In-office status */}
+                    {r?.stillInOffice !== undefined && (
                       <div>
-                        <span style={{ color: '#8b949e' }}>IN OFFICE </span>
+                        <span style={{ color: 'var(--text-secondary)' }}>IN OFFICE </span>
                         {r.stillInOffice
-                          ? <span style={{ color: '#3fb950' }}>Yes</span>
-                          : <span style={{ color: '#f85149' }}>No{r.replacedBy ? ` → ${r.replacedBy}` : ''}</span>}
+                          ? <span style={{ color: 'var(--success)' }}>Yes</span>
+                          : <span style={{ color: 'var(--danger)' }}>No{r.replacedBy ? ` → ${r.replacedBy as string}` : ''}</span>}
                       </div>
                     )}
-                    {r.currentTitle && <div><span style={{ color: '#8b949e' }}>TITLE </span>{r.currentTitle as string}</div>}
-                    {r.directEmail  && <div><span style={{ color: '#8b949e' }}>DIRECT </span>{r.directEmail as string}</div>}
-                    {r.officeEmail  && <div><span style={{ color: '#8b949e' }}>OFFICE </span>{r.officeEmail as string}</div>}
-                    {r.changes && r.changes !== 'No changes detected' && (
-                      <div><span style={{ color: '#8b949e' }}>CHANGES </span><span style={{ color: '#58a6ff' }}>{r.changes as string}</span></div>
+                    {r?.currentTitle && (
+                      <div><span style={{ color: 'var(--text-secondary)' }}>TITLE </span>{r.currentTitle as string}</div>
                     )}
-                    {r.flags && (
-                      <div><span style={{ color: '#8b949e' }}>FLAGS </span><span style={{ color: '#e3b341' }}>{r.flags as string}</span></div>
-                    )}
-                    {r.confidence && (
+
+                    {/* Email section */}
+                    <div style={{ marginTop: 6, marginBottom: 2, fontSize: 9, color: 'var(--text-muted)', letterSpacing: '0.1em' }}>CONTACT</div>
+                    {o.schedulerName && (
                       <div>
-                        <span style={{ color: '#8b949e' }}>CONF </span>
-                        <span style={{ color: r.confidence === 'high' ? '#3fb950' : r.confidence === 'medium' ? '#e3b341' : '#f85149' }}>
-                          {(r.confidence as string).toUpperCase()}
-                        </span>
+                        <span style={{ color: '#C8A84B' }}>SCHEDULER </span>
+                        <span style={{ color: 'var(--text-base)' }}>{o.schedulerName}</span>
+                        {o.schedulerEmail && (
+                          <> · <a href={`mailto:${o.schedulerEmail}`} style={{ color: '#C8A84B' }} onClick={e => e.stopPropagation()}>{o.schedulerEmail}</a></>
+                        )}
                       </div>
+                    )}
+                    {o.directEmail && (
+                      <div>
+                        <span style={{ color: 'var(--text-secondary)' }}>DIRECT </span>
+                        <a href={`mailto:${o.directEmail}`} style={{ color: 'var(--accent-highlight)' }} onClick={e => e.stopPropagation()}>{o.directEmail}</a>
+                        {' '}<EmailSourceBadge source={o.emailSource} />
+                      </div>
+                    )}
+                    {o.officeEmail && (
+                      <div>
+                        <span style={{ color: 'var(--text-secondary)' }}>OFFICE </span>
+                        <a href={`mailto:${o.officeEmail}`} style={{ color: 'var(--accent-highlight)' }} onClick={e => e.stopPropagation()}>{o.officeEmail}</a>
+                      </div>
+                    )}
+                    {o.officePhone && (
+                      <div><span style={{ color: 'var(--text-secondary)' }}>PHONE </span>{o.officePhone}</div>
+                    )}
+                    {o.appearanceFormUrl && (
+                      <div>
+                        <span style={{ color: '#a371f7' }}>APPEARANCE FORM </span>
+                        <a href={o.appearanceFormUrl} target="_blank" rel="noreferrer"
+                          style={{ color: '#a371f7' }} onClick={e => e.stopPropagation()}>
+                          {o.appearanceFormUrl.length > 60 ? o.appearanceFormUrl.slice(0, 60) + '…' : o.appearanceFormUrl}
+                        </a>
+                      </div>
+                    )}
+
+                    {/* Verify result */}
+                    {r && !r.error && (
+                      <>
+                        {r.changes && r.changes !== 'No changes detected' && (
+                          <div style={{ marginTop: 4 }}>
+                            <span style={{ color: 'var(--text-secondary)' }}>CHANGES </span>
+                            <span style={{ color: 'var(--blue)' }}>{r.changes as string}</span>
+                          </div>
+                        )}
+                        {r.flags && (
+                          <div><span style={{ color: 'var(--text-secondary)' }}>FLAGS </span><span style={{ color: 'var(--warning)' }}>{r.flags as string}</span></div>
+                        )}
+                        {r.confidence && (
+                          <div>
+                            <span style={{ color: 'var(--text-secondary)' }}>CONF </span>
+                            <span style={{ color: r.confidence === 'high' ? 'var(--success)' : r.confidence === 'medium' ? 'var(--warning)' : 'var(--danger)' }}>
+                              {(r.confidence as string).toUpperCase()}
+                            </span>
+                          </div>
+                        )}
+                      </>
                     )}
                   </>
                 }
@@ -157,8 +282,8 @@ export default function OfficialsTab({
         );
       })}
 
-      <div style={{ padding: '10px 18px', borderTop: '1px solid #161b22' }}>
-        <button className="if-btn sm" onClick={addManually}>+ Add Manually</button>
+      <div style={{ padding: '10px 18px', borderTop: '1px solid var(--border-subtle)' }}>
+        <button className="if-btn sm" onClick={onAddManually}>+ Add Manually</button>
       </div>
     </div>
   );

--- a/src/contactscout/src/constants.ts
+++ b/src/contactscout/src/constants.ts
@@ -1,9 +1,13 @@
 import type { CSStatus } from './types';
 
-export const CS_LS_KEY = 'contactscout_state';
-export const CS_JX_KEY = 'contactscout_jurisdiction';
+export const CS_LS_KEY   = 'contactscout_state';
+export const CS_JX_KEY   = 'contactscout_jurisdiction';
 export const CS_APIKEY_SK = 'cs_api_key';
-export const SCOUT_PW = 'scout2025';
+export const SCOUT_PW    = 'scout2025';
+
+// Model IDs — update here when new releases drop; api.ts + App.tsx read these.
+export const MODEL_SCAN   = 'claude-sonnet-4-6';
+export const MODEL_VERIFY = 'claude-sonnet-4-6';
 
 export const SCAN_TARGETS = [
   { id: 'us-congress',  label: 'US Congress',          desc: 'All current US reps + senators for your state' },
@@ -15,13 +19,37 @@ export const SCAN_TARGETS = [
   { id: 'city-3',       label: 'City Council — City 3', desc: 'Current mayor and all council members' },
 ] as const;
 
-export const VERIFY_SYS =
-  `Verify this elected official for 2025-2026 using web search. Respond ONLY with valid JSON no markdown:\n` +
-  `{"stillInOffice":true,"currentTitle":"","directEmail":"","officeEmail":"","officePhone":"","changes":"No changes detected","flags":"","replacedBy":"","confidence":"high"}`;
+// JSON schema carried in system prompts.
+// The scheduler fields are the critical addition: for event invitations you contact
+// the scheduler, not the official directly. The LLM is asked to find both.
+const SCAN_JSON_SCHEMA =
+  `{"officials":[{` +
+  `"name":"","title":"","district":"","county":"",` +
+  `"category":"US Senate|US House|Executive|State Senate|House|City Council",` +
+  `"directEmail":"","officeEmail":"","officePhone":"",` +
+  `"schedulerName":"","schedulerEmail":"",` +
+  `"appearanceFormUrl":""}],` +
+  `"confidence":"high|medium|low","notes":""}`;
 
 export const SCAN_SYS =
-  `Find all current elected officials for 2025-2026 using web search. Respond ONLY with valid JSON no markdown:\n` +
-  `{"officials":[{"name":"","title":"","district":"","county":"","category":"US Senate|US House|Executive|State Senate|House|City Council","directEmail":"","officeEmail":"","officePhone":""}],"confidence":"high","notes":""}`;
+  `You are a research assistant finding current elected officials (2025-2026) using web search.\n` +
+  `For each official also search for their SCHEDULER or CHIEF OF STAFF — the person who manages event\n` +
+  `invitations and appearance requests. If the office uses a web form instead of a direct email for\n` +
+  `appearance requests, capture that URL in appearanceFormUrl.\n` +
+  `Respond ONLY with valid JSON, no markdown fences:\n` +
+  SCAN_JSON_SCHEMA;
+
+const VERIFY_JSON_SCHEMA =
+  `{"stillInOffice":true,"currentTitle":"","directEmail":"","officeEmail":"","officePhone":"",` +
+  `"schedulerName":"","schedulerEmail":"","appearanceFormUrl":"",` +
+  `"changes":"No changes detected","flags":"","replacedBy":"","confidence":"high"}`;
+
+export const VERIFY_SYS =
+  `You are verifying an elected official's current status and contact details (2025-2026) using web search.\n` +
+  `In addition to the official's own contact info, search for their SCHEDULER or CHIEF OF STAFF who handles\n` +
+  `event invitations. If their office uses a web form for appearance requests, find and return that URL.\n` +
+  `Respond ONLY with valid JSON, no markdown fences:\n` +
+  VERIFY_JSON_SCHEMA;
 
 export const CATS = ['All', 'US Senate', 'US House', 'Executive', 'State Senate', 'House', 'City Council'] as const;
 

--- a/src/contactscout/src/constants.ts
+++ b/src/contactscout/src/constants.ts
@@ -6,8 +6,8 @@ export const CS_APIKEY_SK = 'cs_api_key';
 export const SCOUT_PW    = 'scout2025';
 
 // Model IDs — update here when new releases drop; api.ts + App.tsx read these.
-export const MODEL_SCAN   = 'claude-sonnet-4-6';
-export const MODEL_VERIFY = 'claude-sonnet-4-6';
+export const MODEL_SCAN   = 'gemini-2.5-flash';
+export const MODEL_VERIFY = 'gemini-2.5-flash';
 
 export const SCAN_TARGETS = [
   { id: 'us-congress',  label: 'US Congress',          desc: 'All current US reps + senators for your state' },

--- a/src/contactscout/src/emailPatterns.ts
+++ b/src/contactscout/src/emailPatterns.ts
@@ -1,0 +1,134 @@
+/**
+ * Deterministic email pattern inference for elected officials.
+ *
+ * The exploration report's "scraper path" cannot run in a browser (CORS).
+ * What IS portable is the email address patterns themselves — these are publicly
+ * documented conventions that government offices follow:
+ *
+ *   Federal House:   FirstName.LastName@mail.house.gov
+ *   Federal Senate:  FirstName.LastName@{surname}.senate.gov
+ *   NC State Leg:    FirstName.LastName@ncleg.gov
+ *
+ * These are applied POST-SCAN to fill in officials who have no scanned email,
+ * reducing reliance on a second LLM call just to get a guessable address.
+ *
+ * Challenge to the exploration report: the report conflates "scheduler email"
+ * with "official email". The pattern above reaches the OFFICIAL's office mailbox,
+ * not the scheduler directly. Scheduler emails follow no standard pattern and
+ * MUST come from LLM web-search. Inferred emails are therefore marked as such
+ * and ranked below scanned/manual in the contact priority order.
+ */
+
+import type { CSOfficial, CSJurisdiction } from './types';
+
+function normalise(s: string) {
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')  // strip diacritics
+    .replace(/[^a-z\s'-]/g, '')
+    .trim();
+}
+
+function nameParts(name: string): { first: string; last: string } {
+  const parts = normalise(name).split(/\s+/);
+  return {
+    first: parts[0] ?? '',
+    last:  parts[parts.length - 1] ?? '',
+  };
+}
+
+/**
+ * Returns a deterministically inferred email for a federal House member.
+ * Pattern: FirstName.LastName@mail.house.gov
+ */
+export function inferHouseEmail(name: string): string {
+  const { first, last } = nameParts(name);
+  if (!first || !last) return '';
+  return `${first}.${last}@mail.house.gov`;
+}
+
+/**
+ * Returns a deterministically inferred email for a federal Senator.
+ * Pattern: FirstName.LastName@{surname}.senate.gov
+ */
+export function inferSenateEmail(name: string): string {
+  const { first, last } = nameParts(name);
+  if (!first || !last) return '';
+  return `${first}.${last}@${last}.senate.gov`;
+}
+
+/**
+ * Returns a deterministically inferred email for an NC General Assembly member.
+ * Pattern: FirstName.LastName@ncleg.gov
+ * Source: https://www.ncleg.gov — standard for all members.
+ */
+export function inferNCLegEmail(name: string): string {
+  const { first, last } = nameParts(name);
+  if (!first || !last) return '';
+  return `${first}.${last}@ncleg.gov`;
+}
+
+/**
+ * Main entry point.  Returns an inferred email (or empty string) for an official
+ * that has no scanned email, based on their category and jurisdiction state.
+ *
+ * Scope: only fills `directEmail` (office-inbox pattern) — never scheduler email,
+ * which has no standard pattern and must be sourced from LLM web search.
+ */
+export function inferEmail(official: CSOfficial, jx: CSJurisdiction): string {
+  const st = jx.state.trim().toLowerCase();
+
+  switch (official.category) {
+    case 'US House':
+      return inferHouseEmail(official.name);
+
+    case 'US Senate':
+      return inferSenateEmail(official.name);
+
+    case 'State Senate':
+    case 'House':
+      if (st === 'north carolina' || st === 'nc') {
+        return inferNCLegEmail(official.name);
+      }
+      return '';
+
+    default:
+      // Executive and City Council have no standard pattern — too varied.
+      return '';
+  }
+}
+
+/**
+ * Applies email inference to a batch of officials.
+ * Only modifies officials with no directEmail and no officeEmail.
+ * Sets emailSource to 'inferred' on modified officials.
+ * Returns a new array (does not mutate).
+ */
+export function applyEmailInference(
+  officials: CSOfficial[],
+  jx: CSJurisdiction,
+): { officials: CSOfficial[]; inferredCount: number } {
+  let inferredCount = 0;
+  const updated = officials.map(o => {
+    if (o.directEmail || o.officeEmail) return o;
+    const inferred = inferEmail(o, jx);
+    if (!inferred) return o;
+    inferredCount++;
+    return { ...o, directEmail: inferred, emailSource: 'inferred' as const };
+  });
+  return { officials: updated, inferredCount };
+}
+
+/**
+ * Returns the best contact email for an official, in priority order:
+ *   1. schedulerEmail  — most likely to reach the right person for event invites
+ *   2. directEmail     — official's own inbox (may be inferred)
+ *   3. officeEmail     — general office inbox
+ *
+ * appearanceFormUrl takes precedence over all email when it exists, but that
+ * logic lives in the export layer since InviteFlow only accepts email fields.
+ */
+export function bestEmail(o: CSOfficial): string {
+  return o.schedulerEmail || o.directEmail || o.officeEmail || '';
+}

--- a/src/contactscout/src/styles.css
+++ b/src/contactscout/src/styles.css
@@ -252,9 +252,10 @@
 }
 
 /* ── OFFICIALS LIST ROW ── */
+/* Default 6-col layout: checkbox · name · contact-method · category · status · chevron */
 .if-official-row {
   display: grid;
-  grid-template-columns: 20px 1fr 105px 90px 14px;
+  grid-template-columns: 20px 1fr 100px 86px 90px 14px;
   gap: 8px;
   padding: 10px 18px;
   cursor: pointer;
@@ -336,6 +337,9 @@
   .if-btn { min-height: 44px; padding: 0 18px; font-size: 13px; border-radius: 8px; }
   .if-btn.sm { min-height: 36px; padding: 0 14px; font-size: 11px; }
   .if-input { min-height: 44px; padding: 10px 12px; font-size: 13px; }
+  /* Collapse to: checkbox · name · status · chevron */
   .if-official-row { grid-template-columns: 20px 1fr 90px 14px; }
   .if-official-cat { display: none; }
+  /* Hide contact-method badge on narrow viewports — shown in expanded row instead */
+  .if-official-row > :nth-child(3) { display: none; }
 }

--- a/src/contactscout/src/types.ts
+++ b/src/contactscout/src/types.ts
@@ -1,6 +1,12 @@
 export type CSStatus = 'pending' | 'checking' | 'done' | 'changed' | 'left_office' | 'error';
 export type ScanState = 'idle' | 'scanning' | 'done' | 'error';
 
+// How an email address was obtained — drives display badge + export trust ordering.
+export type EmailSource = 'scanned' | 'inferred' | 'manual';
+
+// Which contact method should be used first when sending an event invitation.
+export type ContactMethod = 'scheduler' | 'direct' | 'office' | 'form' | 'phone';
+
 export interface CSJurisdiction {
   state: string;
   counties: string;
@@ -15,9 +21,23 @@ export interface CSOfficial {
   district: string;
   county: string;
   category: string;
+
+  // Email fields — all three may be populated; export logic picks the best one.
   directEmail: string;
   officeEmail: string;
   officePhone: string;
+
+  // Scheduler/staff contact — the person who actually handles the calendar.
+  // For federal officials this is often the most reliable path to getting on their schedule.
+  schedulerName: string;
+  schedulerEmail: string;
+
+  // If the office uses a web form for appearance requests instead of direct email.
+  appearanceFormUrl: string;
+
+  // Tracks how the primary email was obtained; drives the INFERRED badge in the UI.
+  emailSource: EmailSource;
+
   status: CSStatus;
   result: Record<string, string | boolean> | null;
   _scanId?: string;

--- a/src/contactscout/src/utils.ts
+++ b/src/contactscout/src/utils.ts
@@ -1,38 +1,96 @@
 import type { CSOfficial, CSJurisdiction, InviteeExport } from './types';
+import { bestEmail } from './emailPatterns';
 
 export const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
 
+/**
+ * Converts an official to the InviteFlow invitee schema for export.
+ * Contact priority: schedulerEmail > directEmail > officeEmail.
+ * This means if a scheduler was found, the invitation goes to them — exactly
+ * the right person for event appearance requests.
+ */
 export function officialToInvitee(o: CSOfficial): InviteeExport {
   const parts = o.name.trim().split(/\s+/);
+  const email = bestEmail(o);
+
+  // Build notes: district, county, and flag if using scheduler or appearance form.
+  const noteParts: string[] = [];
+  if (o.district) noteParts.push(o.district);
+  if (o.county)   noteParts.push(o.county);
+  if (o.schedulerEmail && email === o.schedulerEmail && o.schedulerName) {
+    noteParts.push(`via scheduler: ${o.schedulerName}`);
+  }
+  if (o.appearanceFormUrl && !email) {
+    noteParts.push(`form: ${o.appearanceFormUrl}`);
+  }
+
   return {
     firstName: parts[0] ?? '',
     lastName: parts.slice(1).join(' '),
     title: o.title,
     category: o.category,
-    email: o.officeEmail || o.directEmail || '',
+    email,
     rsvpLink: '',
     inviteStatus: 'pending',
     sentAt: '',
     rsvpStatus: 'No Response',
     rsvpDate: '',
-    notes: [o.district, o.county].filter(Boolean).join(' · '),
+    notes: noteParts.join(' · '),
   };
 }
 
+/**
+ * Builds scan prompts from jurisdiction settings.
+ * Prompts are scheduler-aware: they explicitly request the name and email of
+ * the official's scheduler/chief-of-staff alongside the official's own contact.
+ */
 export function buildScanPrompts(jx: CSJurisdiction): Record<string, string> {
   const st = jx.state.trim()    || '[YOUR STATE]';
   const co = jx.counties.trim() || '[YOUR COUNTIES]';
   const c1 = jx.city1.trim()    || '[CITY 1]';
   const c2 = jx.city2.trim()    || '[CITY 2]';
   const c3 = jx.city3.trim()    || '[CITY 3]';
+
+  const schedNote =
+    `For each official, also search for their SCHEDULER or CHIEF OF STAFF (the person who manages ` +
+    `event invitations and appearance requests) and return their name and email in schedulerName/schedulerEmail. ` +
+    `If the office uses a web form for appearance requests, return that URL in appearanceFormUrl.`;
+
   return {
-    'us-congress':  `Search for every current US Congress member for ${st} (119th Congress 2025-2026): all House reps + 2 senators. For each: full name, title, district, official scheduler/contact email.`,
-    'state-exec':   `Search for all current ${st} statewide executive elected officials as of 2025: Governor, Lt. Governor, AG, Treasurer, Auditor, Superintendent of Public Instruction, and other commissioners. Full name, title, email.`,
-    'state-senate': `Search for all current ${st} State Senate members as of 2025. Full name, district, official email.`,
-    'state-house':  `Search for all current ${st} House members for ${co} as of 2025. Full name, district, county, official email.`,
-    'city-1':       `Search for current ${c1} City Council as of 2025. Mayor + every council member: full name, title, official email.`,
-    'city-2':       `Search for current ${c2} City Council as of 2025. Mayor + every council member: full name, title, official email.`,
-    'city-3':       `Search for current ${c3} City Council as of 2025. Mayor + every council member: full name, title, official email.`,
+    'us-congress': (
+      `Search for every current US Congress member for ${st} (119th Congress 2025-2026): ` +
+      `all House representatives and both senators. For each: full name, title (e.g. "U.S. Representative"), ` +
+      `district number (House only), official email. ${schedNote}`
+    ),
+    'state-exec': (
+      `Search for all current ${st} statewide executive elected officials as of 2025-2026: ` +
+      `Governor, Lt. Governor, Attorney General, State Treasurer, State Auditor, ` +
+      `Superintendent of Public Instruction, and any other statewide commissioners. ` +
+      `Full name, title, official contact email. ${schedNote}`
+    ),
+    'state-senate': (
+      `Search for ALL current ${st} State Senate members as of 2025-2026. ` +
+      `Full name, district number, official contact email. Include every seat. ${schedNote}`
+    ),
+    'state-house': (
+      `Search for all current ${st} State House members representing ${co} as of 2025-2026. ` +
+      `Full name, district number, county, official contact email. ${schedNote}`
+    ),
+    'city-1': (
+      `Search for the current ${c1} city government as of 2025-2026: ` +
+      `the Mayor and every current City Council member. ` +
+      `Full name, title, official contact email. ${schedNote}`
+    ),
+    'city-2': (
+      `Search for the current ${c2} city government as of 2025-2026: ` +
+      `the Mayor and every current City Council member. ` +
+      `Full name, title, official contact email. ${schedNote}`
+    ),
+    'city-3': (
+      `Search for the current ${c3} city government as of 2025-2026: ` +
+      `the Mayor and every current City Council member. ` +
+      `Full name, title, official contact email. ${schedNote}`
+    ),
   };
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces paid Anthropic Claude API with Google Gemini 2.5 Flash + Google Search Grounding — free forever, no credit card (Google AI Studio free tier: 15 RPM, 1000 RPD)
- Surveyed 5 free-forever LLM providers; Gemini selected as the only one with built-in web search, browser-direct access, and no cost
- Migration plan and LLM usage critique persisted at `docs/superpowers/plans/2026-04-29-gemini-migration.md`

## Changes

| File | What changed |
|------|-------------|
| `src/contact-scout/src/api.ts` | `callClaude()` replaced by `callGemini()` using Gemini REST endpoint with `google_search` grounding tool; same `extractJson()` parser and 429 retry logic |
| `src/contact-scout/src/constants.ts` | `MODEL_SCAN`/`MODEL_VERIFY` set to `gemini-2.5-flash` |
| `src/contact-scout/src/components/ApiKeyModal.tsx` | Key validation updated from `sk-ant-` to `AIza`; instructions point to aistudio.google.com |
| `src/contact-scout/src/App.tsx` | Import renamed; inter-call delay 700ms → 4500ms to stay under Gemini 15 RPM |
| `src/contact-scout/CLAUDE.md` | API setup docs updated for Google AI Studio |
| `docs/superpowers/plans/2026-04-29-gemini-migration.md` | Persisted migration plan + LLM usage critique |

## Test plan

- [ ] Get a free API key from aistudio.google.com (starts with `AIza`)
- [ ] Open ContactScout, click Key, paste the key — modal should accept it
- [ ] Run one scan target (e.g. US Congress) — should return officials via Gemini with Google Search grounding
- [ ] Run verify on one official — should update contact details
- [ ] Confirm key rejected if pasted key does not start with `AIza`
- [ ] Build passes: `cd src/contact-scout && npm run build`

https://claude.ai/code/session_014Z7EgcBNzjaW9o7z8n2SCi
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Z7EgcBNzjaW9o7z8n2SCi)_