### PR TITLE
feat: redirect root to InviteFlow events page

### DIFF
--- a/scripts/copy-static.js
+++ b/scripts/copy-static.js
@@ -11,6 +11,10 @@ const dist = join(root, 'dist');
   console.log(`Copied ${file} → dist/${file}`);
 });
 
+// Promote inviteflow.html to root index.html for GitHub Pages redirect
+copyFileSync(join(dist, 'src', 'inviteflow', 'index.html'), join(dist, 'index.html'));
+console.log(`Promoted dist/src/inviteflow/index.html → dist/index.html`);
+
 // Promote nested app HTMLs to root-level named files
 const apps = ['inviteflow', 'contactscout'];
 for (const app of apps) {


### PR DESCRIPTION
## Summary

Landing page now goes directly to the redesigned InviteFlow events page instead of the old suite with two buttons. ContactScout has been integrated into InviteFlow as the discover step.

## Changes

- : Promote  to  during deploy

## Test Plan

- [ ] Visit https://lychan110.github.io/rsvp-automation/ — should land on InviteFlow events page