### PR TITLE
feat: InviteFlow Phase 2 — page-stack router & workflow pages

### DIFF
--- a/src/inviteflow/App.tsx
+++ b/src/inviteflow/App.tsx
@@ -1,207 +1,48 @@
-import { useState } from 'react';
-import { AppProvider, useAppState, useAppDispatch } from './state/AppContext';
-import type { TabId } from './types';
-import EventsTab from './tabs/EventsTab';
-import SetupTab from './tabs/SetupTab';
-import InviteesTab from './tabs/InviteesTab';
-import ComposeTab from './tabs/ComposeTab';
-import SendTab from './tabs/SendTab';
-import TrackerTab from './tabs/TrackerTab';
-import SyncTab from './tabs/SyncTab';
+import { AppProvider } from './state/AppContext';
+import { RouterProvider, useRouter } from './state/RouterContext';
+import EventsPage from './pages/EventsPage';
+import EventDashboard from './pages/EventDashboard';
+import EventSetupPage from './pages/EventSetupPage';
+import InviteesPage from './pages/InviteesPage';
+import ComposePage from './pages/ComposePage';
+import SendPage from './pages/SendPage';
+import TrackerPage from './pages/TrackerPage';
+import SyncPage from './pages/SyncPage';
+import SettingsPage from './pages/SettingsPage';
 
-const TABS: { id: TabId; label: string }[] = [
-  { id: 'events',   label: 'Events'   },
-  { id: 'setup',    label: 'Setup'    },
-  { id: 'invitees', label: 'Invitees' },
-  { id: 'compose',  label: 'Compose'  },
-  { id: 'send',     label: 'Send'     },
-  { id: 'tracker',  label: 'Tracker'  },
-  { id: 'sync',     label: 'Sync'     },
-];
-
-function TabContent() {
-  const { tab } = useAppState();
-  switch (tab) {
-    case 'events':   return <EventsTab />;
-    case 'setup':    return <SetupTab />;
-    case 'invitees': return <InviteesTab />;
-    case 'compose':  return <ComposeTab />;
-    case 'send':     return <SendTab />;
-    case 'tracker':  return <TrackerTab />;
-    case 'sync':     return <SyncTab />;
+function PageContent() {
+  const { route } = useRouter();
+  switch (route) {
+    case 'events':      return <EventsPage />;
+    case 'event-home':  return <EventDashboard />;
+    case 'event-setup': return <EventSetupPage />;
+    case 'invitees':    return <InviteesPage />;
+    case 'compose':     return <ComposePage />;
+    case 'send':        return <SendPage />;
+    case 'tracker':     return <TrackerPage />;
+    case 'sync':        return <SyncPage />;
+    case 'settings':    return <SettingsPage />;
   }
-}
-
-function AppInner() {
-  const state = useAppState();
-  const dispatch = useAppDispatch();
-  const [drawerOpen, setDrawerOpen] = useState(false);
-
-  const activeEvent = state.events.find(e => e.id === state.activeEventId);
-
-  function selectTab(id: TabId) {
-    dispatch({ type: 'SET_TAB', tab: id });
-    setDrawerOpen(false);
-  }
-
-  return (
-    <div
-      className="h-screen flex flex-col overflow-hidden"
-      style={{ background: 'var(--bg-root)', color: 'var(--text-base)', fontFamily: 'var(--rf-mono)' }}
-    >
-      {/* ── Header ─────────────────────────────────────────────────────── */}
-      <header
-        className="shrink-0"
-        style={{ background: 'var(--bg-surface)', borderBottom: '1px solid var(--border)' }}
-      >
-        {/* Row 1 — Brand + event context */}
-        <div className="flex items-center gap-4 px-5 pt-3 pb-2">
-          {/* Brand */}
-          <div className="flex flex-col shrink-0">
-            <span className="if-eyebrow" style={{ marginBottom: 3 }}>CONVENE · ROSTER</span>
-            <span className="if-page-title" style={{ fontSize: 16 }}>InviteFlow</span>
-          </div>
-
-          {/* Active event context */}
-          {activeEvent && (
-            <div
-              className="flex items-center gap-2 pl-4 truncate"
-              style={{ borderLeft: '1px solid var(--border)' }}
-            >
-              <span
-                style={{
-                  width: 6, height: 6, borderRadius: '50%',
-                  background: 'var(--accent)', flexShrink: 0,
-                }}
-              />
-              <span
-                className="truncate"
-                style={{
-                  fontFamily: 'var(--rf-mono)', fontSize: 10,
-                  letterSpacing: '0.1em', color: 'var(--text-base)',
-                }}
-              >
-                {activeEvent.name.toUpperCase()}
-              </span>
-              {activeEvent.date && (
-                <>
-                  <span style={{ color: 'var(--border-input)', flexShrink: 0 }}>·</span>
-                  <span
-                    style={{
-                      fontFamily: 'var(--rf-mono)', fontSize: 10,
-                      color: 'var(--text-secondary)', letterSpacing: '0.08em', flexShrink: 0,
-                    }}
-                  >
-                    {activeEvent.date}
-                  </span>
-                </>
-              )}
-            </div>
-          )}
-
-          {/* Unsaved indicator */}
-          {state.unsaved && (
-            <span
-              style={{
-                fontFamily: 'var(--rf-mono)', fontSize: 9,
-                letterSpacing: '0.1em', color: 'var(--text-muted)',
-              }}
-            >
-              UNSAVED
-            </span>
-          )}
-
-          {/* Mobile hamburger */}
-          <button
-            className="ml-auto md:hidden if-header-btn"
-            onClick={() => setDrawerOpen(true)}
-            aria-label="Open navigation"
-          >
-            ☰
-          </button>
-        </div>
-
-        {/* Row 2 — Desktop tab navigation */}
-        <nav
-          className="hidden md:flex px-5"
-          role="tablist"
-          style={{ borderTop: '1px solid var(--border)' }}
-        >
-          {TABS.map(t => (
-            <button
-              key={t.id}
-              role="tab"
-              aria-selected={state.tab === t.id}
-              onClick={() => selectTab(t.id)}
-              className={`if-nav-tab${state.tab === t.id ? ' active' : ''}`}
-            >
-              {t.label}
-            </button>
-          ))}
-        </nav>
-      </header>
-
-      {/* ── Mobile drawer ──────────────────────────────────────────────── */}
-      {drawerOpen && (
-        <>
-          <div
-            className="fixed inset-0 z-40 md:hidden"
-            style={{ background: 'rgba(0,0,0,0.6)' }}
-            onClick={() => setDrawerOpen(false)}
-          />
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-label="Navigation"
-            className="fixed inset-y-0 left-0 w-56 z-50 flex flex-col md:hidden"
-            style={{ background: 'var(--bg-surface)', borderRight: '1px solid var(--border)' }}
-          >
-            <div
-              className="flex items-center justify-between px-5 py-3"
-              style={{ borderBottom: '1px solid var(--border)' }}
-            >
-              <div>
-                <div className="if-eyebrow" style={{ marginBottom: 2 }}>CONVENE · ROSTER</div>
-                <div className="if-page-title" style={{ fontSize: 15 }}>InviteFlow</div>
-              </div>
-              <button className="if-header-btn" onClick={() => setDrawerOpen(false)} aria-label="Close">
-                ✕
-              </button>
-            </div>
-            <nav role="tablist" className="flex flex-col py-2">
-              {TABS.map(t => (
-                <button
-                  key={t.id}
-                  role="tab"
-                  aria-selected={state.tab === t.id}
-                  onClick={() => selectTab(t.id)}
-                  className="min-h-[44px] flex items-center px-5 cursor-pointer border-l-2"
-                  style={{
-                    fontFamily: 'var(--rf-mono)',
-                    fontSize: 10,
-                    letterSpacing: '0.07em',
-                    textTransform: 'uppercase',
-                    ...(state.tab === t.id
-                      ? { borderColor: 'var(--accent)', background: 'var(--bg-subtle)', color: 'var(--accent)' }
-                      : { borderColor: 'transparent', color: 'var(--text-secondary)', background: 'transparent' }),
-                  }}
-                >
-                  {t.label}
-                </button>
-              ))}
-            </nav>
-          </div>
-        </>
-      )}
-
-      {/* ── Main content ────────────────────────────────────────────────── */}
-      <main className="flex-1 overflow-auto flex flex-col">
-        <TabContent />
-      </main>
-    </div>
-  );
 }
 
 export default function App() {
-  return <AppProvider><AppInner /></AppProvider>;
+  return (
+    <AppProvider>
+      <RouterProvider>
+        <div
+          style={{
+            height: '100dvh',
+            overflow: 'hidden',
+            background: 'var(--bg-root)',
+            color: 'var(--text-base)',
+            fontFamily: 'var(--rf-mono)',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <PageContent />
+        </div>
+      </RouterProvider>
+    </AppProvider>
+  );
 }

--- a/src/inviteflow/components/Icon.tsx
+++ b/src/inviteflow/components/Icon.tsx
@@ -1,0 +1,44 @@
+interface IconProps {
+  name: string;
+  size?: number;
+  stroke?: number;
+  style?: React.CSSProperties;
+}
+
+export default function Icon({ name, size = 16, stroke = 1.5, style = {} }: IconProps) {
+  const props = {
+    width: size, height: size, viewBox: '0 0 24 24',
+    fill: 'none', stroke: 'currentColor',
+    strokeWidth: stroke, strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const, style,
+  };
+  switch (name) {
+    case 'chevron-right': return <svg {...props}><path d="M9 6l6 6-6 6"/></svg>;
+    case 'chevron-left':  return <svg {...props}><path d="M15 6l-6 6 6 6"/></svg>;
+    case 'menu':          return <svg {...props}><path d="M3 6h18M3 12h18M3 18h18"/></svg>;
+    case 'plus':          return <svg {...props}><path d="M12 5v14M5 12h14"/></svg>;
+    case 'search':        return <svg {...props}><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>;
+    case 'check':         return <svg {...props}><path d="M5 12l4 4L19 6"/></svg>;
+    case 'send':          return <svg {...props}><path d="M22 2L11 13"/><path d="M22 2l-7 20-4-9-9-4z"/></svg>;
+    case 'users':         return <svg {...props}><circle cx="9" cy="8" r="4"/><path d="M2 21c0-3.9 3.1-7 7-7s7 3.1 7 7"/><circle cx="17" cy="6" r="3"/><path d="M22 18c0-2.5-2-4.5-5-4.5"/></svg>;
+    case 'calendar':      return <svg {...props}><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 9h18M8 3v4M16 3v4"/></svg>;
+    case 'mail':          return <svg {...props}><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6 9-6"/></svg>;
+    case 'filter':        return <svg {...props}><path d="M3 5h18M6 12h12M10 19h4"/></svg>;
+    case 'upload':        return <svg {...props}><path d="M12 20V8M7 13l5-5 5 5M4 21h16"/></svg>;
+    case 'download':      return <svg {...props}><path d="M12 4v12M7 11l5 5 5-5M4 21h16"/></svg>;
+    case 'settings':      return <svg {...props}><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z"/></svg>;
+    case 'lock':          return <svg {...props}><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V8a4 4 0 018 0v3"/></svg>;
+    case 'pen':           return <svg {...props}><path d="M14 4l6 6L8 22H2v-6z"/></svg>;
+    case 'x':             return <svg {...props}><path d="M6 6l12 12M18 6L6 18"/></svg>;
+    case 'clock':         return <svg {...props}><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>;
+    case 'shield':        return <svg {...props}><path d="M12 2l8 4v6c0 5-3.5 9-8 10-4.5-1-8-5-8-10V6z"/></svg>;
+    case 'moon':          return <svg {...props}><path d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z"/></svg>;
+    case 'pin':           return <svg {...props}><path d="M12 22s7-7.5 7-13a7 7 0 10-14 0c0 5.5 7 13 7 13z"/><circle cx="12" cy="9" r="2.5"/></svg>;
+    case 'user':          return <svg {...props}><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>;
+    case 'building':      return <svg {...props}><rect x="4" y="3" width="16" height="18" rx="1"/><path d="M9 8h6M9 12h6M9 16h6"/></svg>;
+    case 'sync':          return <svg {...props}><path d="M23 4v6h-6"/><path d="M1 20v-6h6"/><path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/></svg>;
+    case 'star':          return <svg {...props}><path d="M12 3l2.6 6.2 6.7.5-5.1 4.4 1.6 6.5L12 17.3 6.2 20.6l1.6-6.5L2.7 9.7l6.7-.5z"/></svg>;
+    case 'sparkle':       return <svg {...props}><path d="M12 3l2 6 6 2-6 2-2 6-2-6-6-2 6-2z"/></svg>;
+    default:              return <svg {...props}/>;
+  }
+}

--- a/src/inviteflow/components/PageHeader.tsx
+++ b/src/inviteflow/components/PageHeader.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react';
+import { useRouter } from '../state/RouterContext';
+import Icon from './Icon';
+
+interface PageHeaderProps {
+  eyebrow: string;
+  title: string;
+  showBack?: boolean;
+  // undefined = show hamburger → settings, null = hide, ReactNode = custom
+  right?: ReactNode | null;
+}
+
+export default function PageHeader({ eyebrow, title, showBack = false, right }: PageHeaderProps) {
+  const { goBack, navigate } = useRouter();
+
+  const rightEl: ReactNode = right === undefined
+    ? (
+      <button
+        className="if-header-btn"
+        onClick={() => navigate('settings')}
+        aria-label="Settings"
+      >
+        <Icon name="menu" size={15}/>
+      </button>
+    )
+    : right;
+
+  return (
+    <div style={{
+      padding: '12px 18px 14px',
+      display: 'flex', alignItems: 'center', gap: 10,
+      flexShrink: 0,
+    }}>
+      {showBack && (
+        <button className="if-header-btn" onClick={goBack} aria-label="Back">
+          <Icon name="chevron-left" size={14}/>
+        </button>
+      )}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="if-eyebrow" style={{ marginBottom: 3 }}>{eyebrow}</div>
+        <div className="if-page-title">{title}</div>
+      </div>
+      {rightEl}
+    </div>
+  );
+}

--- a/src/inviteflow/pages/ComposePage.tsx
+++ b/src/inviteflow/pages/ComposePage.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useCallback, useState } from 'react';
+import { useEditor, EditorContent } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import { useRouter } from '../state/RouterContext';
+import PageHeader from '../components/PageHeader';
+import Icon from '../components/Icon';
+import { personalize } from '../api/gmail';
+
+const TOKENS = [
+  'FirstName', 'LastName', 'FullName', 'FullTitle',
+  'EventName', 'EventDate', 'Venue', 'OrgName',
+  'ContactName', 'ContactEmail', 'VIPStart', 'VIPEnd', 'RSVP_Link', 'Date_Sent',
+];
+
+export default function ComposePage() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const { navigate } = useRouter();
+  const [activePane, setActivePane] = useState<'edit' | 'preview'>('edit');
+  const ev = state.events.find(e => e.id === state.activeEventId);
+  const sample = state.invitees[0];
+
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: state.htmlBody || '<p>Dear Honorable {{FirstName}} {{LastName}},</p><p></p><p>{{RSVP_Link}}</p>',
+    onUpdate({ editor }) {
+      dispatch({ type: 'SET_COMPOSE', subject: state.textSubject, html: editor.getHTML() });
+    },
+  });
+
+  useEffect(() => {
+    if (editor && state.htmlBody && editor.getHTML() !== state.htmlBody) {
+      editor.commands.setContent(state.htmlBody, false);
+    }
+  }, []);
+
+  const insertToken = useCallback((token: string) => {
+    editor?.commands.insertContent(`{{${token}}}`);
+  }, [editor]);
+
+  const preview = ev && sample ? personalize(state.htmlBody, sample, ev) : state.htmlBody;
+  const wordCount = state.htmlBody.replace(/<[^>]+>/g, '').trim().split(/\s+/).filter(Boolean).length;
+  const tokenCount = (state.htmlBody.match(/\{\{\w+\}\}/g) || []).length;
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <PageHeader eyebrow="COMPOSE" title="Invitation template" showBack />
+
+      {/* Top controls */}
+      <div style={{ padding: '0 18px 10px', flexShrink: 0, borderBottom: '1px solid var(--border)' }}>
+        {/* Tab switcher + stats */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginBottom: 10 }}>
+          <div className="if-tab-switcher" style={{ width: 180 }}>
+            <button className={`if-tab-option${activePane === 'edit' ? ' active' : ''}`} onClick={() => setActivePane('edit')}>Edit</button>
+            <button className={`if-tab-option${activePane === 'preview' ? ' active' : ''}`} onClick={() => setActivePane('preview')}>Preview</button>
+          </div>
+          <div style={{ display: 'flex', gap: 16 }}>
+            {[{ label: 'WORDS', value: wordCount }, { label: 'TOKENS', value: tokenCount }, { label: 'RECIPIENTS', value: state.invitees.length }].map(s => (
+              <div key={s.label} style={{ textAlign: 'center' }}>
+                <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 7, letterSpacing: '0.1em', color: 'var(--text-muted)' }}>{s.label}</div>
+                <div style={{ fontFamily: 'var(--rf-serif)', fontSize: 16, fontWeight: 500, color: 'var(--text-heading)', lineHeight: 1 }}>{s.value}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Subject */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+          <label className="if-label" style={{ flexShrink: 0, marginBottom: 0 }}>Subject</label>
+          <input
+            className="if-input"
+            style={{ flex: 1 }}
+            value={state.textSubject}
+            onChange={e => dispatch({ type: 'SET_COMPOSE', subject: e.target.value, html: state.htmlBody })}
+            placeholder="You are cordially invited to {{EventName}}"
+          />
+        </div>
+
+        {/* Tokens */}
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
+          <span className="if-label" style={{ marginBottom: 0 }}>Insert</span>
+          {TOKENS.map(t => (
+            <button key={t} onClick={() => insertToken(t)} className="if-btn sm"
+              style={{ color: 'var(--accent)', borderColor: 'var(--accent-border)' }}>
+              {`{{${t}}}`}
+            </button>
+          ))}
+        </div>
+
+        {/* Format bar */}
+        {activePane === 'edit' && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 8 }}>
+            {[
+              { label: 'B', action: () => editor?.chain().focus().toggleBold().run(), active: () => !!editor?.isActive('bold') },
+              { label: 'I', action: () => editor?.chain().focus().toggleItalic().run(), active: () => !!editor?.isActive('italic') },
+              { label: '• List', action: () => editor?.chain().focus().toggleBulletList().run(), active: () => !!editor?.isActive('bulletList') },
+              { label: '1. List', action: () => editor?.chain().focus().toggleOrderedList().run(), active: () => !!editor?.isActive('orderedList') },
+            ].map(({ label, action, active }) => (
+              <button key={label} className="if-btn sm"
+                style={active() ? { borderColor: 'var(--accent)', color: 'var(--accent)', background: 'rgba(229,113,88,0.1)' } : {}}
+                onClick={action}>
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Editor / Preview */}
+      <div style={{ flex: 1, overflow: 'hidden', display: 'flex' }}>
+        {/* Editor pane */}
+        <div style={{
+          flex: 1, overflowY: 'auto', padding: 16,
+          display: activePane === 'edit' ? 'block' : 'none',
+          borderRight: '1px solid var(--border)',
+        }}>
+          <div className="if-section-label" style={{ marginBottom: 10 }}>EDITOR</div>
+          <EditorContent editor={editor} style={{ color: 'var(--text-base)', fontSize: 13, lineHeight: 1.7 }} />
+        </div>
+
+        {/* Preview pane */}
+        <div style={{
+          flex: 1, overflowY: 'auto', padding: 16,
+          background: 'var(--bg-subtle)',
+          display: activePane === 'preview' ? 'block' : 'none',
+        }}>
+          <div className="if-section-label" style={{ marginBottom: 10 }}>
+            PREVIEW
+            {sample
+              ? <span style={{ marginLeft: 6, color: 'var(--text-muted)' }}>({sample.firstName} {sample.lastName})</span>
+              : <span style={{ marginLeft: 6, color: 'var(--text-muted)' }}>(no invitees)</span>
+            }
+          </div>
+          {!sample ? (
+            <div className="if-empty" style={{ padding: '24px 0' }}>Add invitees to see a personalized preview.</div>
+          ) : (
+            <div style={{ background: '#fff', borderRadius: 8, padding: 16, fontSize: 13, lineHeight: 1.7, color: '#1a1a1a' }}
+              dangerouslySetInnerHTML={{ __html: preview }} />
+          )}
+        </div>
+      </div>
+
+      {/* Sticky CTA */}
+      <div style={{ flexShrink: 0, padding: '12px 18px', borderTop: '1px solid var(--border)', background: 'var(--bg-root)' }}>
+        <button className="if-btn pri" style={{ width: '100%' }} onClick={() => navigate('send')}>
+          <Icon name="send" size={13} style={{ marginRight: 6 }} />
+          CONTINUE TO SEND →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/inviteflow/pages/EventDashboard.tsx
+++ b/src/inviteflow/pages/EventDashboard.tsx
@@ -1,0 +1,191 @@
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import { useRouter } from '../state/RouterContext';
+import PageHeader from '../components/PageHeader';
+import Icon from '../components/Icon';
+import type { RouteId } from '../state/RouterContext';
+
+interface WorkflowRow {
+  num: string;
+  icon: string;
+  title: string;
+  sub: string;
+  route: RouteId;
+}
+
+const WORKFLOW: WorkflowRow[] = [
+  { num: '01', icon: 'users',    title: 'Invitees',   sub: 'IMPORT, MANAGE & REVIEW GUEST LIST',  route: 'invitees' },
+  { num: '02', icon: 'pen',      title: 'Compose',    sub: 'WRITE & PREVIEW THE INVITE EMAIL',    route: 'compose'  },
+  { num: '03', icon: 'send',     title: 'Send',       sub: 'BULK SEND VIA GMAIL',                 route: 'send'     },
+  { num: '04', icon: 'calendar', title: 'Tracker',    sub: 'MONITOR RSVP RESPONSES',              route: 'tracker'  },
+  { num: '05', icon: 'sync',     title: 'Sync',       sub: 'PUSH / PULL GOOGLE SHEETS',           route: 'sync'     },
+];
+
+function CardRow({
+  chip, title, sub, route, isLast,
+}: {
+  chip: React.ReactNode;
+  title: string;
+  sub: string;
+  route: RouteId;
+  isLast?: boolean;
+}) {
+  const { navigate } = useRouter();
+  return (
+    <button
+      onClick={() => navigate(route)}
+      style={{
+        width: '100%', display: 'flex', alignItems: 'center', gap: 10,
+        padding: 'var(--rt-row-pad)', background: 'transparent', border: 'none',
+        borderBottom: isLast ? 'none' : '1px solid var(--border)',
+        cursor: 'pointer', textAlign: 'left',
+      }}
+    >
+      <div style={{
+        width: 28, height: 28, borderRadius: 6, flexShrink: 0,
+        background: 'var(--bg-root)', border: '1px solid var(--border)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: 'var(--text-secondary)',
+      }}>
+        {chip}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="if-card-row-title">{title}</div>
+        <div className="if-card-row-sub">{sub}</div>
+      </div>
+      <Icon name="chevron-right" size={13} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
+    </button>
+  );
+}
+
+export default function EventDashboard() {
+  const state = useAppState();
+  const { navigate } = useRouter();
+
+  const ev = state.events.find(e => e.id === state.activeEventId);
+
+  const total     = state.invitees.length;
+  const sent      = state.invitees.filter(i => i.inviteStatus === 'sent').length;
+  const attending = state.invitees.filter(i => i.rsvpStatus === 'Attending').length;
+  const pending   = state.invitees.filter(i => i.rsvpStatus === 'No Response').length;
+
+  const recent = [...state.sendLog].reverse().slice(0, 5);
+
+  if (!ev) {
+    return (
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+        <PageHeader eyebrow="EVENT" title="No event selected" showBack />
+        <div className="if-empty">
+          No event active.
+          <div className="if-empty-sub">GO BACK AND SELECT AN EVENT</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <PageHeader eyebrow="EVENT" title={ev.name} showBack />
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 32px' }}>
+
+        {/* Stats card */}
+        <div className="if-card" style={{ padding: '14px 16px', marginBottom: 12 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 0 }}>
+            {[
+              { label: 'INVITED',   value: sent,      color: 'var(--text-heading)' },
+              { label: 'ATTENDING', value: attending, color: 'var(--accent)' },
+              { label: 'PENDING',   value: pending,   color: 'var(--text-muted)' },
+            ].map((s, i) => (
+              <div
+                key={s.label}
+                style={{
+                  textAlign: 'center',
+                  borderRight: i < 2 ? '1px solid var(--border)' : 'none',
+                  padding: '4px 0',
+                }}
+              >
+                <div style={{ fontFamily: 'var(--rf-serif)', fontSize: 28, fontWeight: 500, color: s.color, lineHeight: 1 }}>
+                  {s.value}
+                </div>
+                <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 8, color: 'var(--text-muted)', letterSpacing: '0.12em', marginTop: 4 }}>
+                  {s.label}
+                </div>
+              </div>
+            ))}
+          </div>
+          {ev.date && (
+            <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--text-secondary)', letterSpacing: '0.1em', marginTop: 12, paddingTop: 10, borderTop: '1px solid var(--border)' }}>
+              {ev.date} {ev.venue ? `· ${ev.venue}` : ''}
+            </div>
+          )}
+        </div>
+
+        {/* Workflow */}
+        <div className="if-section-label" style={{ padding: '8px 0 8px' }}>WORKFLOW</div>
+        <div className="if-card" style={{ marginBottom: 12 }}>
+          {WORKFLOW.map((w, i) => (
+            <CardRow
+              key={w.route}
+              chip={<span style={{ fontFamily: 'var(--rf-mono)', fontSize: 9 }}>{w.num}</span>}
+              title={w.title}
+              sub={w.sub}
+              route={w.route}
+              isLast={i === WORKFLOW.length - 1}
+            />
+          ))}
+        </div>
+
+        {/* More */}
+        <div className="if-section-label" style={{ padding: '8px 0 8px' }}>MORE</div>
+        <div className="if-card" style={{ marginBottom: 12 }}>
+          <CardRow
+            chip={<Icon name="settings" size={13} />}
+            title="Event Setup"
+            sub="EDIT EVENT DETAILS, OAUTH, SHEET URLS"
+            route="event-setup"
+          />
+          <CardRow
+            chip={<Icon name="sparkle" size={13} />}
+            title="Discover Officials"
+            sub="FIND ELECTED OFFICIALS WITH CONTACTSCOUT"
+            route="invitees"
+            isLast
+          />
+        </div>
+
+        {/* Recent activity */}
+        {recent.length > 0 && (
+          <>
+            <div className="if-section-label" style={{ padding: '8px 0 8px' }}>RECENT ACTIVITY</div>
+            <div className="if-card">
+              {recent.map((entry, i) => (
+                <div
+                  key={entry.id}
+                  style={{
+                    display: 'flex', gap: 10, alignItems: 'baseline',
+                    padding: 'var(--rt-row-pad)',
+                    borderBottom: i < recent.length - 1 ? '1px solid var(--border)' : 'none',
+                  }}
+                >
+                  <span style={{
+                    fontFamily: 'var(--rf-mono)', fontSize: 8, letterSpacing: '0.08em',
+                    color: entry.status === 'sent' ? 'var(--success)' : 'var(--danger)',
+                    flexShrink: 0, minWidth: 32,
+                  }}>
+                    {entry.status.toUpperCase()}
+                  </span>
+                  <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 11, color: 'var(--text-base)', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {entry.name}
+                  </span>
+                  <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--text-muted)', flexShrink: 0 }}>
+                    {entry.timestamp.slice(0, 10)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/inviteflow/pages/EventSetupPage.tsx
+++ b/src/inviteflow/pages/EventSetupPage.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+import type { AppEvent } from '../types';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import PageHeader from '../components/PageHeader';
+import Icon from '../components/Icon';
+import { getToken, setClientId } from '../api/auth';
+import { updateAppDataFile } from '../api/drive';
+
+const FIELDS: Array<{ key: keyof AppEvent; label: string; type?: string; placeholder?: string }> = [
+  { key: 'name',            label: 'Event Name',              placeholder: 'Annual Civic Leadership Reception' },
+  { key: 'date',            label: 'Event Date',              type: 'date' },
+  { key: 'venue',           label: 'Venue',                   placeholder: 'Veterans Memorial Hall' },
+  { key: 'orgName',         label: 'Organization Name',       placeholder: 'Civic Foundation' },
+  { key: 'contactName',     label: 'Contact Name',            placeholder: 'Lenya Chan' },
+  { key: 'contactEmail',    label: 'Contact Email',           type: 'email', placeholder: 'contact@org.com' },
+  { key: 'vipStart',        label: 'VIP Start Time',          placeholder: '5:30 PM' },
+  { key: 'vipEnd',          label: 'VIP End Time',            placeholder: '6:30 PM' },
+  { key: 'formUrl',         label: 'Google Form Base URL',    placeholder: 'https://docs.google.com/forms/…' },
+  { key: 'entryEmail',      label: 'Form Email Entry ID',     placeholder: 'entry.123456789' },
+  { key: 'rsvpResponseUrl', label: 'RSVP Response Sheet URL', placeholder: 'https://docs.google.com/spreadsheets/…' },
+  { key: 'masterSheetUrl',  label: 'Master Sheet URL',        placeholder: 'https://docs.google.com/spreadsheets/…' },
+  { key: 'imgEmblemUrl',    label: 'Emblem Image URL',        placeholder: 'https://drive.google.com/…' },
+];
+
+export default function EventSetupPage() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const ev = state.events.find(e => e.id === state.activeEventId) ?? null;
+
+  const [clientIdDraft, setClientIdDraft] = useState(ev?.googleClientId ?? localStorage.getItem('gClientId') ?? '');
+  const [draft, setDraft] = useState<AppEvent | null>(ev ? { ...ev } : null);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState('');
+
+  if (!ev || !draft) return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <PageHeader eyebrow="EVENT SETUP" title="No event" showBack />
+      <div className="if-empty">
+        No event selected.
+        <div className="if-empty-sub">GO BACK AND SELECT AN EVENT</div>
+      </div>
+    </div>
+  );
+
+  function setField(key: keyof AppEvent, value: string) {
+    setDraft(d => d ? { ...d, [key]: value } : d);
+  }
+
+  async function save() {
+    if (!draft) return;
+    setSaving(true); setStatus('');
+    try {
+      const token = await getToken('drive.appdata');
+      const saved = { ...draft, googleClientId: clientIdDraft };
+      await updateAppDataFile(token, draft.id, saved);
+      setClientId(clientIdDraft);
+      dispatch({ type: 'UPDATE_EVENT', event: saved });
+      setStatus('Saved.');
+    } catch (e) { setStatus('Error: ' + String(e)); }
+    finally { setSaving(false); }
+  }
+
+  async function authorize(scope: string) {
+    setStatus('');
+    try { await getToken(scope); setStatus(`${scope} authorized.`); }
+    catch (e) { setStatus('Auth error: ' + String(e)); }
+  }
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <div style={{ flexShrink: 0 }}>
+        <PageHeader eyebrow="EVENT SETUP" title={ev.name || 'Event Setup'} showBack />
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 100px' }}>
+
+        <div className="if-section-label" style={{ padding: '12px 0 8px' }}>GOOGLE OAUTH</div>
+        <div className="if-card" style={{ marginBottom: 12 }}>
+          <div style={{ padding: 'var(--rt-row-pad)', borderBottom: '1px solid var(--border)' }}>
+            <label className="if-label" style={{ display: 'block', marginBottom: 6 }}>GOOGLE CLIENT ID</label>
+            <input
+              className="if-input"
+              style={{ width: '100%' }}
+              value={clientIdDraft}
+              onChange={e => setClientIdDraft(e.target.value)}
+              placeholder="123456789-abc.apps.googleusercontent.com"
+            />
+          </div>
+          <div style={{ padding: 'var(--rt-row-pad)', display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button className="if-btn ghost sm" onClick={() => authorize('spreadsheets')}>Authorize Sheets</button>
+            <button className="if-btn ghost sm" onClick={() => authorize('gmail.send')}>Authorize Gmail</button>
+            <button className="if-btn ghost sm" onClick={() => authorize('drive.appdata')}>Authorize Drive</button>
+          </div>
+        </div>
+
+        <div className="if-section-label" style={{ padding: '8px 0 8px' }}>EVENT DETAILS</div>
+        <div className="if-card" style={{ padding: 14, marginBottom: 12 }}>
+          <div style={{ display: 'grid', gap: 12 }}>
+            {FIELDS.map(f => (
+              <div key={f.key}>
+                <label className="if-label" style={{ display: 'block', marginBottom: 5 }}>{f.label}</label>
+                <input
+                  className="if-input"
+                  style={{ width: '100%' }}
+                  type={f.type ?? 'text'}
+                  placeholder={f.placeholder}
+                  value={draft[f.key] as string}
+                  onChange={e => setField(f.key, e.target.value)}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {status && (
+          <div className={`if-status ${status.startsWith('Error') || status.startsWith('Auth') ? 'err' : 'ok'}`} style={{ marginBottom: 12 }}>
+            {status}
+          </div>
+        )}
+      </div>
+
+      <div style={{
+        flexShrink: 0, padding: '12px 18px',
+        borderTop: '1px solid var(--border)', background: 'var(--bg-root)',
+      }}>
+        <button className="if-btn pri" style={{ width: '100%' }} onClick={save} disabled={saving}>
+          <Icon name="check" size={13} style={{ marginRight: 6 }} />
+          {saving ? 'SAVING…' : 'SAVE EVENT'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/inviteflow/pages/EventsPage.tsx
+++ b/src/inviteflow/pages/EventsPage.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useState } from 'react';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import { useRouter } from '../state/RouterContext';
+import PageHeader from '../components/PageHeader';
+import Icon from '../components/Icon';
+import { getToken } from '../api/auth';
+import { listAppDataFiles, getAppDataFile, createAppDataFile, deleteAppDataFile } from '../api/drive';
+import type { AppEvent } from '../types';
+
+function blankEvent(id: string): AppEvent {
+  return {
+    id, name: 'New Event', date: '', venue: '', orgName: '',
+    contactName: '', contactEmail: '', formUrl: '', rsvpResponseUrl: '',
+    masterSheetUrl: '', entryEmail: '', imgEmblemUrl: '', vipStart: '', vipEnd: '',
+    googleClientId: localStorage.getItem('gClientId') ?? '',
+  };
+}
+
+function daysUntil(dateStr: string): number | null {
+  if (!dateStr) return null;
+  const diff = new Date(dateStr).getTime() - Date.now();
+  return Math.ceil(diff / (1000 * 60 * 60 * 24));
+}
+
+function formatDate(dateStr: string): string {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export default function EventsPage() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const { navigate } = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  async function loadEvents() {
+    setLoading(true); setErr('');
+    try {
+      const token = await getToken('drive.appdata');
+      const files = await listAppDataFiles(token);
+      const configs = await Promise.all(
+        files
+          .filter(f => f.name.endsWith('.json'))
+          .map(async f => {
+            const data = await getAppDataFile(token, f.id) as AppEvent;
+            return { ...data, id: f.id };
+          })
+      );
+      dispatch({ type: 'SET_EVENTS', events: configs });
+    } catch (e) { setErr(String(e)); }
+    finally { setLoading(false); }
+  }
+
+  useEffect(() => { loadEvents(); }, []);
+
+  async function createEvent() {
+    setErr('');
+    try {
+      const token = await getToken('drive.appdata');
+      const tempId = crypto.randomUUID();
+      const ev = blankEvent(tempId);
+      const realId = await createAppDataFile(token, tempId + '.json', ev);
+      ev.id = realId;
+      dispatch({ type: 'ADD_EVENT', event: ev });
+      dispatch({ type: 'SET_ACTIVE_EVENT', id: realId });
+      navigate('event-setup');
+    } catch (e) { setErr(String(e)); }
+  }
+
+  async function deleteEvent(id: string) {
+    setErr('');
+    try {
+      const token = await getToken('drive.appdata');
+      await deleteAppDataFile(token, id);
+      dispatch({ type: 'DELETE_EVENT', id });
+    } catch (e) { setErr(String(e)); }
+    finally { setConfirmDelete(null); }
+  }
+
+  function openEvent(id: string) {
+    dispatch({ type: 'SET_ACTIVE_EVENT', id });
+    navigate('event-home');
+  }
+
+  const upcoming = state.events.filter(e => !e.date || daysUntil(e.date) === null || daysUntil(e.date)! >= 0);
+  const past = state.events.filter(e => e.date && daysUntil(e.date) !== null && daysUntil(e.date)! < 0);
+
+  const headerRight = (
+    <button className="if-header-btn" onClick={loadEvents} disabled={loading} aria-label="Refresh">
+      <Icon name="sync" size={13} />
+    </button>
+  );
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <PageHeader eyebrow="INVITEFLOW" title="Events" right={headerRight} />
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 32px' }}>
+        {err && <div className="if-status err" style={{ marginBottom: 12 }}>{err}</div>}
+
+        {state.events.length === 0 && !loading && (
+          <div className="if-card" style={{ textAlign: 'center', padding: '48px 24px', marginTop: 8 }}>
+            <div style={{ fontFamily: 'var(--rf-serif)', fontSize: 16, color: 'var(--text-secondary)', marginBottom: 8, fontStyle: 'italic' }}>
+              No events yet
+            </div>
+            <div className="if-section-label" style={{ marginBottom: 16 }}>
+              CREATE YOUR FIRST EVENT TO GET STARTED
+            </div>
+            <button className="if-btn pri" onClick={createEvent}>+ New Event</button>
+          </div>
+        )}
+
+        {[{ label: 'UPCOMING', list: upcoming }, { label: 'PAST', list: past }].map(({ label, list }) =>
+          list.length === 0 ? null : (
+            <div key={label}>
+              <div className="if-section-label" style={{ padding: '16px 0 8px' }}>
+                {label} · {list.length}
+              </div>
+              <div className="if-card">
+                {list.map((ev, i) => {
+                  const days = daysUntil(ev.date);
+                  const isActive = state.activeEventId === ev.id;
+                  const isLast = i === list.length - 1;
+                  const isConfirming = confirmDelete === ev.id;
+
+                  return (
+                    <div
+                      key={ev.id}
+                      style={{
+                        display: 'flex', alignItems: 'center', gap: 10,
+                        padding: 'var(--rt-row-pad)',
+                        borderBottom: isLast ? 'none' : '1px solid var(--border)',
+                        cursor: 'default',
+                      }}
+                      onClick={e => {
+                        if ((e.target as HTMLElement).closest('button, a')) return;
+                        openEvent(ev.id);
+                      }}
+                    >
+                      <div style={{
+                        width: 28, height: 28, borderRadius: 6, flexShrink: 0,
+                        border: `1px solid ${isActive ? 'var(--accent)' : 'var(--border)'}`,
+                        background: isActive ? 'var(--accent)' : 'transparent',
+                        color: isActive ? 'var(--bg-root)' : 'var(--text-muted)',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        fontFamily: 'var(--rf-mono)', fontSize: 9, letterSpacing: '0.06em',
+                      }}>
+                        {isActive ? <Icon name="check" size={11} /> : String(i + 1).padStart(2, '0')}
+                      </div>
+
+                      <div style={{ flex: 1, minWidth: 0, cursor: 'pointer' }} onClick={() => openEvent(ev.id)}>
+                        <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 12, color: 'var(--text-heading)', fontWeight: 500 }}>
+                          {ev.name || 'Unnamed Event'}
+                        </div>
+                        <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--text-muted)', letterSpacing: '0.08em', marginTop: 2 }}>
+                          {formatDate(ev.date) || 'No date set'}
+                          {ev.venue ? ` · ${ev.venue}` : ''}
+                          {days !== null && (
+                            <span style={{ marginLeft: 8, color: days <= 7 ? 'var(--warning)' : 'var(--text-secondary)' }}>
+                              {days === 0 ? 'TODAY' : days > 0 ? `${days}d away` : `${Math.abs(days)}d ago`}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0 }} onClick={e => e.stopPropagation()}>
+                        {isConfirming ? (
+                          <>
+                            <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--danger)' }}>DELETE?</span>
+                            <button className="if-btn del sm" onClick={() => deleteEvent(ev.id)}>Yes</button>
+                            <button className="if-btn sm" onClick={() => setConfirmDelete(null)}>No</button>
+                          </>
+                        ) : (
+                          <>
+                            {!isActive && (
+                              <button className="if-btn sm" onClick={() => openEvent(ev.id)}>Open</button>
+                            )}
+                            <button className="if-btn del sm" onClick={() => setConfirmDelete(ev.id)}>
+                              <Icon name="x" size={11} />
+                            </button>
+                          </>
+                        )}
+                      </div>
+
+                      <Icon name="chevron-right" size={13} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )
+        )}
+
+        {state.events.length > 0 && (
+          <button
+            className="if-btn ghost"
+            style={{ width: '100%', marginTop: 8, minHeight: 42, justifyContent: 'center', borderRadius: 'var(--rt-card-radius)' }}
+            onClick={createEvent}
+          >
+            <Icon name="plus" size={13} style={{ marginRight: 6 }} />
+            New event
+          </button>
+        )}
+      </div>
+
+      {state.events.length === 0 && (
+        <div style={{ padding: '0 18px 32px' }}>
+          <button className="if-btn pri" style={{ width: '100%', minHeight: 46 }} onClick={createEvent}>
+            <Icon name="plus" size={13} style={{ marginRight: 6 }} />
+            NEW EVENT
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/inviteflow/pages/InviteesPage.tsx
+++ b/src/inviteflow/pages/InviteesPage.tsx
@@ -1,0 +1,283 @@
+import { useRef, useState } from 'react';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import { useRouter } from '../state/RouterContext';
+import PageHeader from '../components/PageHeader';
+import Icon from '../components/Icon';
+import { getToken } from '../api/auth';
+import { sheetsGet, extractSheetId } from '../api/sheets';
+import type { Invitee } from '../types';
+
+function makeInvitee(partial: Partial<Invitee> = {}): Invitee {
+  return {
+    id: crypto.randomUUID(), firstName: '', lastName: '', title: '',
+    category: '', email: '', rsvpLink: '', inviteStatus: 'pending',
+    sentAt: '', rsvpStatus: 'No Response', rsvpDate: '', notes: '',
+    ...partial,
+  };
+}
+
+const INVITE_COLOR: Record<string, string> = {
+  pending: 'var(--text-muted)', sent: 'var(--success)', failed: 'var(--danger)',
+};
+const RSVP_COLOR: Record<string, string> = {
+  'No Response': 'var(--text-muted)', Attending: 'var(--success)', Declined: 'var(--danger)',
+};
+
+export default function InviteesPage() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const { navigate } = useRouter();
+  const [selected, setSelected] = useState<Invitee[]>([]);
+  const [showAdd, setShowAdd] = useState(false);
+  const [draft, setDraft] = useState<Partial<Invitee>>({});
+  const [sheetsUrl, setSheetsUrl] = useState('');
+  const [importing, setImporting] = useState(false);
+  const [importStatus, setImportStatus] = useState('');
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const ev = state.events.find(e => e.id === state.activeEventId);
+
+  async function importFromSheets() {
+    if (!sheetsUrl.trim()) return;
+    setImporting(true); setImportStatus('');
+    try {
+      const token = await getToken('spreadsheets');
+      const id = extractSheetId(sheetsUrl);
+      const rows = await sheetsGet(token, id, 'Sheet1!A:K');
+      if (rows.length < 2) { setImportStatus('Sheet appears empty.'); return; }
+      const [header, ...data] = rows;
+      const col = (name: string) => header.findIndex(h => h.trim().toLowerCase() === name.toLowerCase());
+      const ci = {
+        fn: col('FirstName'), ln: col('LastName'), title: col('Title'), cat: col('Category'),
+        email: col('Email'), rsvp: col('RSVP_Link'), sent: col('InviteSent'),
+        sentDate: col('InviteSentDate'), rsvpStatus: col('RSVP_Status'),
+        rsvpDate: col('RSVP_Date'), notes: col('Notes'),
+      };
+      const incoming = data.map(r => makeInvitee({
+        firstName: r[ci.fn] ?? '', lastName: r[ci.ln] ?? '', title: r[ci.title] ?? '',
+        category: r[ci.cat] ?? '', email: r[ci.email] ?? '', rsvpLink: r[ci.rsvp] ?? '',
+        inviteStatus: r[ci.sent]?.toLowerCase() === 'true' ? 'sent' : 'pending',
+        sentAt: r[ci.sentDate] ?? '',
+        rsvpStatus: (['Attending', 'Declined'].includes(r[ci.rsvpStatus]) ? r[ci.rsvpStatus] : 'No Response') as Invitee['rsvpStatus'],
+        rsvpDate: r[ci.rsvpDate] ?? '', notes: r[ci.notes] ?? '',
+      })).filter(i => i.email);
+      const merged = [...state.invitees];
+      for (const inc of incoming) {
+        const idx = merged.findIndex(m => m.email.toLowerCase() === inc.email.toLowerCase());
+        if (idx >= 0) merged[idx] = { ...merged[idx], ...inc, id: merged[idx].id };
+        else merged.push(inc);
+      }
+      dispatch({ type: 'SET_INVITEES', invitees: merged });
+      setImportStatus(`Imported ${incoming.length} rows (${merged.length - state.invitees.length} new).`);
+    } catch (e) { setImportStatus('Error: ' + String(e)); }
+    finally { setImporting(false); }
+  }
+
+  function importJSON(file: File) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const raw = JSON.parse(reader.result as string) as Array<Record<string, string>>;
+        const parsed = raw.map(r => {
+          const full = r.name ?? `${r.firstName ?? ''} ${r.lastName ?? ''}`.trim();
+          const parts = full.split(' ');
+          return makeInvitee({
+            firstName: r.firstName ?? parts[0] ?? '', lastName: r.lastName ?? parts.slice(1).join(' ') ?? '',
+            title: r.title ?? '', category: r.category ?? '', email: r.email ?? '',
+          });
+        }).filter(i => i.email);
+        const merged = [...state.invitees];
+        for (const inc of parsed) {
+          if (!merged.find(m => m.email.toLowerCase() === inc.email.toLowerCase())) merged.push(inc);
+        }
+        dispatch({ type: 'SET_INVITEES', invitees: merged });
+        setImportStatus(`JSON import: ${parsed.length} rows.`);
+      } catch (e) { setImportStatus('JSON parse error: ' + String(e)); }
+    };
+    reader.readAsText(file);
+  }
+
+  function exportCSV() {
+    const header = 'FirstName,LastName,Title,Category,Email,RSVP_Link,InviteSent,InviteSentDate,RSVP_Status,RSVP_Date,Notes';
+    const rows = state.invitees.map(i =>
+      [i.firstName, i.lastName, i.title, i.category, i.email, i.rsvpLink,
+       i.inviteStatus === 'sent' ? 'TRUE' : 'FALSE', i.sentAt, i.rsvpStatus, i.rsvpDate, i.notes]
+        .map(v => `"${String(v).replace(/"/g, '""')}"`)
+        .join(',')
+    );
+    const blob = new Blob([[header, ...rows].join('\n')], { type: 'text/csv' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `invitees-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  }
+
+  function generateAllRsvpLinks() {
+    const updated = state.invitees.map(i => ({
+      ...i,
+      rsvpLink: i.rsvpLink || (ev?.formUrl && ev?.entryEmail
+        ? `${ev.formUrl}?${ev.entryEmail}=${encodeURIComponent(i.email)}`
+        : ''),
+    }));
+    dispatch({ type: 'SET_INVITEES', invitees: updated });
+  }
+
+  function bulkMarkSent() {
+    const ids = new Set(selected.map(s => s.id));
+    const updated = state.invitees.map(i =>
+      ids.has(i.id) ? { ...i, inviteStatus: 'sent' as const, sentAt: new Date().toISOString() } : i
+    );
+    dispatch({ type: 'SET_INVITEES', invitees: updated });
+    setSelected([]);
+  }
+
+  function bulkReset() {
+    const ids = new Set(selected.map(s => s.id));
+    const updated = state.invitees.map(i =>
+      ids.has(i.id) ? { ...i, inviteStatus: 'pending' as const, sentAt: '' } : i
+    );
+    dispatch({ type: 'SET_INVITEES', invitees: updated });
+    setSelected([]);
+  }
+
+  function bulkDelete() {
+    if (!confirm(`Delete ${selected.length} invitee(s)?`)) return;
+    dispatch({ type: 'DELETE_INVITEES', ids: selected.map(s => s.id) });
+    setSelected([]);
+  }
+
+  function addManually() {
+    if (!draft.email) return;
+    dispatch({ type: 'ADD_INVITEE', invitee: makeInvitee(draft) });
+    setDraft({});
+    setShowAdd(false);
+  }
+
+  const toolbarRight = (
+    <div style={{ display: 'flex', gap: 6 }}>
+      <button className="if-header-btn" onClick={() => setShowAdd(true)} aria-label="Add invitee">
+        <Icon name="plus" size={13} />
+      </button>
+    </div>
+  );
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <PageHeader eyebrow="INVITEES" title={`Roster · ${state.invitees.length}`} showBack right={toolbarRight} />
+
+      {/* Toolbar row */}
+      <div style={{ padding: '0 18px 10px', display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', flexShrink: 0 }}>
+        <input
+          className="if-input"
+          style={{ flex: 1, minWidth: 200 }}
+          placeholder="Paste Google Sheets URL to import…"
+          value={sheetsUrl}
+          onChange={e => setSheetsUrl(e.target.value)}
+        />
+        <button className="if-btn ghost sm" onClick={importFromSheets} disabled={importing}>
+          {importing ? 'Importing…' : 'Import Sheets'}
+        </button>
+        <button className="if-btn sm" onClick={exportCSV}>Export CSV</button>
+        <button className="if-btn sm" onClick={generateAllRsvpLinks}>Gen RSVP Links</button>
+        <input ref={fileRef} type="file" accept=".json" style={{ display: 'none' }}
+          onChange={e => e.target.files?.[0] && importJSON(e.target.files[0])} />
+        <button className="if-btn sm" onClick={() => fileRef.current?.click()}>Import JSON</button>
+      </div>
+
+      {importStatus && (
+        <div className={`if-status ${importStatus.startsWith('Error') ? 'err' : 'ok'}`} style={{ margin: '0 18px 8px' }}>
+          {importStatus}
+        </div>
+      )}
+
+      {selected.length > 0 && (
+        <div className="if-bulk-bar" style={{ margin: '0 18px 8px', flexShrink: 0 }}>
+          <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 10, color: 'var(--accent)', letterSpacing: '0.08em' }}>
+            {selected.length} SELECTED
+          </span>
+          <button className="if-btn grn sm" onClick={bulkMarkSent}>Mark Sent</button>
+          <button className="if-btn sm" onClick={bulkReset}>Reset</button>
+          <button className="if-btn pri sm" onClick={() => navigate('send')}>Send Selected →</button>
+          <button className="if-btn del sm" onClick={bulkDelete}>Delete</button>
+        </div>
+      )}
+
+      <div style={{ flex: 1, overflow: 'hidden', margin: '0 18px 18px', borderRadius: 'var(--rt-card-radius)', border: '1px solid var(--border)' }}>
+        <DataTable
+          value={state.invitees}
+          selection={selected}
+          onSelectionChange={e => setSelected(e.value as Invitee[])}
+          selectionMode="multiple"
+          dataKey="id"
+          scrollable
+          scrollHeight="flex"
+          virtualScrollerOptions={{ itemSize: 36 }}
+          size="small"
+          filterDisplay="row"
+          emptyMessage="No invitees yet. Add one above or import from Sheets."
+          style={{ fontSize: 11 }}
+          onRowEditComplete={e => dispatch({ type: 'UPDATE_INVITEE', invitee: e.newData as Invitee })}
+          editMode="row"
+        >
+          <Column selectionMode="multiple" style={{ width: 40 }} />
+          <Column field="firstName" header="First"    sortable filter filterPlaceholder="Search" style={{ minWidth: 90 }} />
+          <Column field="lastName"  header="Last"     sortable filter filterPlaceholder="Search" style={{ minWidth: 90 }} />
+          <Column field="title"     header="Title"    sortable style={{ minWidth: 120 }} />
+          <Column field="category"  header="Category" sortable filter filterPlaceholder="Filter" style={{ minWidth: 100 }} />
+          <Column field="email"     header="Email"    sortable style={{ minWidth: 160 }} />
+          <Column
+            field="inviteStatus" header="Status" sortable filter filterPlaceholder="Filter" style={{ minWidth: 90 }}
+            body={(r: Invitee) => (
+              <span style={{ color: INVITE_COLOR[r.inviteStatus] ?? 'var(--text-muted)', fontSize: 9, letterSpacing: '0.07em', fontFamily: 'var(--rf-mono)' }}>
+                {r.inviteStatus.toUpperCase()}
+              </span>
+            )}
+          />
+          <Column
+            field="sentAt" header="Sent At" sortable style={{ minWidth: 110 }}
+            body={(r: Invitee) => r.sentAt ? new Date(r.sentAt).toLocaleDateString() : '—'}
+          />
+          <Column
+            field="rsvpStatus" header="RSVP" sortable filter filterPlaceholder="Filter" style={{ minWidth: 110 }}
+            body={(r: Invitee) => (
+              <span style={{ color: RSVP_COLOR[r.rsvpStatus] ?? 'var(--text-muted)', fontSize: 9, fontFamily: 'var(--rf-mono)' }}>
+                {r.rsvpStatus}
+              </span>
+            )}
+          />
+          <Column
+            field="notes" header="Notes" style={{ minWidth: 140 }}
+            editor={(opts) => (
+              <input className="if-input" style={{ fontSize: 11, minHeight: 28, padding: '4px 8px' }}
+                value={opts.value} onChange={e => opts.editorCallback?.(e.target.value)} />
+            )}
+          />
+          <Column rowEditor style={{ width: 70 }} />
+        </DataTable>
+      </div>
+
+      {showAdd && (
+        <div className="if-modal-backdrop">
+          <div className="if-modal">
+            <div className="if-modal-title">Add Invitee</div>
+            <div className="if-modal-sub">Email is required.</div>
+            {(['firstName', 'lastName', 'title', 'category', 'email'] as const).map(k => (
+              <div key={k} style={{ marginBottom: 10 }}>
+                <label className="if-label">{k}</label>
+                <input className="if-input" value={String(draft[k] ?? '')}
+                  onChange={e => setDraft(d => ({ ...d, [k]: e.target.value }))} />
+              </div>
+            ))}
+            <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+              <button className="if-btn grn" onClick={addManually} disabled={!draft.email}>Add</button>
+              <button className="if-btn" onClick={() => { setShowAdd(false); setDraft({}); }}>Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/inviteflow/pages/SendPage.tsx
+++ b/src/inviteflow/pages/SendPage.tsx
@@ -1,0 +1,243 @@
+import { useState } from 'react';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import PageHeader from '../components/PageHeader';
+import Icon from '../components/Icon';
+import { getToken } from '../api/auth';
+import { buildMimeRaw, personalize, sendEmail } from '../api/gmail';
+
+type Filter = 'all' | 'pending' | 'failed';
+
+const BATCH_SIZE = 80;
+const BATCH_DELAY_MS = 61000;
+
+export default function SendPage() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const [filter, setFilter] = useState<Filter>('pending');
+  const [activePane, setActivePane] = useState<'preflight' | 'log'>('preflight');
+  const [err, setErr] = useState('');
+
+  const ev = state.events.find(e => e.id === state.activeEventId);
+
+  const filtered = state.invitees.filter(i =>
+    filter === 'all' ? true : filter === 'pending' ? i.inviteStatus === 'pending' : i.inviteStatus === 'failed'
+  );
+  const pendingCount = state.invitees.filter(i => i.inviteStatus === 'pending').length;
+  const sentCount    = state.invitees.filter(i => i.inviteStatus === 'sent').length;
+  const failedCount  = state.invitees.filter(i => i.inviteStatus === 'failed').length;
+
+  const templateSaved = !!state.htmlBody.trim();
+  const hasMissingEmail = state.invitees.some(i => !i.email);
+  const allChecks = ev && templateSaved && !hasMissingEmail;
+
+  const progress = state.sendProgress.total > 0
+    ? Math.round((state.sendProgress.current / state.sendProgress.total) * 100)
+    : 0;
+
+  async function sendBulk() {
+    if (!ev) { setErr('No active event — go to Event Setup.'); return; }
+    if (!state.htmlBody.trim()) { setErr('No email body — go to Compose.'); return; }
+    if (filtered.length === 0) { setErr('No invitees match the current filter.'); return; }
+    setErr('');
+
+    dispatch({ type: 'START_SEND', total: filtered.length });
+
+    let token: string;
+    try { token = await getToken('gmail.send'); }
+    catch (e) { setErr(String(e)); dispatch({ type: 'STOP_SEND' }); return; }
+
+    const from = ev.contactEmail || 'me';
+    let sent = 0;
+
+    for (let i = 0; i < filtered.length; i++) {
+      const inv = filtered[i];
+      const html = personalize(state.htmlBody, inv, ev);
+      const subject = personalize(state.textSubject, inv, ev);
+      const raw = buildMimeRaw(from, inv.email, subject, html);
+      try {
+        await sendEmail(token, raw);
+        dispatch({ type: 'UPDATE_INVITEE', invitee: { ...inv, inviteStatus: 'sent', sentAt: new Date().toISOString() } });
+        dispatch({ type: 'LOG_SEND', entry: { id: crypto.randomUUID(), email: inv.email, name: `${inv.firstName} ${inv.lastName}`, status: 'sent', timestamp: new Date().toISOString() } });
+      } catch (e) {
+        dispatch({ type: 'UPDATE_INVITEE', invitee: { ...inv, inviteStatus: 'failed' } });
+        dispatch({ type: 'LOG_SEND', entry: { id: crypto.randomUUID(), email: inv.email, name: `${inv.firstName} ${inv.lastName}`, status: 'failed', timestamp: new Date().toISOString(), error: String(e) } });
+      }
+      sent++;
+      dispatch({ type: 'SEND_PROGRESS', current: sent });
+      if (sent % BATCH_SIZE === 0 && i < filtered.length - 1) {
+        await new Promise(r => setTimeout(r, BATCH_DELAY_MS));
+      }
+    }
+
+    dispatch({ type: 'STOP_SEND' });
+  }
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <PageHeader eyebrow="SEND" title="Bulk send" showBack />
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 100px' }}>
+
+        {/* Pane switcher */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+          <div className="if-meta-line">
+            {ev ? (
+              <>
+                <span style={{ width: 6, height: 6, borderRadius: '50%', background: allChecks ? 'var(--success)' : 'var(--warning)', display: 'inline-block', marginRight: 8 }} />
+                <span>{ev.contactEmail ? `GMAIL · ${ev.contactEmail.split('@')[0].toUpperCase()}@…` : 'SENDER NOT CONFIGURED'}</span>
+                <span className="if-meta-sep">·</span>
+                <span style={{ color: 'var(--accent)' }}>{filtered.length} {filter.toUpperCase()}</span>
+              </>
+            ) : <span style={{ color: 'var(--warning)' }}>NO ACTIVE EVENT</span>}
+          </div>
+          <div className="if-tab-switcher" style={{ width: 180, flexShrink: 0 }}>
+            <button className={`if-tab-option${activePane === 'preflight' ? ' active' : ''}`} onClick={() => setActivePane('preflight')}>Pre-flight</button>
+            <button className={`if-tab-option${activePane === 'log' ? ' active' : ''}`} onClick={() => setActivePane('log')}>Log</button>
+          </div>
+        </div>
+
+        {err && <div className="if-status err" style={{ marginBottom: 12 }}>{err}</div>}
+
+        {/* ── Pre-flight pane ────────────────────────── */}
+        {activePane === 'preflight' && (
+          <>
+            <div className="if-section-label" style={{ marginBottom: 8 }}>PRE-FLIGHT CHECKS</div>
+            <div className="if-card" style={{ marginBottom: 16 }}>
+              {[
+                {
+                  ok: !!ev?.contactEmail,
+                  title: 'Sender configured',
+                  sub: ev?.contactEmail ? ev.contactEmail.toUpperCase() : 'CONTACT EMAIL NOT SET IN EVENT SETUP',
+                },
+                {
+                  ok: templateSaved,
+                  title: 'Template saved',
+                  sub: templateSaved
+                    ? `${(state.htmlBody.match(/\{\{\w+\}\}/g) || []).length} MERGE TOKENS DETECTED`
+                    : 'NO BODY — GO TO COMPOSE',
+                },
+                {
+                  ok: !hasMissingEmail,
+                  title: 'Recipients validated',
+                  sub: `${state.invitees.length} TOTAL · ${hasMissingEmail ? `${state.invitees.filter(i => !i.email).length} MISSING EMAIL` : 'ALL HAVE EMAIL'}`,
+                },
+              ].map((check, i) => (
+                <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: 'var(--rt-row-pad)', borderBottom: '1px solid var(--border)' }}>
+                  <div style={{
+                    width: 28, height: 28, borderRadius: 6, flexShrink: 0,
+                    background: check.ok ? 'rgba(98,196,98,0.15)' : 'rgba(229,113,88,0.12)',
+                    border: `1px solid ${check.ok ? 'var(--success)' : 'var(--danger)'}`,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    color: check.ok ? 'var(--success)' : 'var(--danger)',
+                    fontFamily: 'var(--rf-mono)', fontSize: 10,
+                  }}>
+                    {check.ok ? <Icon name="check" size={11} /> : '!'}
+                  </div>
+                  <div>
+                    <div className="if-card-row-title">{check.title}</div>
+                    <div className="if-card-row-sub">{check.sub}</div>
+                  </div>
+                </div>
+              ))}
+
+              {/* Filter */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: 'var(--rt-row-pad)' }}>
+                <div style={{ width: 28, height: 28, borderRadius: 6, flexShrink: 0, background: 'var(--bg-root)', border: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-muted)' }}>
+                  <Icon name="filter" size={12} />
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div className="if-card-row-title">Active filter</div>
+                  <div className="if-card-row-sub">{filter.toUpperCase()} · {filtered.length} WILL RECEIVE</div>
+                </div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  {(['pending', 'failed', 'all'] as Filter[]).map(f => (
+                    <button key={f} className={`if-filter-chip${filter === f ? ' active' : ''}`} onClick={() => setFilter(f)}>
+                      {f}
+                      <span className="count"> {f === 'all' ? state.invitees.length : f === 'pending' ? pendingCount : failedCount}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Stat strip */}
+            <div className="if-section-label" style={{ marginBottom: 8 }}>THIS EVENT</div>
+            <div style={{ display: 'flex', gap: 10, marginBottom: 20 }}>
+              {[
+                { label: 'Pending', value: pendingCount, color: 'var(--text-secondary)' },
+                { label: 'Sent',    value: sentCount,    color: 'var(--success)' },
+                { label: 'Failed',  value: failedCount,  color: 'var(--danger)' },
+                { label: 'Ready',   value: filtered.length, color: 'var(--accent)' },
+              ].map(s => (
+                <div key={s.label} className="if-stat-chip">
+                  <div className="if-stat-chip-label">{s.label}</div>
+                  <div className="if-stat-chip-value" style={{ color: s.color }}>{s.value}</div>
+                </div>
+              ))}
+            </div>
+
+            {/* Progress */}
+            {state.sending && (
+              <div style={{ marginBottom: 20 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--text-muted)', marginBottom: 6, letterSpacing: '0.08em' }}>
+                  <span>SENDING IN PROGRESS</span>
+                  <span>{state.sendProgress.current} / {state.sendProgress.total} ({progress}%)</span>
+                </div>
+                <div className="if-progress-track">
+                  <div className="if-progress-fill" style={{ width: `${progress}%` }} />
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* ── Log pane ────────────────────────────────── */}
+        {activePane === 'log' && (
+          <>
+            <div className="if-section-label" style={{ marginBottom: 8 }}>DELIVERY LOG</div>
+            {state.sendLog.length === 0 ? (
+              <div className="if-card">
+                <div className="if-empty" style={{ padding: '32px 18px' }}>
+                  No sends yet
+                  <div className="if-empty-sub" style={{ marginTop: 6, marginBottom: 0 }}>RUN A SEND TO SEE DELIVERY LOG</div>
+                </div>
+              </div>
+            ) : (
+              <div className="if-card" style={{ overflow: 'hidden' }}>
+                {state.sendLog.map((entry, i) => (
+                  <div key={entry.id} style={{
+                    display: 'flex', gap: 10, alignItems: 'baseline',
+                    padding: 'var(--rt-row-pad)',
+                    borderBottom: i < state.sendLog.length - 1 ? '1px solid var(--border)' : 'none',
+                    fontFamily: 'var(--rf-mono)', fontSize: 11,
+                  }}>
+                    <span style={{ minWidth: 40, fontSize: 9, letterSpacing: '0.07em', color: entry.status === 'sent' ? 'var(--success)' : 'var(--danger)' }}>
+                      {entry.status.toUpperCase()}
+                    </span>
+                    <span style={{ color: 'var(--text-base)', minWidth: 160 }}>{entry.name}</span>
+                    <span style={{ color: 'var(--text-muted)', flex: 1, fontSize: 10 }}>{entry.email}</span>
+                    {entry.error && <span style={{ fontSize: 9, color: 'var(--danger)' }}>{entry.error}</span>}
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Sticky CTA */}
+      <div style={{ flexShrink: 0, padding: '12px 18px', borderTop: '1px solid var(--border)', background: 'var(--bg-root)' }}>
+        <button
+          className="if-primary-btn"
+          onClick={sendBulk}
+          disabled={state.sending || filtered.length === 0}
+          style={{ width: '100%' }}
+        >
+          {state.sending
+            ? `SENDING… ${state.sendProgress.current}/${state.sendProgress.total}`
+            : `SEND ${filtered.length} INVITATION${filtered.length !== 1 ? 'S' : ''} →`}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/inviteflow/pages/SettingsPage.tsx
+++ b/src/inviteflow/pages/SettingsPage.tsx
@@ -1,0 +1,142 @@
+import { useRef, useState } from 'react';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import PageHeader from '../components/PageHeader';
+import Icon from '../components/Icon';
+import { getToken, setClientId } from '../api/auth';
+
+export default function SettingsPage() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const [clientIdDraft, setClientIdDraft] = useState(localStorage.getItem('gClientId') ?? '');
+  const [status, setStatus] = useState('');
+
+  async function authorize(scope: string) {
+    setStatus('');
+    try { await getToken(scope); setStatus(`${scope} authorized.`); }
+    catch (e) { setStatus('Error: ' + String(e)); }
+  }
+
+  function saveClientId() {
+    setClientId(clientIdDraft);
+    setStatus('Client ID saved.');
+  }
+
+  function exportData() {
+    const { sendLog: _sl, sending: _s, sendProgress: _sp, ...rest } = state;
+    const blob = new Blob([JSON.stringify({ exportedAt: new Date().toISOString(), ...rest }, null, 2)], { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `inviteflow-backup-${new Date().toISOString().slice(0, 10)}.json`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  }
+
+  function importBackup(file: File) {
+    const reader = new FileReader();
+    reader.onload = e => {
+      try {
+        const parsed = JSON.parse(e.target?.result as string);
+        if (parsed.events) {
+          dispatch({ type: 'LOAD_STATE', partial: parsed });
+          setStatus('Backup imported.');
+        } else {
+          setStatus('Error: Invalid backup file (no events field).');
+        }
+      } catch { setStatus('Error: Invalid JSON.'); }
+    };
+    reader.readAsText(file);
+  }
+
+  const authRow = (icon: string, title: string, sub: string, scope: string, isLast = false) => (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 10, padding: 'var(--rt-row-pad)',
+      borderBottom: isLast ? 'none' : '1px solid var(--border)',
+    }}>
+      <div style={{ width: 28, height: 28, borderRadius: 6, background: 'var(--bg-root)', border: '1px solid var(--border)', color: 'var(--text-secondary)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+        <Icon name={icon} size={13} />
+      </div>
+      <div style={{ flex: 1 }}>
+        <div className="if-card-row-title">{title}</div>
+        <div className="if-card-row-sub">{sub}</div>
+      </div>
+      <button className="if-btn ghost sm" onClick={() => authorize(scope)}>Authorize</button>
+    </div>
+  );
+
+  const actionRow = (icon: string, title: string, sub: string, onClick: () => void, isLast = false) => (
+    <button
+      onClick={onClick}
+      style={{
+        width: '100%', display: 'flex', alignItems: 'center', gap: 10,
+        padding: 'var(--rt-row-pad)', background: 'transparent', border: 'none',
+        borderBottom: isLast ? 'none' : '1px solid var(--border)', textAlign: 'left', cursor: 'pointer',
+      }}
+    >
+      <div style={{ width: 28, height: 28, borderRadius: 6, background: 'var(--bg-root)', border: '1px solid var(--border)', color: 'var(--text-secondary)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+        <Icon name={icon} size={13} />
+      </div>
+      <div style={{ flex: 1 }}>
+        <div className="if-card-row-title">{title}</div>
+        <div className="if-card-row-sub">{sub}</div>
+      </div>
+      <Icon name="chevron-right" size={13} style={{ color: 'var(--text-muted)' }} />
+    </button>
+  );
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <PageHeader eyebrow="SETTINGS" title="Account & defaults" showBack right={null} />
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 32px' }}>
+
+        {status && (
+          <div className={`if-status ${status.startsWith('Error') ? 'err' : 'ok'}`} style={{ margin: '8px 0' }}>
+            {status}
+          </div>
+        )}
+
+        <div className="if-section-label" style={{ padding: '12px 0 8px' }}>GOOGLE OAUTH</div>
+        <div className="if-card" style={{ marginBottom: 12 }}>
+          {authRow('mail',     'Gmail · Send',              'AUTHORIZE GMAIL SENDING',        'gmail.send')}
+          {authRow('building', 'Google Sheets',             'AUTHORIZE SPREADSHEET ACCESS',   'spreadsheets')}
+          {authRow('user',     'Google Drive AppData',      'AUTHORIZE EVENT STORAGE',        'drive.appdata', true)}
+        </div>
+
+        <div className="if-section-label" style={{ padding: '8px 0 8px' }}>CLIENT ID</div>
+        <div className="if-card" style={{ padding: 14, marginBottom: 12 }}>
+          <label className="if-label" style={{ display: 'block', marginBottom: 6 }}>GOOGLE CLIENT ID</label>
+          <input
+            className="if-input"
+            style={{ width: '100%', marginBottom: 8 }}
+            value={clientIdDraft}
+            onChange={e => setClientIdDraft(e.target.value)}
+            placeholder="123456789-abc.apps.googleusercontent.com"
+          />
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--text-muted)', letterSpacing: '0.06em' }}>
+              REQUIRED FOR ALL GOOGLE API CALLS
+            </span>
+            <button className="if-btn grn sm" onClick={saveClientId}>Save</button>
+          </div>
+        </div>
+
+        <div className="if-section-label" style={{ padding: '8px 0 8px' }}>DATA</div>
+        <div className="if-card" style={{ marginBottom: 12 }}>
+          {actionRow('download', 'Export all data',  'DOWNLOAD FULL BACKUP AS JSON',  exportData)}
+          {actionRow('upload',   'Import backup',    'RESTORE FROM JSON FILE',        () => fileRef.current?.click(), true)}
+          <input ref={fileRef} type="file" accept=".json" style={{ display: 'none' }}
+            onChange={e => { const f = e.target.files?.[0]; if (f) importBackup(f); e.target.value = ''; }} />
+        </div>
+
+        <div className="if-section-label" style={{ padding: '8px 0 8px' }}>ABOUT</div>
+        <div className="if-card" style={{ padding: 14, textAlign: 'center' }}>
+          <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--text-muted)', letterSpacing: '0.06em' }}>
+            INVITEFLOW · v3.2 · by Lenya Chan
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/inviteflow/pages/SyncPage.tsx
+++ b/src/inviteflow/pages/SyncPage.tsx
@@ -1,0 +1,201 @@
+import { useState } from 'react';
+import type { Invitee } from '../types';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import PageHeader from '../components/PageHeader';
+import Icon from '../components/Icon';
+import { getToken } from '../api/auth';
+import { sheetsGet, sheetsUpdate, sheetsClear, extractSheetId } from '../api/sheets';
+
+const MASTER_COLUMNS = ['FirstName', 'LastName', 'Title', 'Category', 'Email', 'RSVP_Link', 'InviteSent', 'InviteSentDate', 'RSVP_Status', 'RSVP_Date', 'Notes'];
+
+const GAS_CODE = `// InviteFlow v4 — RSVP ingest trigger
+// Deploy: Extensions → Apps Script → add trigger: onFormSubmit (Form Submit)
+// Set script property MASTER_SHEET_URL via Project Settings → Script Properties
+
+function onFormSubmit(e) {
+  const props = PropertiesService.getScriptProperties();
+  const sheetUrl = props.getProperty('MASTER_SHEET_URL');
+  if (!sheetUrl) return;
+
+  const ss = SpreadsheetApp.openByUrl(sheetUrl);
+  const sheet = ss.getSheets()[0];
+  const responses = e.response.getItemResponses();
+
+  let email = '';
+  let attending = '';
+  for (const r of responses) {
+    const title = r.getItem().getTitle().toLowerCase();
+    if (title.includes('email')) email = r.getResponse().trim();
+    if (title.includes('attend') || title.includes('rsvp')) attending = r.getResponse().trim();
+  }
+  if (!email) return;
+
+  const data = sheet.getDataRange().getValues();
+  const header = data[0];
+  const emailCol = header.indexOf('Email');
+  const statusCol = header.indexOf('RSVP_Status');
+  const dateCol = header.indexOf('RSVP_Date');
+  if (emailCol < 0) return;
+
+  const today = new Date().toISOString().slice(0, 10);
+  for (let i = 1; i < data.length; i++) {
+    if (String(data[i][emailCol]).toLowerCase() === email.toLowerCase()) {
+      if (statusCol >= 0) sheet.getRange(i + 1, statusCol + 1).setValue(attending || 'Attending');
+      if (dateCol >= 0) sheet.getRange(i + 1, dateCol + 1).setValue(today);
+      break;
+    }
+  }
+}`;
+
+const CHIP: React.CSSProperties = {
+  width: 28, height: 28, borderRadius: 6, flexShrink: 0,
+  background: 'var(--bg-root)', border: '1px solid var(--border)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  color: 'var(--text-secondary)',
+};
+
+export default function SyncPage() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const ev = state.events.find(e => e.id === state.activeEventId) ?? null;
+
+  const [pushing, setPushing] = useState(false);
+  const [pulling, setPulling] = useState(false);
+  const [status, setStatus] = useState('');
+
+  async function pushToSheets() {
+    if (!ev?.masterSheetUrl) { setStatus('Error: Master Sheet URL not set — go to Event Setup.'); return; }
+    setPushing(true); setStatus('');
+    try {
+      const token = await getToken('spreadsheets');
+      const id = extractSheetId(ev.masterSheetUrl);
+      await sheetsClear(token, id, 'Sheet1!A:K');
+      const rows = state.invitees.map(i => [
+        i.firstName, i.lastName, i.title, i.category, i.email, i.rsvpLink,
+        i.inviteStatus === 'sent' ? 'TRUE' : 'FALSE', i.sentAt,
+        i.rsvpStatus, i.rsvpDate, i.notes,
+      ]);
+      await sheetsUpdate(token, id, 'Sheet1!A1', [MASTER_COLUMNS, ...rows]);
+      setStatus(`Pushed ${rows.length} rows to master sheet.`);
+    } catch (e) { setStatus('Error: ' + String(e)); }
+    finally { setPushing(false); }
+  }
+
+  async function pullRsvp() {
+    if (!ev?.rsvpResponseUrl) { setStatus('Error: RSVP Response Sheet URL not set — go to Event Setup.'); return; }
+    setPulling(true); setStatus('');
+    try {
+      const token = await getToken('spreadsheets');
+      const id = extractSheetId(ev.rsvpResponseUrl);
+      const rows = await sheetsGet(token, id, 'Sheet1!A:K');
+      if (rows.length < 2) { setStatus('RSVP sheet appears empty.'); return; }
+      const [header, ...data] = rows;
+      const emailCol  = header.findIndex(h => h.toLowerCase().includes('email'));
+      const statusCol = header.findIndex(h => h.toLowerCase().includes('attend') || h.toLowerCase().includes('rsvp'));
+      const dateCol   = header.findIndex(h => h.toLowerCase().includes('date'));
+      if (emailCol < 0) { setStatus('Cannot find Email column in RSVP sheet.'); return; }
+      let updated = 0;
+      const invitees = state.invitees.map(inv => {
+        const match = data.find(r => r[emailCol]?.toLowerCase() === inv.email.toLowerCase());
+        if (!match) return inv;
+        const rawStatus = match[statusCol] ?? '';
+        const rsvpStatus: Invitee['rsvpStatus'] =
+          rawStatus.toLowerCase().includes('yes') || rawStatus.toLowerCase().includes('attend') ? 'Attending' :
+          rawStatus.toLowerCase().includes('no')  || rawStatus.toLowerCase().includes('declin') ? 'Declined' :
+          'No Response';
+        const rsvpDate = dateCol >= 0 ? (match[dateCol] ?? '') : new Date().toISOString().slice(0, 10);
+        updated++;
+        return { ...inv, rsvpStatus, rsvpDate };
+      });
+      dispatch({ type: 'SET_INVITEES', invitees });
+      setStatus(`Updated ${updated} RSVP responses.`);
+    } catch (e) { setStatus('Error: ' + String(e)); }
+    finally { setPulling(false); }
+  }
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <PageHeader eyebrow="SYNC" title="Google Sheets sync" showBack />
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 32px' }}>
+
+        {status && (
+          <div className={`if-status ${status.startsWith('Error') ? 'err' : 'ok'}`} style={{ margin: '8px 0' }}>
+            {status}
+          </div>
+        )}
+
+        <div className="if-section-label" style={{ padding: '12px 0 8px' }}>OPERATIONS</div>
+        <div className="if-card" style={{ marginBottom: 16 }}>
+
+          {/* Push */}
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, padding: 'var(--rt-row-pad)', borderBottom: '1px solid var(--border)' }}>
+            <div style={CHIP}><Icon name="upload" size={13} /></div>
+            <div style={{ flex: 1 }}>
+              <div className="if-card-row-title">Push to master sheet</div>
+              <div className="if-card-row-sub">CLEARS AND REWRITES ALL {state.invitees.length} INVITEES TO GOOGLE SHEETS</div>
+              <div style={{ marginTop: 8, display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                {ev?.masterSheetUrl ? (
+                  <a href={ev.masterSheetUrl} target="_blank" rel="noreferrer"
+                    style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--accent)', letterSpacing: '0.06em' }}>
+                    OPEN SHEET ↗
+                  </a>
+                ) : (
+                  <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--danger)', letterSpacing: '0.06em' }}>
+                    MASTER SHEET URL NOT SET IN EVENT SETUP
+                  </span>
+                )}
+                <button className="if-btn grn sm" onClick={pushToSheets} disabled={pushing}>
+                  {pushing ? 'Pushing…' : `Push ${state.invitees.length} rows`}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Pull */}
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, padding: 'var(--rt-row-pad)' }}>
+            <div style={CHIP}><Icon name="download" size={13} /></div>
+            <div style={{ flex: 1 }}>
+              <div className="if-card-row-title">Pull RSVP responses</div>
+              <div className="if-card-row-sub">READS RSVP STATUS FROM RESPONSE SHEET AND UPDATES RECORDS</div>
+              <div style={{ marginTop: 8, display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                {ev?.rsvpResponseUrl ? (
+                  <a href={ev.rsvpResponseUrl} target="_blank" rel="noreferrer"
+                    style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--accent)', letterSpacing: '0.06em' }}>
+                    OPEN SHEET ↗
+                  </a>
+                ) : (
+                  <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--danger)', letterSpacing: '0.06em' }}>
+                    RSVP RESPONSE URL NOT SET IN EVENT SETUP
+                  </span>
+                )}
+                <button className="if-btn ghost sm" onClick={pullRsvp} disabled={pulling}>
+                  {pulling ? 'Pulling…' : 'Pull RSVP responses'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="if-section-label" style={{ padding: '8px 0 8px' }}>APPS SCRIPT TRIGGER</div>
+        <p style={{ fontFamily: 'var(--rf-mono)', fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.7, marginBottom: 10 }}>
+          Paste into your Google Form&apos;s Apps Script. Add an{' '}
+          <code style={{ background: 'var(--bg-subtle)', padding: '1px 5px', borderRadius: 3, fontSize: 9 }}>onFormSubmit</code>
+          {' '}trigger and set the{' '}
+          <code style={{ background: 'var(--bg-subtle)', padding: '1px 5px', borderRadius: 3, fontSize: 9 }}>MASTER_SHEET_URL</code>
+          {' '}script property.
+        </p>
+        <div style={{ position: 'relative' }}>
+          <pre className="if-code">{GAS_CODE}</pre>
+          <button
+            className="if-btn sm"
+            style={{ position: 'absolute', top: 8, right: 8 }}
+            onClick={() => { navigator.clipboard.writeText(GAS_CODE); setStatus('Copied GAS code to clipboard.'); }}
+          >
+            Copy
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/inviteflow/pages/TrackerPage.tsx
+++ b/src/inviteflow/pages/TrackerPage.tsx
@@ -1,0 +1,201 @@
+import { useState } from 'react';
+import { useAppState } from '../state/AppContext';
+import PageHeader from '../components/PageHeader';
+
+type Filter = 'all' | 'attending' | 'pending' | 'declined';
+
+export default function TrackerPage() {
+  const state = useAppState();
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const inv = state.invitees;
+  const total      = inv.length;
+  const sent       = inv.filter(i => i.inviteStatus === 'sent').length;
+  const pending    = inv.filter(i => i.inviteStatus === 'pending').length;
+  const failed     = inv.filter(i => i.inviteStatus === 'failed').length;
+  const attending  = inv.filter(i => i.rsvpStatus === 'Attending').length;
+  const declined   = inv.filter(i => i.rsvpStatus === 'Declined').length;
+  const noResponse = inv.filter(i => i.rsvpStatus === 'No Response').length;
+
+  const filtered = filter === 'all' ? inv
+    : filter === 'attending' ? inv.filter(i => i.rsvpStatus === 'Attending')
+    : filter === 'pending'   ? inv.filter(i => i.rsvpStatus === 'No Response')
+    : inv.filter(i => i.rsvpStatus === 'Declined');
+
+  const cats = Array.from(new Set(inv.map(i => i.category).filter(Boolean))).sort();
+  const byCategory = cats.map(cat => {
+    const rows = inv.filter(i => i.category === cat);
+    return {
+      category: cat,
+      total:      rows.length,
+      sent:       rows.filter(i => i.inviteStatus === 'sent').length,
+      attending:  rows.filter(i => i.rsvpStatus === 'Attending').length,
+      declined:   rows.filter(i => i.rsvpStatus === 'Declined').length,
+      noResponse: rows.filter(i => i.rsvpStatus === 'No Response').length,
+    };
+  });
+
+  if (total === 0) {
+    return (
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+        <PageHeader eyebrow="TRACKER" title="RSVP roster" showBack />
+        <div className="if-empty">
+          No invitees yet.
+          <div className="if-empty-sub">ADD THEM IN THE INVITEES PAGE</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <PageHeader eyebrow="TRACKER" title="RSVP roster" showBack />
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 32px' }}>
+
+        {/* Stat strip */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8, margin: '8px 0 16px' }}>
+          {[
+            { label: 'TOTAL',      value: total,      color: 'var(--text-secondary)' },
+            { label: 'SENT',       value: sent,        color: 'var(--success)' },
+            { label: 'ATTENDING',  value: attending,   color: 'var(--accent)' },
+            { label: 'NO RESP.',   value: noResponse,  color: 'var(--text-muted)' },
+          ].map(s => (
+            <div key={s.label} className="if-stat" style={{ borderLeftColor: s.color }}>
+              <div className="if-stat-label">{s.label}</div>
+              <div className="if-stat-value" style={{ color: s.color }}>{s.value}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* RSVP overview */}
+        <div className="if-card" style={{ padding: '14px 16px', marginBottom: 16 }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 12 }}>
+            <span style={{ fontFamily: 'var(--rf-serif)', fontSize: 40, fontWeight: 500, color: 'var(--accent)', lineHeight: 1, letterSpacing: '-0.02em' }}>
+              {attending}
+            </span>
+            <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 12, color: 'var(--text-secondary)', letterSpacing: '0.06em' }}>
+              of {total} confirmed
+            </span>
+          </div>
+
+          <div className="if-bar-track" style={{ marginBottom: 8 }}>
+            {attending  > 0 && <div style={{ width: `${attending / total * 100}%`,  background: 'var(--accent)' }} />}
+            {noResponse > 0 && <div style={{ width: `${noResponse / total * 100}%`, background: 'var(--warning)', opacity: 0.5 }} />}
+            {declined   > 0 && <div style={{ width: `${declined / total * 100}%`,   background: 'var(--danger)',  opacity: 0.5 }} />}
+          </div>
+
+          <div style={{ display: 'flex', gap: 16, fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--text-secondary)', letterSpacing: '0.08em' }}>
+            {[
+              { label: `${attending} YES`,   dot: 'var(--accent)',   opacity: 1 },
+              { label: `${noResponse} PEND`, dot: 'var(--warning)', opacity: 0.7 },
+              { label: `${declined} NO`,     dot: 'var(--danger)',   opacity: 0.7 },
+            ].map(l => (
+              <span key={l.label} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                <span style={{ width: 6, height: 6, borderRadius: '50%', background: l.dot, opacity: l.opacity, flexShrink: 0, display: 'inline-block' }} />
+                {l.label}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Filter chips */}
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 12 }}>
+          {[
+            { k: 'all' as Filter,       l: 'All',     c: total },
+            { k: 'attending' as Filter, l: 'Yes',     c: attending },
+            { k: 'pending' as Filter,   l: 'Pending', c: noResponse },
+            { k: 'declined' as Filter,  l: 'No',      c: declined },
+          ].map(f => (
+            <button key={f.k} className={`if-filter-chip${filter === f.k ? ' active' : ''}`} onClick={() => setFilter(f.k)}>
+              {f.l}
+              <span className="count"> {f.c}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Dense list */}
+        <div className="if-section-label" style={{ marginBottom: 8 }}>INVITEES</div>
+        <div className="if-card" style={{ marginBottom: 24 }}>
+          {filtered.length === 0 ? (
+            <div className="if-empty" style={{ padding: 24 }}>No results for this filter.</div>
+          ) : filtered.map((o, i) => {
+            const rsvpColor = o.rsvpStatus === 'Attending' ? 'var(--accent)' : o.rsvpStatus === 'Declined' ? 'var(--danger)' : 'var(--warning)';
+            const rsvpLabel = o.rsvpStatus === 'Attending' ? 'YES' : o.rsvpStatus === 'Declined' ? 'NO' : 'WAIT';
+
+            return (
+              <div key={o.id} style={{
+                display: 'flex', alignItems: 'center', gap: 10,
+                padding: 'var(--rt-row-pad)',
+                borderBottom: i < filtered.length - 1 ? '1px solid var(--border)' : 'none',
+              }}>
+                <div style={{ width: 3, alignSelf: 'stretch', background: rsvpColor, borderRadius: 2, flexShrink: 0 }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                    <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 12, fontWeight: 500, color: 'var(--text-heading)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      {o.firstName} {o.lastName}
+                    </span>
+                    {o.category && (
+                      <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 8, color: 'var(--text-muted)', letterSpacing: '0.08em', flexShrink: 0 }}>
+                        {o.category.toUpperCase()}
+                      </span>
+                    )}
+                  </div>
+                  {o.title && (
+                    <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 10, color: 'var(--text-secondary)', marginTop: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      {o.title}
+                    </div>
+                  )}
+                </div>
+                <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: o.inviteStatus === 'sent' ? 'var(--success)' : o.inviteStatus === 'failed' ? 'var(--danger)' : 'var(--text-muted)', flexShrink: 0, letterSpacing: '0.06em' }}>
+                  {o.inviteStatus.toUpperCase()}
+                </span>
+                <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, padding: '3px 6px', borderRadius: 3, border: `1px solid ${rsvpColor}`, color: rsvpColor, letterSpacing: '0.1em', flexShrink: 0 }}>
+                  {rsvpLabel}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* By category */}
+        {byCategory.length > 0 && (
+          <>
+            <div className="if-section-label" style={{ marginBottom: 8 }}>BY CATEGORY</div>
+            <div className="if-card" style={{ overflow: 'hidden' }}>
+              <div style={{ overflowX: 'auto' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'var(--rf-mono)' }}>
+                  <thead>
+                    <tr>
+                      {['Category', 'Total', 'Sent', 'Attending', 'Declined', 'No Response'].map(h => (
+                        <th key={h} style={{
+                          fontSize: 8, color: 'var(--text-secondary)', letterSpacing: '0.12em',
+                          textTransform: 'uppercase', textAlign: 'left', padding: '7px 12px',
+                          borderBottom: '1px solid var(--border)', background: 'var(--bg-subtle)',
+                        }}>
+                          {h}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {byCategory.map((row, i) => (
+                      <tr key={row.category} style={{ borderBottom: i < byCategory.length - 1 ? '1px solid var(--border)' : 'none' }}>
+                        <td style={{ fontSize: 11, color: 'var(--text-base)', padding: '6px 12px' }}>{row.category}</td>
+                        <td style={{ fontSize: 11, color: 'var(--text-secondary)', padding: '6px 12px' }}>{row.total}</td>
+                        <td style={{ fontSize: 11, color: 'var(--success)', padding: '6px 12px' }}>{row.sent}</td>
+                        <td style={{ fontSize: 11, color: 'var(--accent)', padding: '6px 12px' }}>{row.attending}</td>
+                        <td style={{ fontSize: 11, color: 'var(--danger)', padding: '6px 12px' }}>{row.declined}</td>
+                        <td style={{ fontSize: 11, color: 'var(--text-muted)', padding: '6px 12px' }}>{row.noResponse}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/inviteflow/state/RouterContext.tsx
+++ b/src/inviteflow/state/RouterContext.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+export type RouteId =
+  | 'events'
+  | 'event-home'
+  | 'event-setup'
+  | 'invitees'
+  | 'compose'
+  | 'send'
+  | 'tracker'
+  | 'sync'
+  | 'settings';
+
+interface RouterContextValue {
+  route: RouteId;
+  navigate: (page: RouteId) => void;
+  goBack: () => void;
+}
+
+const RouterCtx = createContext<RouterContextValue>({
+  route: 'events',
+  navigate: () => {},
+  goBack: () => {},
+});
+
+export function RouterProvider({ children }: { children: ReactNode }) {
+  const [stack, setStack] = useState<RouteId[]>(['events']);
+  const route = stack[stack.length - 1];
+
+  function navigate(page: RouteId) {
+    setStack(s => [...s, page]);
+  }
+
+  function goBack() {
+    setStack(s => (s.length > 1 ? s.slice(0, -1) : s));
+  }
+
+  return (
+    <RouterCtx.Provider value={{ route, navigate, goBack }}>
+      {children}
+    </RouterCtx.Provider>
+  );
+}
+
+export const useRouter = () => useContext(RouterCtx);


### PR DESCRIPTION
## Summary

- Replaces the 7-tab flat nav with a **page-stack router**: Events List → Event Dashboard → individual workflow pages
- Adds `RouterContext` (navigate/goBack stack), `PageHeader` component, and shared `Icon` component
- Creates 9 new page files under `src/inviteflow/pages/` — all existing API/state logic preserved unchanged

## Pages

| Route | Page | Notes |
|---|---|---|
| `events` | EventsPage | Drive auto-load, UPCOMING/PAST groups |
| `event-home` | EventDashboard | Stats + 5 numbered workflow rows + recent activity |
| `event-setup` | EventSetupPage | OAuth + 13 fields + sticky save |
| `invitees` | InviteesPage | DataTable, Sheets/JSON import, bulk actions |
| `compose` | ComposePage | TipTap + edit/preview toggle + sticky CTA |
| `send` | SendPage | Pre-flight checks + batch send + delivery log |
| `tracker` | TrackerPage | RSVP count, stacked bar, category table |
| `sync` | SyncPage | Push/pull Sheets + GAS code block |
| `settings` | SettingsPage | OAuth, client ID, export/import |

## Test plan

- [ ] Events list loads from Drive on mount
- [ ] Create event → navigates to EventSetupPage
- [ ] Click event row → navigates to EventDashboard
- [ ] All 5 workflow CardRows navigate to correct pages
- [ ] Back button returns to previous page in all flows
- [ ] Hamburger → Settings from any page
- [ ] Gmail send, Sheets push/pull, RSVP pull all functional
- [ ] Build passes: `npm run build` (zero TS errors)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)