### PR TITLE
feat: ScoutPage + OAuth setup banner

### DIFF
--- a/src/inviteflow/App.tsx
+++ b/src/inviteflow/App.tsx
@@ -9,6 +9,7 @@ import SendPage from './pages/SendPage';
 import TrackerPage from './pages/TrackerPage';
 import SyncPage from './pages/SyncPage';
 import SettingsPage from './pages/SettingsPage';
+import ScoutPage from './pages/ScoutPage';
 
 function PageContent() {
   const { route } = useRouter();
@@ -22,6 +23,7 @@ function PageContent() {
     case 'tracker':     return <TrackerPage />;
     case 'sync':        return <SyncPage />;
     case 'settings':    return <SettingsPage />;
+    case 'scout':       return <ScoutPage />;
   }
 }
 

--- a/src/inviteflow/pages/EventDashboard.tsx
+++ b/src/inviteflow/pages/EventDashboard.tsx
@@ -148,7 +148,7 @@ export default function EventDashboard() {
             chip={<Icon name="sparkle" size={13} />}
             title="Discover Officials"
             sub="FIND ELECTED OFFICIALS WITH CONTACTSCOUT"
-            route="invitees"
+            route="scout"
             isLast
           />
         </div>

--- a/src/inviteflow/pages/EventsPage.tsx
+++ b/src/inviteflow/pages/EventsPage.tsx
@@ -93,9 +93,31 @@ export default function EventsPage() {
     </button>
   );
 
+  const hasOAuth = !!localStorage.getItem('gClientId');
+
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
       <PageHeader eyebrow="INVITEFLOW" title="Events" right={headerRight} />
+
+      {!hasOAuth && (
+        <div style={{
+          margin: '8px 18px 0', padding: '10px 14px', borderRadius: 8,
+          background: 'rgba(251,191,36,0.08)', border: '1px solid rgba(251,191,36,0.3)',
+          display: 'flex', alignItems: 'center', gap: 10,
+        }}>
+          <Icon name="lock" size={14} style={{ color: 'var(--warning)', flexShrink: 0 }} />
+          <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 11, color: 'var(--text-secondary)', flex: 1 }}>
+            Google OAuth not configured. Set up your client ID to enable event management.
+          </span>
+          <button
+            className="if-btn sm"
+            style={{ flexShrink: 0, background: 'var(--warning)', color: '#000', border: 'none' }}
+            onClick={() => navigate('settings')}
+          >
+            Set up OAuth
+          </button>
+        </div>
+      )}
 
       <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 32px' }}>
         {err && <div className="if-status err" style={{ marginBottom: 12 }}>{err}</div>}
@@ -106,9 +128,14 @@ export default function EventsPage() {
               No events yet
             </div>
             <div className="if-section-label" style={{ marginBottom: 16 }}>
-              CREATE YOUR FIRST EVENT TO GET STARTED
+              {hasOAuth ? 'CREATE YOUR FIRST EVENT TO GET STARTED' : 'SET UP OAUTH FIRST'}
             </div>
-            <button className="if-btn pri" onClick={createEvent}>+ New Event</button>
+            <button
+              className="if-btn pri"
+              onClick={() => hasOAuth ? createEvent() : navigate('settings')}
+            >
+              {hasOAuth ? '+ New Event' : 'Set up Google OAuth first'}
+            </button>
           </div>
         )}
 
@@ -207,9 +234,13 @@ export default function EventsPage() {
 
       {state.events.length === 0 && (
         <div style={{ padding: '0 18px 32px' }}>
-          <button className="if-btn pri" style={{ width: '100%', minHeight: 46 }} onClick={createEvent}>
-            <Icon name="plus" size={13} style={{ marginRight: 6 }} />
-            NEW EVENT
+          <button
+            className="if-btn pri"
+            style={{ width: '100%', minHeight: 46 }}
+            onClick={() => hasOAuth ? createEvent() : navigate('settings')}
+          >
+            <Icon name={hasOAuth ? 'plus' : 'lock'} size={13} style={{ marginRight: 6 }} />
+            {hasOAuth ? 'NEW EVENT' : 'SET UP GOOGLE OAUTH'}
           </button>
         </div>
       )}

--- a/src/inviteflow/pages/ScoutPage.tsx
+++ b/src/inviteflow/pages/ScoutPage.tsx
@@ -1,0 +1,312 @@
+// ── ContactScout engine (direct imports — same logic as ContactScout standalone app) ───
+import { callGemini } from '../../contactscout/src/api';
+import { fetchStateLegislators } from '../../contactscout/src/openStates';
+import {
+  SCAN_TARGETS,
+  SCAN_SYS,
+  MODEL_SCAN,
+  CS_APIKEY_SK,
+  CS_JX_KEY,
+  CS_OS_KEY,
+} from '../../contactscout/src/constants';
+import { officialToInvitee, buildScanPrompts } from '../../contactscout/src/utils';
+import { bestEmail } from '../../contactscout/src/emailPatterns';
+import type { CSOfficial, CSJurisdiction } from '../../contactscout/src/types';
+
+import { useEffect, useState } from 'react';
+import { useAppState, useAppDispatch } from '../state/AppContext';
+import { useRouter } from '../state/RouterContext';
+import PageHeader from '../components/PageHeader';
+import Icon from '../components/Icon';
+import type { Invitee } from '../types';
+
+// ── Types ───────────────────────────────────────────────────────────────────────
+
+type ScanState = 'idle' | 'scanning' | 'done' | 'error';
+
+interface DiscoveredOfficial {
+  id: string;
+  official: CSOfficial;
+  confidence: 'high' | 'med' | 'low';
+  added: boolean; // already in invitees list
+}
+
+// ── Component ───────────────────────────────────────────────────────────────────
+
+export default function ScoutPage() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+  const { goBack } = useRouter();
+
+  const apiKey    = sessionStorage.getItem(CS_APIKEY_SK) ?? ''; // CS_APIKEY_SK = '***'
+  const osKey     = sessionStorage.getItem(CS_OS_KEY) ?? '';
+  const hasGemini = !!apiKey;
+  const hasOS     = !!osKey;
+  const hasKeys   = hasGemini || hasOS;
+
+  const [scanState,  setScanState]  = useState<ScanState>('idle');
+  const [results,    setResults]    = useState<DiscoveredOfficial[]>([]);
+  const [selected,   setSelected]   = useState<Set<string>>(new Set());
+  const [error,      setError]      = useState('');
+  const [scanTarget, setScanTarget] = useState<string>('openstates');
+
+  // Load saved results from sessionStorage
+  useEffect(() => {
+    const saved = sessionStorage.getItem('scout_results');
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as DiscoveredOfficial[];
+        setResults(parsed);
+        if (parsed.length > 0) setScanState('done');
+      } catch { /* ignore */ }
+    }
+  }, []);
+
+  function scoreConfidence(o: CSOfficial): 'high' | 'med' | 'low' {
+    const email = bestEmail(o);
+    if (email && (email.includes('.gov') || email.includes('.senate') || email.includes('.house'))) return 'high';
+    if (email) return 'med';
+    return 'low';
+  }
+
+  async function runScan() {
+    setError('');
+    setScanState('scanning');
+    setResults([]);
+    setSelected(new Set());
+
+    try {
+      let officials: CSOfficial[] = [];
+
+      if (scanTarget === 'openstates') {
+        // Open States — no jurisdiction needed, fetches all legislators
+        const jx = JSON.parse(sessionStorage.getItem(CS_JX_KEY) ?? '{}') as Partial<CSJurisdiction>;
+        const state = (jx.state ?? 'California').toLowerCase();
+        const { officials: leg } = await fetchStateLegislators(osKey, state, 'upper');
+        const { officials: house } = await fetchStateLegislators(osKey, state, 'lower');
+        officials = [...leg, ...house];
+      } else {
+        // Gemini web search
+        const jx = JSON.parse(sessionStorage.getItem(CS_JX_KEY) ?? '{}') as CSJurisdiction;
+        const target = SCAN_TARGETS.find(t => t.id === scanTarget);
+        if (!target) throw new Error(`Unknown scan target: ${scanTarget}`);
+
+        const prompts = buildScanPrompts(jx);
+        const targetPrompt = prompts[scanTarget] ?? target.desc;
+
+        const raw = await callGemini(apiKey, MODEL_SCAN, SCAN_SYS, targetPrompt);
+        officials = (raw.officials as CSOfficial[]) ?? [];
+      }
+
+      const scored: DiscoveredOfficial[] = officials.map(o => ({
+        id: crypto.randomUUID(),
+        official: o,
+        confidence: scoreConfidence(o),
+        added: state.invitees.some(
+          i => i.email?.toLowerCase() === bestEmail(o).toLowerCase()
+        ),
+      }));
+
+      setResults(scored);
+      setScanState('done');
+      sessionStorage.setItem('scout_results', JSON.stringify(scored));
+    } catch (e) {
+      setError(String(e));
+      setScanState('error');
+    }
+  }
+
+  function toggle(id: string) {
+    setSelected(s => {
+      const next = new Set(s);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }
+
+  function addToInvitees() {
+    const toAdd = results.filter(r => selected.has(r.id) && !r.added);
+    const invitees: Invitee[] = toAdd.map(r => ({
+      ...officialToInvitee(r.official),
+      id: crypto.randomUUID(),
+    }));
+    invitees.forEach(i => dispatch({ type: 'ADD_INVITEE', invitee: i }));
+    setResults(prev => prev.map(r =>
+      selected.has(r.id) ? { ...r, added: true } : r
+    ));
+    setSelected(new Set());
+  }
+
+  const badgeStyle = (c: 'high' | 'med' | 'low') => ({
+    padding: '2px 6px',
+    borderRadius: 4,
+    fontFamily: 'var(--rf-mono)',
+    fontSize: 9,
+    letterSpacing: '0.08em',
+    background:   c === 'high' ? 'rgba(52,211,153,0.15)' : c === 'med' ? 'rgba(251,191,36,0.15)' : 'rgba(148,163,184,0.15)',
+    color:        c === 'high' ? '#34d399'        : c === 'med' ? '#fbbf24'        : '#94a3b8',
+    border: `1px solid ${c === 'high' ? 'rgba(52,211,153,0.3)' : c === 'med' ? 'rgba(251,191,36,0.3)' : 'rgba(148,163,184,0.3)'}`,
+  });
+
+  const headerRight = (
+    <button className="if-header-btn" onClick={goBack} aria-label="Back">
+      <Icon name="chevron-left" size={13} />
+    </button>
+  );
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <PageHeader eyebrow="OFFICIAL DISCOVERY" title="ContactScout" right={headerRight} />
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 32px' }}>
+
+        {/* Setup banner */}
+        {!hasKeys && (
+          <div style={{
+            marginTop: 8, padding: '14px 16px', borderRadius: 8,
+            background: 'rgba(251,191,36,0.06)', border: '1px solid rgba(251,191,36,0.25)',
+            marginBottom: 12,
+          }}>
+            <div style={{ fontFamily: 'var(--rf-serif)', fontSize: 13, color: 'var(--text-heading)', marginBottom: 6 }}>
+              API keys required
+            </div>
+            <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 11, color: 'var(--text-secondary)', marginBottom: 10 }}>
+              Open ContactScout to configure your Gemini and Open States API keys. They are stored in sessionStorage and carry over automatically.
+            </div>
+            <a
+              href="/contactscout/"
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 6,
+                fontFamily: 'var(--rf-mono)', fontSize: 11,
+                color: 'var(--accent)', textDecoration: 'none',
+              }}
+            >
+              <Icon name="chevron-right" size={11} /> Open ContactScout
+            </a>
+          </div>
+        )}
+
+        {/* Scan controls */}
+        {hasKeys && scanState === 'idle' && (
+          <div className="if-card" style={{ padding: '16px', marginBottom: 12 }}>
+            <div className="if-section-label" style={{ marginBottom: 10 }}>SCAN TARGET</div>
+            <select
+              value={scanTarget}
+              onChange={e => setScanTarget(e.target.value)}
+              style={{
+                width: '100%', padding: '8px 10px', marginBottom: 12,
+                background: 'var(--bg-raised)', border: '1px solid var(--border)',
+                color: 'var(--text-base)', fontFamily: 'var(--rf-mono)', fontSize: 12,
+                borderRadius: 6, cursor: 'pointer',
+              }}
+            >
+              <optgroup label="Fast — no web search">
+                <option value="openstates">State Legislators (Open States — all chambers)</option>
+              </optgroup>
+              <optgroup label="Gemini web search">
+                {SCAN_TARGETS.map(t => (
+                  <option key={t.id} value={t.id}>{t.label}</option>
+                ))}
+              </optgroup>
+            </select>
+            <button className="if-btn pri" style={{ width: '100%' }} onClick={runScan}>
+              <Icon name="search" size={13} style={{ marginRight: 6 }} />
+              Start Scan
+            </button>
+          </div>
+        )}
+
+        {/* Scanning state */}
+        {scanState === 'scanning' && (
+          <div style={{ textAlign: 'center', padding: '40px 0' }}>
+            <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 12, color: 'var(--text-secondary)', marginBottom: 12 }}>
+              Scanning...
+            </div>
+            <div style={{ color: 'var(--text-muted)', fontFamily: 'var(--rf-mono)', fontSize: 11 }}>
+              Gemini scans may take 30–60 seconds
+            </div>
+          </div>
+        )}
+
+        {/* Error */}
+        {scanState === 'error' && (
+          <div className="if-status err" style={{ marginBottom: 12 }}>{error}</div>
+        )}
+
+        {/* Results */}
+        {scanState === 'done' && (
+          <>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+              <div className="if-section-label" style={{ padding: 0 }}>
+                {results.length} OFFICIALS FOUND
+              </div>
+              {selected.size > 0 && (
+                <button className="if-btn pri sm" onClick={addToInvitees}>
+                  Add {selected.size} to Invitees
+                </button>
+              )}
+            </div>
+
+            <div className="if-card">
+              {results.length === 0 && (
+                <div style={{ padding: '24px', textAlign: 'center', color: 'var(--text-muted)', fontFamily: 'var(--rf-mono)', fontSize: 11 }}>
+                  No officials found. Try a different scan target.
+                </div>
+              )}
+              {results.map((r, i) => {
+                const isLast = i === results.length - 1;
+                const email = bestEmail(r.official);
+                return (
+                  <div
+                    key={r.id}
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: 10,
+                      padding: 'var(--rt-row-pad)',
+                      borderBottom: isLast ? 'none' : '1px solid var(--border)',
+                      opacity: r.added ? 0.5 : 1,
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selected.has(r.id)}
+                      onChange={() => !r.added && toggle(r.id)}
+                      disabled={r.added}
+                      style={{ width: 14, height: 14, cursor: r.added ? 'not-allowed' : 'pointer', flexShrink: 0 }}
+                    />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 12, color: 'var(--text-heading)' }}>
+                        {r.official.name}
+                        {r.official.title ? `, ${r.official.title}` : ''}
+                      </div>
+                      <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--text-muted)', marginTop: 2 }}>
+                        {r.official.district ? `${r.official.district}` : ''}
+                        {r.official.county ? ` · ${r.official.county}` : ''}
+                        {email ? ` · ${email}` : ' · no email found'}
+                      </div>
+                    </div>
+                    <span style={badgeStyle(r.confidence)}>
+                      {r.confidence.toUpperCase()}
+                    </span>
+                    {r.added && (
+                      <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--success)', letterSpacing: '0.08em' }}>
+                        ADDED
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+
+            <button
+              className="if-btn ghost"
+              style={{ width: '100%', marginTop: 8 }}
+              onClick={() => { setScanState('idle'); setResults([]); sessionStorage.removeItem('scout_results'); }}
+            >
+              Clear results
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/inviteflow/state/RouterContext.tsx
+++ b/src/inviteflow/state/RouterContext.tsx
@@ -9,7 +9,8 @@ export type RouteId =
   | 'send'
   | 'tracker'
   | 'sync'
-  | 'settings';
+  | 'settings'
+  | 'scout';
 
 interface RouterContextValue {
   route: RouteId;


### PR DESCRIPTION
## Summary

Integrates ContactScout official discovery into InviteFlow and adds first-time OAuth setup guidance.

### Changes

**ScoutPage (`src/inviteflow/pages/ScoutPage.tsx`)**
- New page at `/scout` route — uses ContactScout engine directly from `src/contactscout/src/`
- Scan targets: Open States (fast, no API calls) and Gemini web search (7 targets)
- Displays discovered officials with confidence badges (high/med/low)
- Bulk-select officials and add to the InviteFlow invitees list in one click
- Results cached in `sessionStorage.scout_results`

**EventsPage (`src/inviteflow/pages/EventsPage.tsx`)**
- OAuth warning banner appears when `gClientId` is missing from localStorage
- Empty-state and bottom buttons redirect to Settings instead of silently failing

**EventDashboard (`src/inviteflow/pages/EventDashboard.tsx`)**
- DISCOVER section "Discover Officials" card now routes to `/scout` instead of `/invitees`

**Router + App**
- Added `'scout'` to `RouteId` union type
- Wired `ScoutPage` into the route switch

### Testing

- `npx tsc --noEmit` passes clean (no new type errors)

### Notes

- ContactScout engine (`src/contactscout/src/`) must be configured with a Gemini API key and Open States key in the standalone ContactScout app first. Keys are stored in `sessionStorage` and carry over automatically.
- Requires `npm install` after merge to ensure `src/contactscout/` dependencies are available.
