### PR TITLE
Add Open States v3 integration for state legislature scans

### DIFF
--- a/src/contactscout/src/App.tsx
+++ b/src/contactscout/src/App.tsx
@@ -1,12 +1,13 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import {
-  CS_APIKEY_SK, VERIFY_SYS, SCAN_SYS, SCAN_TARGETS,
+  CS_APIKEY_SK, CS_OS_KEY, VERIFY_SYS, SCAN_SYS, SCAN_TARGETS,
   MODEL_SCAN, MODEL_VERIFY,
 } from './constants';
 import { loadCSState, saveCSState, loadJurisdiction } from './storage';
 import { sleep, officialToInvitee, buildScanPrompts, downloadBlob, todaySlug } from './utils';
 import { applyEmailInference } from './emailPatterns';
 import { callGemini } from './api';
+import { fetchStateLegislators } from './openStates';
 import ApiKeyModal from './components/ApiKeyModal';
 import JurisdictionModal from './components/JurisdictionModal';
 import AddOfficialModal from './components/AddOfficialModal';
@@ -66,6 +67,7 @@ function ContactScoutInner() {
   const [progress,      setProgress]     = useState({ done: 0, total: 0 });
   const [log,           setLog]          = useState<string[]>([]);
   const [apiKey,        setApiKey]       = useState(() => sessionStorage.getItem(CS_APIKEY_SK) || '');
+  const [osApiKey,      setOsApiKey]     = useState(() => sessionStorage.getItem(CS_OS_KEY) || '');
   const [jx,            setJx]           = useState<CSJurisdiction>(loadJurisdiction);
   const [showKeyModal,  setShowKeyModal]  = useState(false);
   const [showJxModal,   setShowJxModal]   = useState(false);
@@ -92,9 +94,15 @@ function ContactScoutInner() {
     setShowKeyModal(true);
   }
 
-  function handleKeySave(key: string) {
-    setApiKey(key);
-    sessionStorage.setItem(CS_APIKEY_SK, key);
+  function handleKeySave(geminiKey: string, osKey: string) {
+    setApiKey(geminiKey);
+    if (geminiKey) sessionStorage.setItem(CS_APIKEY_SK, geminiKey);
+    else sessionStorage.removeItem(CS_APIKEY_SK);
+
+    setOsApiKey(osKey);
+    if (osKey) sessionStorage.setItem(CS_OS_KEY, osKey);
+    else sessionStorage.removeItem(CS_OS_KEY);
+
     const cb = pendingRef.current;
     pendingRef.current = null;
     cb?.();
@@ -194,43 +202,87 @@ function ContactScoutInner() {
 
   async function runScan(id: string) {
     if (running) return;
-    if (!apiKey) { openKeyModal(() => runScan(id)); return; }
+
+    const isStateLeg = id === 'state-senate' || id === 'state-house';
+    const useOpenStates = isStateLeg && !!osApiKey;
+
+    // Open States scans don't need a Gemini key; all other scans do.
+    if (!useOpenStates && !apiKey) { openKeyModal(() => runScan(id)); return; }
+
     abortRef.current = false;
     setRunning(true);
     setScanStatus(prev => ({ ...prev, [id]: 'scanning' }));
     addLog(`Scanning: ${SCAN_TARGETS.find(t => t.id === id)?.label}…`);
 
     try {
-      const r = await apiCall(MODEL_SCAN, SCAN_SYS, buildScanPrompts(jx)[id]);
-      const currentNames = new Set(officials.map(o => o.name.toLowerCase().trim()));
-      const found = ((r.officials as CSOfficial[]) ?? []).map(normaliseOfficial);
-      const fresh = found.filter(o => !currentNames.has(o.name.toLowerCase().trim()));
+      if (useOpenStates) {
+        const chamber = id === 'state-senate' ? 'upper' : 'lower';
+        const { officials: found, total } = await fetchStateLegislators(osApiKey, jx.state, chamber);
 
-      // Apply email inference to fresh officials that have no scanned email
-      const { officials: inferredFresh, inferredCount } = applyEmailInference(fresh, jx);
+        const currentNames = new Set(officials.map(o => o.name.toLowerCase().trim()));
+        const fresh = found.filter(o => !currentNames.has(o.name.toLowerCase().trim()));
 
-      setScanStatus(prev => ({ ...prev, [id]: 'done' }));
-      setScanMeta(prev => ({
-        ...prev,
-        [id]: { total: found.length, confidence: r.confidence as string, notes: r.notes as string },
-      }));
+        const { officials: inferredFresh, inferredCount } = applyEmailInference(fresh, jx);
 
-      if (inferredFresh.length > 0) {
-        setNewOfficials(prev => {
-          const ex = new Set(prev.map(x => x.name.toLowerCase()));
-          return [
-            ...prev,
-            ...inferredFresh
-              .filter(x => !ex.has(x.name.toLowerCase()))
-              .map(x => ({ ...x, _scanId: id, status: 'pending' as CSStatus })),
-          ];
-        });
-        const infMsg = inferredCount > 0 ? `, ${inferredCount} emails inferred` : '';
-        addLog(`✓ ${inferredFresh.length} new found${infMsg}.`);
+        setScanStatus(prev => ({ ...prev, [id]: 'done' }));
+        setScanMeta(prev => ({
+          ...prev,
+          [id]: {
+            total,
+            confidence: 'high',
+            notes: id === 'state-house'
+              ? 'All districts via Open States — dismiss those outside your counties'
+              : 'via Open States API',
+          },
+        }));
+
+        if (inferredFresh.length > 0) {
+          setNewOfficials(prev => {
+            const ex = new Set(prev.map(x => x.name.toLowerCase()));
+            return [
+              ...prev,
+              ...inferredFresh
+                .filter(x => !ex.has(x.name.toLowerCase()))
+                .map(x => ({ ...x, _scanId: id, status: 'pending' as CSStatus })),
+            ];
+          });
+          const infMsg = inferredCount > 0 ? `, ${inferredCount} emails inferred` : '';
+          addLog(`✓ Open States: ${inferredFresh.length} new (${total} total)${infMsg}. Verify individuals to add scheduler info.`);
+        } else {
+          addLog(`✓ Open States: All ${total} already in list.`);
+        }
       } else {
-        addLog(`✓ All ${found.length} already in list.`);
+        // Gemini path
+        const r = await apiCall(MODEL_SCAN, SCAN_SYS, buildScanPrompts(jx)[id]);
+        const currentNames = new Set(officials.map(o => o.name.toLowerCase().trim()));
+        const found = ((r.officials as CSOfficial[]) ?? []).map(normaliseOfficial);
+        const fresh = found.filter(o => !currentNames.has(o.name.toLowerCase().trim()));
+
+        const { officials: inferredFresh, inferredCount } = applyEmailInference(fresh, jx);
+
+        setScanStatus(prev => ({ ...prev, [id]: 'done' }));
+        setScanMeta(prev => ({
+          ...prev,
+          [id]: { total: found.length, confidence: r.confidence as string, notes: r.notes as string },
+        }));
+
+        if (inferredFresh.length > 0) {
+          setNewOfficials(prev => {
+            const ex = new Set(prev.map(x => x.name.toLowerCase()));
+            return [
+              ...prev,
+              ...inferredFresh
+                .filter(x => !ex.has(x.name.toLowerCase()))
+                .map(x => ({ ...x, _scanId: id, status: 'pending' as CSStatus })),
+            ];
+          });
+          const infMsg = inferredCount > 0 ? `, ${inferredCount} emails inferred` : '';
+          addLog(`✓ ${inferredFresh.length} new found${infMsg}.`);
+        } else {
+          addLog(`✓ All ${found.length} already in list.`);
+        }
+        if (r.notes) addLog(`ℹ ${r.notes as string}`);
       }
-      if (r.notes) addLog(`ℹ ${r.notes as string}`);
     } catch (e) {
       setScanStatus(prev => ({ ...prev, [id]: 'error' }));
       addLog(`✗ Scan: ${String(e)}`);
@@ -417,7 +469,7 @@ function ContactScoutInner() {
             className={`if-btn sm${apiKey ? ' grn' : ' del'}`}
             onClick={() => openKeyModal()}
           >
-            ⚙ Key{apiKey ? ' ✓' : ''}
+            ⚙ Key{apiKey ? ' ✓' : ''}{osApiKey ? ' + OS' : ''}
           </button>
           {running && (
             <button className="if-btn sm del" onClick={() => { abortRef.current = true; }}>■ Stop</button>
@@ -500,6 +552,7 @@ function ContactScoutInner() {
               scanMeta={scanMeta}
               newOfficials={newOfficials}
               running={running}
+              hasOsKey={!!osApiKey}
               runScan={runScan}
               addNew={addNew}
               dismissNew={dismissNew}
@@ -540,7 +593,8 @@ function ContactScoutInner() {
       {/* Modals */}
       {showKeyModal && (
         <ApiKeyModal
-          apiKey={apiKey}
+          geminiKey={apiKey}
+          osKey={osApiKey}
           onSave={handleKeySave}
           onClose={() => { setShowKeyModal(false); pendingRef.current = null; }}
         />

--- a/src/contactscout/src/components/ApiKeyModal.tsx
+++ b/src/contactscout/src/components/ApiKeyModal.tsx
@@ -1,43 +1,82 @@
 import { useState } from 'react';
 
 interface Props {
-  apiKey: string;
-  onSave: (key: string) => void;
+  geminiKey: string;
+  osKey: string;
+  onSave: (geminiKey: string, osKey: string) => void;
   onClose: () => void;
 }
 
-export default function ApiKeyModal({ apiKey, onSave, onClose }: Props) {
-  const [draft, setDraft] = useState(apiKey);
-  const [err, setErr] = useState(false);
+export default function ApiKeyModal({ geminiKey, osKey, onSave, onClose }: Props) {
+  const [gDraft, setGDraft] = useState(geminiKey);
+  const [osDraft, setOsDraft] = useState(osKey);
+  const [gErr, setGErr] = useState(false);
 
   function save() {
-    if (!draft.startsWith('AIza')) { setErr(true); return; }
-    onSave(draft);
+    if (gDraft && !gDraft.startsWith('AIza')) { setGErr(true); return; }
+    onSave(gDraft.trim(), osDraft.trim());
     onClose();
   }
 
   return (
     <div className="if-modal-backdrop" onClick={onClose}>
-      <div className="if-modal" onClick={e => e.stopPropagation()}>
-        <div className="if-modal-title">Google AI Studio API Key</div>
-        <div className="if-modal-sub">
-          Get a free key at{' '}
-          <a href="https://aistudio.google.com/" target="_blank" rel="noreferrer" style={{ color: '#58a6ff' }}>
-            aistudio.google.com
-          </a>{' '}
-          → Get API key → Create API key. Starts with <code>AIza</code>. Stored in session only.
+      <div className="if-modal" onClick={e => e.stopPropagation()} style={{ maxWidth: 440, width: '90%' }}>
+        <div className="if-modal-title">API Keys</div>
+
+        {/* Gemini */}
+        <div style={{ marginBottom: 4 }}>
+          <div className="if-label" style={{ marginBottom: 4 }}>Google AI Studio — Gemini</div>
+          <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.6, marginBottom: 6 }}>
+            Required for all scans. Get a free key at{' '}
+            <a href="https://aistudio.google.com/" target="_blank" rel="noreferrer" style={{ color: '#58a6ff' }}>
+              aistudio.google.com
+            </a>{' '}
+            → Get API key → Create API key. Starts with <code>AIza</code>.
+          </div>
+          <input
+            className={`if-input${gErr ? ' err' : ''}`}
+            type="password"
+            placeholder="AIza..."
+            value={gDraft}
+            onChange={e => { setGDraft(e.target.value); setGErr(false); }}
+            onKeyDown={e => e.key === 'Enter' && save()}
+            autoFocus
+          />
+          {gErr && <div style={{ fontSize: 10, color: 'var(--danger)', marginTop: 4 }}>Must start with AIza</div>}
         </div>
-        <input
-          className={`if-input${err ? ' err' : ''}`}
-          type="password"
-          placeholder="AIza..."
-          value={draft}
-          onChange={e => { setDraft(e.target.value); setErr(false); }}
-          onKeyDown={e => e.key === 'Enter' && save()}
-          autoFocus
-        />
-        {err && <div style={{ fontSize: 10, color: '#f85149', marginTop: 6 }}>Must start with AIza</div>}
-        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 12 }}>
+
+        {/* Divider */}
+        <div style={{ borderTop: '1px solid var(--border)', margin: '14px 0' }} />
+
+        {/* Open States */}
+        <div style={{ marginBottom: 4 }}>
+          <div className="if-label" style={{ marginBottom: 4 }}>
+            Open States — State Legislature{' '}
+            <span style={{ color: 'var(--text-muted)', fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>(optional)</span>
+          </div>
+          <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.6, marginBottom: 6 }}>
+            When set, State Senate and State House scans use Open States structured data instead of Gemini.
+            Register at{' '}
+            <a href="https://openstates.org/api/" target="_blank" rel="noreferrer" style={{ color: '#58a6ff' }}>
+              openstates.org/api
+            </a>{' '}
+            for a free key.
+          </div>
+          <input
+            className="if-input"
+            type="password"
+            placeholder="Open States API key..."
+            value={osDraft}
+            onChange={e => setOsDraft(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && save()}
+          />
+        </div>
+
+        <div style={{ fontSize: 9, color: 'var(--text-muted)', marginTop: 10, lineHeight: 1.6 }}>
+          Both keys are stored in session only — never persisted to localStorage.
+        </div>
+
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 14 }}>
           <button className="if-btn" onClick={onClose}>Cancel</button>
           <button className="if-btn pri" onClick={save}>Save</button>
         </div>

--- a/src/contactscout/src/components/DiscoverTab.tsx
+++ b/src/contactscout/src/components/DiscoverTab.tsx
@@ -8,6 +8,7 @@ interface Props {
   scanMeta: Record<string, CSScanMeta>;
   newOfficials: CSOfficial[];
   running: boolean;
+  hasOsKey: boolean;
   runScan: (id: string) => void;
   addNew: (o: CSOfficial) => void;
   dismissNew: (name: string) => void;
@@ -16,7 +17,7 @@ interface Props {
 
 export default function DiscoverTab({
   jx, scanStatus, scanMeta, newOfficials,
-  running, runScan, addNew, dismissNew, onConfigureJx,
+  running, hasOsKey, runScan, addNew, dismissNew, onConfigureJx,
 }: Props) {
   const jxMissing = !jx.state.trim();
   const anyDone   = Object.values(scanStatus).some(s => s === 'done');
@@ -52,6 +53,7 @@ export default function DiscoverTab({
         const meta  = scanMeta[t.id];
         const fresh = newOfficials.filter(o => o._scanId === t.id);
         const withSched = fresh.filter(o => !!o.schedulerEmail).length;
+        const isStateLeg = t.id === 'state-senate' || t.id === 'state-house';
 
         return (
           <div key={t.id} style={{ marginBottom: 10 }}>
@@ -59,7 +61,14 @@ export default function DiscoverTab({
             <div className="if-card">
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8 }}>
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontSize: 12, color: 'var(--text-heading)', fontWeight: 500, marginBottom: 2 }}>{t.label}</div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
+                    <div style={{ fontSize: 12, color: 'var(--text-heading)', fontWeight: 500 }}>{t.label}</div>
+                    {isStateLeg && hasOsKey && (
+                      <span style={{ fontSize: 8, border: '1px solid var(--success-bg)', color: 'var(--success)', borderRadius: 3, padding: '0 4px', letterSpacing: '0.05em' }}>
+                        OPEN STATES
+                      </span>
+                    )}
+                  </div>
                   <div style={{ fontSize: 10, color: 'var(--text-secondary)' }}>{t.desc}</div>
                   {meta && (
                     <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginTop: 4 }}>

--- a/src/contactscout/src/constants.ts
+++ b/src/contactscout/src/constants.ts
@@ -1,9 +1,10 @@
 import type { CSStatus } from './types';
 
-export const CS_LS_KEY   = 'contactscout_state';
-export const CS_JX_KEY   = 'contactscout_jurisdiction';
+export const CS_LS_KEY    = 'contactscout_state';
+export const CS_JX_KEY    = 'contactscout_jurisdiction';
 export const CS_APIKEY_SK = 'cs_api_key';
-export const SCOUT_PW    = 'scout2025';
+export const CS_OS_KEY    = 'cs_os_key';
+export const SCOUT_PW     = 'scout2025';
 
 // Model IDs — update here when new releases drop; api.ts + App.tsx read these.
 export const MODEL_SCAN   = 'gemini-2.5-flash';

--- a/src/contactscout/src/openStates.ts
+++ b/src/contactscout/src/openStates.ts
@@ -1,0 +1,120 @@
+/**
+ * Open States v3 API client — fetches current state legislators.
+ *
+ * Used for state-senate and state-house scan targets as a structured-data
+ * alternative to Gemini web search. Returns actual email addresses from the
+ * official Open States dataset rather than LLM-inferred addresses.
+ *
+ * Free tier: no rate limit enforced on v3. Pagination: max 100 per page.
+ * API key registration: https://openstates.org/api/
+ *
+ * Note: county filtering is not available — Open States returns all legislators
+ * for the chamber. For state-house scans, all districts are returned and the
+ * user dismisses those outside their tracked counties.
+ *
+ * Scheduler/chief-of-staff fields are left empty; the Verify flow fills them
+ * individually via Gemini web search when the user verifies an official.
+ */
+
+import type { CSOfficial, EmailSource } from './types';
+
+const BASE = 'https://v3.openstates.org';
+
+interface OSOffice {
+  name?: string;
+  email?: string | null;
+  voice?: string | null;
+}
+
+interface OSPerson {
+  name: string;
+  current_role: {
+    title: string;
+    org_classification: 'upper' | 'lower';
+    district: string;
+  } | null;
+  offices: OSOffice[];
+}
+
+interface OSResponse {
+  results: OSPerson[];
+  pagination: {
+    per_page: number;
+    page: number;
+    max_page: number;
+    total_items: number;
+  };
+}
+
+/**
+ * Fetches all current legislators for a state chamber from Open States v3.
+ * Handles pagination automatically (100 per page).
+ *
+ * @param apiKey  Open States API key (registered at openstates.org/api/)
+ * @param state   State name or abbreviation (case-insensitive). E.g. "nc" or "North Carolina".
+ * @param chamber "upper" for Senate, "lower" for House.
+ * @returns       Array of CSOfficial records and total count.
+ * @throws        Error with message "Invalid Open States API key" on 401/403.
+ */
+export async function fetchStateLegislators(
+  apiKey: string,
+  state: string,
+  chamber: 'upper' | 'lower',
+): Promise<{ officials: CSOfficial[]; total: number }> {
+  const jurisdiction = state.trim().toLowerCase();
+  const collected: OSPerson[] = [];
+  let page = 1;
+
+  while (true) {
+    const url =
+      `${BASE}/people` +
+      `?jurisdiction=${encodeURIComponent(jurisdiction)}` +
+      `&classification=legislator` +
+      `&chamber=${chamber}` +
+      `&per_page=100` +
+      `&page=${page}` +
+      `&apikey=${encodeURIComponent(apiKey)}`;
+
+    const res = await fetch(url);
+
+    if (res.status === 401 || res.status === 403) {
+      throw new Error('Invalid Open States API key');
+    }
+    if (!res.ok) {
+      throw new Error(`Open States API error ${res.status}: ${await res.text().catch(() => '')}`);
+    }
+
+    const data = await res.json() as OSResponse;
+    collected.push(...data.results);
+
+    if (page >= data.pagination.max_page) break;
+    page++;
+  }
+
+  const category = chamber === 'upper' ? 'State Senate' : 'House';
+
+  const officials: CSOfficial[] = collected.map(p => {
+    const email = p.offices.find(o => o.email)?.email ?? '';
+    const phone = p.offices.find(o => o.voice)?.voice ?? '';
+    const src: EmailSource = email ? 'scanned' : 'inferred';
+
+    return {
+      name:             p.name,
+      title:            p.current_role?.title ?? (chamber === 'upper' ? 'State Senator' : 'State Representative'),
+      district:         p.current_role?.district ?? '',
+      county:           '',
+      category,
+      directEmail:      '',
+      officeEmail:      email,
+      officePhone:      phone,
+      schedulerName:    '',
+      schedulerEmail:   '',
+      appearanceFormUrl: '',
+      emailSource:      src,
+      status:           'pending',
+      result:           null,
+    };
+  });
+
+  return { officials, total: collected.length };
+}


### PR DESCRIPTION
## Summary

- Adds Open States v3 as a structured data source for **State Senate** and **State House** scan targets, replacing the Gemini LLM call when an Open States API key is configured
- Gemini remains the source for all other scan targets (US Congress, State Executive, City Councils) and for the Verify flow where scheduler/chief-of-staff discovery has no structured API equivalent
- Open States key is **optional** — if not set, both state legislature scans continue using Gemini as before

## What changes

| File | Change |
|------|--------|
| `src/openStates.ts` | New API client — fetches all legislators for a chamber with pagination, maps OS person records to `CSOfficial[]` |
| `src/constants.ts` | Adds `CS_OS_KEY` sessionStorage key |
| `src/components/ApiKeyModal.tsx` | Two-key modal: Gemini (required) + Open States (optional, with link to openstates.org/api) |
| `src/App.tsx` | `osApiKey` state from sessionStorage; hybrid `runScan` picks Open States vs Gemini; Key button shows `+ OS` indicator when Open States key is set |
| `src/components/DiscoverTab.tsx` | Green `OPEN STATES` badge on State Senate and State House scan cards when key is configured |

## Why Open States for state legislators

Open States v3 returns a complete, authoritative roster of current state legislators with actual email addresses from their offices. Compared to Gemini web search for the same data:
- No rate limit cost (doesn't count against the 15 RPM Gemini quota)
- Higher confidence — structured government data vs. LLM-inferred contacts
- Complete coverage — all seats returned, not dependent on search quality
- `emailSource: 'scanned'` on emails from Open States vs. `'inferred'` for pattern-derived addresses

## Known limitation — county filtering for State House

Open States returns all house members for the state; it cannot filter by county. When using Open States for the State House scan, the scan meta note reads: _"All districts via Open States — dismiss those outside your counties."_ The user dismisses unwanted candidates in the Discover tab.

## Setup

Register for a free key at https://openstates.org/api/ (no credit card). Enter it in the **Key** modal alongside the Gemini key.

## Test plan

- [ ] Open Key modal — verify two sections appear (Gemini + Open States), both save to sessionStorage
- [ ] With only a Gemini key: State Senate and State House scans use Gemini (no regression)
- [ ] With Open States key set: Key button shows `⚙ Key ✓ + OS`; State Senate/House cards show green `OPEN STATES` badge
- [ ] Run State Senate scan with OS key — candidates appear with `emailSource: 'scanned'` emails; scan meta shows `confidence: high` and `via Open States API` note
- [ ] Run State House scan with OS key — all districts returned; meta note mentions county filtering
- [ ] US Congress, State Executive, City Council scans unchanged — still use Gemini

https://claude.ai/code/session_014Z7EgcBNzjaW9o7z8n2SCi

---
_Generated by [Claude Code](https://claude.ai/code/session_014Z7EgcBNzjaW9o7z8n2SCi)_