### PR TITLE
chore: codebase cleanup, doc audit, demo, and accessibility improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,10 +127,35 @@ GitHub Actions workflow: `.github/workflows/deploy.yml`
 5. **`.env` secrets** — `.env` is gitignored. CI uses env vars from workflow; local dev uses `.env` file
 6. **ContactScout is embedded** — `src/scout/` is the ContactScout engine, imported directly by `ScoutPage`. The standalone ContactScout app no longer exists in this repo.
 
+## Documentation Map
+
+When adding or changing a feature, update the right docs. Each file has a distinct scope — don't blur them.
+
+| File | What belongs here | Update when |
+|------|-------------------|-------------|
+| `README.md` | User-facing feature overview, setup steps, tech stack | New feature added, setup flow changes |
+| `docs/QUICKSTART.md` | Step-by-step guide for first-time users | Workflow changes, new first-run experience (e.g. demo) |
+| `docs/MEMORY.md` | Non-obvious learnings: gotchas, invariants, design decisions with hidden constraints | Something surprising discovered; a decision that would confuse a future developer |
+| `AGENTS.md` | Architecture, conventions, gotchas for agents/developers | Architecture changes, new conventions, new gotchas |
+| `docs/DESIGN.md` | Visual design system, layout rules, color/type scale | Design language changes |
+
+### What goes in MEMORY.md
+
+Add an entry whenever you discover something **non-obvious** — something a future developer would reasonably get wrong. Examples: why a check must be two conditions not one, why an import must also write to Dexie, why a feature uses fixed IDs. Do not add entries for things that are obvious from reading the code.
+
+### UI strings vs. docs
+
+Keep tech implementation details **out of UI labels and action text**. Describe what the feature does for the user, not which service or library implements it. Service names belong in:
+- Setup/configuration screens where the user needs them to sign up (e.g. "Get your key at resend.com →")
+- Help text below form fields
+- Project docs (README, QUICKSTART)
+
+Not in: button labels, workflow step subtitles, status messages, section headers.
+
 ## Agent Operating Principles
 
 - **Think before coding** — state assumptions, present tradeoffs, ask when unclear
 - **Surgical changes** — touch only what's needed, match existing style, clean up your own orphans
 - **Goal-driven** — define success criteria, verify before declaring done
 - **Simplicity first** — no speculative abstractions, no features beyond the ask
-- **Update this file** — when architecture or conventions change, revise AGENTS.md before or alongside the code
+- **Update docs alongside code** — when a feature ships, update README + QUICKSTART (user-facing) and MEMORY (non-obvious learnings) in the same commit or PR

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ VITE_SERPAPI_KEY=xxxxxxxxxxxxxxxxxxxx
 
 ---
 
+## Try the Demo
+
+Open the app with no events and click **▶ Try a demo** on the home screen. It loads a pre-filled event with 14 invitees across multiple categories and RSVP states — no API keys needed, nothing sent.
+
+---
+
 ## The Workflow
 
 1. **Setup** — Create an event with name, date, venue, contact info

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -26,6 +26,16 @@ The Scout/Discover feature calls any OpenAI-compatible API endpoint (`/v1/chat/c
 
 ---
 
+### Demo Seed Uses the Real Import Path
+`src/inviteflow/data/demoSeed.ts` exports `DEMO_BACKUP` — an object shaped exactly like a real app export (`exportData()` in SettingsPage). `loadDemoData()` calls `importBackupData()` from `api/storage.ts`, then returns the backup for the caller to dispatch `LOAD_STATE`. This is the same two-step sequence as `importBackup` in SettingsPage. Any change to import behavior automatically applies to the demo.
+
+`DEMO_BACKUP` uses fixed IDs (`demo-inv-01` … `demo-inv-14`, event `demo-event-2026-08-14`) so repeated loads are idempotent — Dexie `put` upserts without duplicating rows.
+
+### importBackup Must Write to Dexie
+`importBackupData()` in `api/storage.ts` writes events and invitees to Dexie (IndexedDB) before `LOAD_STATE` updates React state/localStorage. This is essential: EventsPage calls `loadEvents()` from Dexie on mount. If events are only in localStorage/state (not Dexie), they disappear the moment EventsPage re-fetches. Any code that "imports" an event must call `importBackupData` or `saveEvent`/`saveInvitee` directly — `LOAD_STATE` alone is not sufficient for persistence.
+
+---
+
 ## Build System
 
 ### Version: Single Source of Truth Is `package.json`

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,6 +6,14 @@ InviteFlow manages VIP event invitations end-to-end — from drafting personaliz
 
 ---
 
+## Try the Demo First
+
+If you have no events yet, the home screen shows a **▶ Try a demo** button. Click it to instantly load a pre-filled event with 14 invitees across Federal, State, City, County, Business, and Education categories — with a mix of sent, pending, failed, attending, and declined statuses. No API keys needed, nothing sent.
+
+This is a great way to explore all the pages before setting up your own event.
+
+---
+
 ## The Workflow
 
 ### Step 1 — Create an Event

--- a/src/inviteflow/api/storage.ts
+++ b/src/inviteflow/api/storage.ts
@@ -49,3 +49,8 @@ export async function logSync(entry: { action: string; source: string; timestamp
   const id = await db.syncLog.add(entry);
   return id as number;
 }
+
+export async function importBackupData(parsed: { events?: AppEvent[]; invitees?: Invitee[] }): Promise<void> {
+  for (const ev of parsed.events ?? []) await db.events.put(ev);
+  for (const inv of parsed.invitees ?? []) await db.invitees.put(inv);
+}

--- a/src/inviteflow/components/ScoutKeysModal.tsx
+++ b/src/inviteflow/components/ScoutKeysModal.tsx
@@ -50,6 +50,7 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
 
   return (
     <div
+      role="presentation"
       style={{
         position: 'fixed',
         inset: 0,
@@ -62,6 +63,9 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="scout-modal-title"
         style={{
           background: 'var(--bg-root)',
           borderRadius: 12,
@@ -74,25 +78,29 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
           boxShadow: '0 20px 25px -5px rgba(0,0,0,0.1)',
         }}
         onClick={e => e.stopPropagation()}
+        onKeyDown={e => e.key === 'Escape' && onClose()}
       >
-        <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--text-heading)', marginBottom: 16 }}>
+        <div id="scout-modal-title" style={{ fontSize: 16, fontWeight: 600, color: 'var(--text-heading)', marginBottom: 16 }}>
           API Configuration
         </div>
 
         {/* AI Provider API Key */}
         <div style={{ marginBottom: 4 }}>
-          <label style={{ display: 'block', fontSize: 11, fontWeight: 600, color: 'var(--text-heading)', marginBottom: 4, letterSpacing: '0.05em' }}>
+          <label htmlFor="scout-api-key" style={{ display: 'block', fontSize: 11, fontWeight: 600, color: 'var(--text-heading)', marginBottom: 4, letterSpacing: '0.05em' }}>
             AI Provider API Key
           </label>
           <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.6, marginBottom: 6 }}>
             API key for your OpenAI-compatible provider (OpenAI, Anthropic, etc.). Stored in session only.
           </div>
           <input
+            id="scout-api-key"
             type="password"
             placeholder="sk-..."
             value={keyDraft}
             onChange={e => { setKeyDraft(e.target.value); setKeyErr(false); }}
             onKeyDown={e => e.key === 'Enter' && save()}
+            aria-invalid={keyErr}
+            aria-describedby={keyErr ? 'scout-api-key-err' : undefined}
             style={{
               width: '100%',
               padding: '8px 10px',
@@ -106,23 +114,26 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
             }}
             autoFocus
           />
-          {keyErr && <div style={{ fontSize: 10, color: 'var(--danger)', marginBottom: 12 }}>API key is required</div>}
+          {keyErr && <div id="scout-api-key-err" role="alert" style={{ fontSize: 10, color: 'var(--danger)', marginBottom: 12 }}>API key is required</div>}
         </div>
 
         {/* AI Provider Endpoint */}
         <div style={{ marginBottom: 4 }}>
-          <label style={{ display: 'block', fontSize: 11, fontWeight: 600, color: 'var(--text-heading)', marginBottom: 4, letterSpacing: '0.05em' }}>
+          <label htmlFor="scout-endpoint" style={{ display: 'block', fontSize: 11, fontWeight: 600, color: 'var(--text-heading)', marginBottom: 4, letterSpacing: '0.05em' }}>
             API Endpoint
           </label>
           <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.6, marginBottom: 6 }}>
             Base URL for any OpenAI-compatible API. Defaults to <code style={{ color: 'var(--blue)' }}>https://api.openai.com/v1</code>.
           </div>
           <input
+            id="scout-endpoint"
             type="text"
             placeholder="https://api.openai.com/v1"
             value={endDraft}
             onChange={e => { setEndDraft(e.target.value); setEndErr(false); }}
             onKeyDown={e => e.key === 'Enter' && save()}
+            aria-invalid={endErr}
+            aria-describedby={endErr ? 'scout-endpoint-err' : undefined}
             style={{
               width: '100%',
               padding: '8px 10px',
@@ -135,14 +146,14 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
               marginBottom: endErr ? 4 : 12,
             }}
           />
-          {endErr && <div style={{ fontSize: 10, color: 'var(--danger)', marginBottom: 12 }}>Must be a valid URL</div>}
+          {endErr && <div id="scout-endpoint-err" role="alert" style={{ fontSize: 10, color: 'var(--danger)', marginBottom: 12 }}>Must be a valid URL</div>}
         </div>
 
         <div style={{ borderTop: '1px solid var(--border)', margin: '14px 0' }} />
 
         {/* SerpAPI Key */}
         <div style={{ marginBottom: 4 }}>
-          <label style={{ display: 'block', fontSize: 11, fontWeight: 600, color: 'var(--text-heading)', marginBottom: 4, letterSpacing: '0.05em' }}>
+          <label htmlFor="scout-serpapi-key" style={{ display: 'block', fontSize: 11, fontWeight: 600, color: 'var(--text-heading)', marginBottom: 4, letterSpacing: '0.05em' }}>
             SerpAPI Key <span style={{ fontWeight: 400, color: 'var(--text-muted)' }}>(recommended)</span>
           </label>
           <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.6, marginBottom: 6 }}>
@@ -153,6 +164,7 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
             {' '} — free tier includes 100 searches/month.
           </div>
           <input
+            id="scout-serpapi-key"
             type="password"
             placeholder="SerpAPI key..."
             value={searchDraft}
@@ -176,7 +188,7 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
 
         {/* Open States */}
         <div style={{ marginBottom: 4 }}>
-          <label style={{ display: 'block', fontSize: 11, fontWeight: 600, color: 'var(--text-heading)', marginBottom: 4, letterSpacing: '0.05em' }}>
+          <label htmlFor="scout-openstates-key" style={{ display: 'block', fontSize: 11, fontWeight: 600, color: 'var(--text-heading)', marginBottom: 4, letterSpacing: '0.05em' }}>
             Open States API <span style={{ fontWeight: 400, color: 'var(--text-muted)' }}>(optional)</span>
           </label>
           <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.6, marginBottom: 6 }}>
@@ -187,6 +199,7 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
             {' '} for a free key.
           </div>
           <input
+            id="scout-openstates-key"
             type="password"
             placeholder="Open States API key..."
             value={osDraft}
@@ -217,8 +230,9 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
             Configure your state and location(s) for targeted official discovery scans.
           </div>
 
-          <label style={{ display: 'block', fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>State</label>
+          <label htmlFor="scout-jx-state" style={{ display: 'block', fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>State</label>
           <input
+            id="scout-jx-state"
             type="text"
             placeholder="e.g., California"
             value={stateDraft}
@@ -237,8 +251,9 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
             }}
           />
 
-          <label style={{ display: 'block', fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>Counties (comma-separated)</label>
+          <label htmlFor="scout-jx-counties" style={{ display: 'block', fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>Counties (comma-separated)</label>
           <input
+            id="scout-jx-counties"
             type="text"
             placeholder="e.g., Santa Clara, San Mateo"
             value={countiesDraft}
@@ -257,8 +272,9 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
             }}
           />
 
-          <label style={{ display: 'block', fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>City 1</label>
+          <label htmlFor="scout-jx-city1" style={{ display: 'block', fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>City 1</label>
           <input
+            id="scout-jx-city1"
             type="text"
             placeholder="e.g., San Jose"
             value={city1Draft}
@@ -277,8 +293,9 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
             }}
           />
 
-          <label style={{ display: 'block', fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>City 2</label>
+          <label htmlFor="scout-jx-city2" style={{ display: 'block', fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>City 2</label>
           <input
+            id="scout-jx-city2"
             type="text"
             placeholder="e.g., Palo Alto"
             value={city2Draft}
@@ -297,8 +314,9 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
             }}
           />
 
-          <label style={{ display: 'block', fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>City 3</label>
+          <label htmlFor="scout-jx-city3" style={{ display: 'block', fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>City 3</label>
           <input
+            id="scout-jx-city3"
             type="text"
             placeholder="e.g., Mountain View"
             value={city3Draft}

--- a/src/inviteflow/components/ScoutKeysModal.tsx
+++ b/src/inviteflow/components/ScoutKeysModal.tsx
@@ -154,7 +154,7 @@ export default function ScoutKeysModal({ apiKey, endpoint, searchKey, osKey, jx,
         {/* SerpAPI Key */}
         <div style={{ marginBottom: 4 }}>
           <label htmlFor="scout-serpapi-key" style={{ display: 'block', fontSize: 11, fontWeight: 600, color: 'var(--text-heading)', marginBottom: 4, letterSpacing: '0.05em' }}>
-            SerpAPI Key <span style={{ fontWeight: 400, color: 'var(--text-muted)' }}>(recommended)</span>
+            Web Search Key <span style={{ fontWeight: 400, color: 'var(--text-muted)' }}>(recommended)</span>
           </label>
           <div style={{ fontSize: 10, color: 'var(--text-secondary)', lineHeight: 1.6, marginBottom: 6 }}>
             Enables web search for discovering officials. Get a free key at{' '}

--- a/src/inviteflow/data/demoSeed.ts
+++ b/src/inviteflow/data/demoSeed.ts
@@ -1,0 +1,82 @@
+import { saveEvent, saveInvitee, loadEvents } from '../api/storage';
+import type { AppEvent, Invitee } from '../types';
+
+export const DEMO_EVENT_ID = 'demo-event-2026-08';
+
+export const DEMO_EVENT: AppEvent = {
+  id: DEMO_EVENT_ID,
+  name: 'Capital Region Leadership Summit',
+  date: '2026-08-14',
+  venue: 'Raleigh Convention Center',
+  orgName: 'North Carolina Leadership Foundation',
+  contactName: 'Jordan Mitchell',
+  contactEmail: 'jordan.mitchell@nclf.org',
+  formUrl: 'https://forms.google.com/demo-rsvp',
+  rsvpResponseUrl: '',
+  masterSheetUrl: '',
+  entryEmail: '',
+  imgEmblemUrl: '',
+  vipStart: '6:00 PM',
+  vipEnd: '7:00 PM',
+  googleClientId: '',
+};
+
+function makeInv(
+  partial: Omit<Invitee, 'id' | 'eventId' | 'rsvpLink' | 'sentAt' | 'rsvpDate' | 'notes'>
+): Invitee {
+  return {
+    id: crypto.randomUUID(),
+    eventId: DEMO_EVENT_ID,
+    rsvpLink: '',
+    sentAt: partial.inviteStatus !== 'pending' ? '2026-07-21T10:00:00Z' : '',
+    rsvpDate: partial.rsvpStatus !== 'No Response' ? '2026-07-23T14:30:00Z' : '',
+    notes: '',
+    ...partial,
+  };
+}
+
+export const DEMO_INVITEES: Invitee[] = [
+  // Federal — sent
+  makeInv({ firstName: 'Robert',    lastName: 'Hayes',    title: 'US Senator',             category: 'Federal',   email: 'r.hayes@hayes.senate.gov',     inviteStatus: 'sent',   rsvpStatus: 'Attending'   }),
+  makeInv({ firstName: 'Patricia',  lastName: 'Summers',  title: 'US Representative',      category: 'Federal',   email: 'p.summers@mail.house.gov',     inviteStatus: 'sent',   rsvpStatus: 'Attending'   }),
+  makeInv({ firstName: 'Marcus',    lastName: 'Webb',     title: 'US Representative',      category: 'Federal',   email: 'm.webb@mail.house.gov',        inviteStatus: 'sent',   rsvpStatus: 'No Response' }),
+  // State — sent
+  makeInv({ firstName: 'Jennifer',  lastName: 'Caldwell', title: 'NC Governor',            category: 'State',     email: 'j.caldwell@governor.nc.gov',   inviteStatus: 'sent',   rsvpStatus: 'Attending'   }),
+  makeInv({ firstName: 'Thomas',    lastName: 'Reeves',   title: 'NC Senate President',    category: 'State',     email: 't.reeves@ncleg.gov',           inviteStatus: 'sent',   rsvpStatus: 'Declined'    }),
+  makeInv({ firstName: 'Diane',     lastName: 'Holloway', title: 'NC House Speaker',       category: 'State',     email: 'd.holloway@ncleg.gov',         inviteStatus: 'sent',   rsvpStatus: 'Declined'    }),
+  makeInv({ firstName: 'Samuel',    lastName: 'Torres',   title: 'NC State Senator',       category: 'State',     email: 's.torres@ncleg.gov',           inviteStatus: 'sent',   rsvpStatus: 'No Response' }),
+  // City — sent
+  makeInv({ firstName: 'Mary',      lastName: 'Washington', title: 'Mayor',               category: 'City',      email: 'm.washington@raleighnc.gov',   inviteStatus: 'sent',   rsvpStatus: 'No Response' }),
+  makeInv({ firstName: 'Daniel',    lastName: 'Park',     title: 'Mayor',                  category: 'City',      email: 'd.park@durhamgov.gov',         inviteStatus: 'sent',   rsvpStatus: 'No Response' }),
+  // County — sent
+  makeInv({ firstName: 'Lisa',      lastName: 'Monroe',   title: 'County Commission Chair', category: 'County',   email: 'l.monroe@wakegov.com',         inviteStatus: 'sent',   rsvpStatus: 'No Response' }),
+  // Business — pending
+  makeInv({ firstName: 'Christopher', lastName: 'Lee',    title: 'CEO',                    category: 'Business',  email: 'c.lee@triangletech.com',       inviteStatus: 'pending', rsvpStatus: 'No Response' }),
+  makeInv({ firstName: 'Amanda',    lastName: 'Foster',   title: 'Executive Director',     category: 'Business',  email: 'a.foster@ncchamber.com',       inviteStatus: 'pending', rsvpStatus: 'No Response' }),
+  // Education — pending
+  makeInv({ firstName: 'Kevin',     lastName: 'Marsh',    title: 'University President',   category: 'Education', email: 'k.marsh@unc-demo.edu',         inviteStatus: 'pending', rsvpStatus: 'No Response' }),
+  // Failed
+  makeInv({ firstName: 'Richard',   lastName: 'Novak',    title: 'NC Lt. Governor',        category: 'State',     email: 'r.novak@ltgov.nc.gov',         inviteStatus: 'failed', rsvpStatus: 'No Response' }),
+];
+
+export const DEMO_COMPOSE = {
+  templateId: 'generic',
+  templateParams: {
+    greeting: 'Dear',
+    body: "You are cordially invited to {{EventName}} on {{EventDate}} at {{Venue}}.\n\nThis exclusive gathering brings together North Carolina's leading voices in government, business, and education for an evening of dialogue and partnership.\n\nVIP Reception: {{VIPStart}}–{{VIPEnd}}\n\nPlease RSVP at your earliest convenience: {{RSVP_Link}}",
+    closing: 'With warm regards,',
+  },
+  textSubject: "You're Invited: {{EventName}} — {{EventDate}}",
+};
+
+export async function loadDemoData() {
+  // Skip if demo event already in Dexie to prevent duplicate inserts.
+  const existing = await loadEvents();
+  if (!existing.find(e => e.id === DEMO_EVENT_ID)) {
+    await saveEvent(DEMO_EVENT);
+    for (const inv of DEMO_INVITEES) {
+      await saveInvitee(inv);
+    }
+  }
+  return { event: DEMO_EVENT, invitees: DEMO_INVITEES, compose: DEMO_COMPOSE };
+}

--- a/src/inviteflow/data/demoSeed.ts
+++ b/src/inviteflow/data/demoSeed.ts
@@ -1,9 +1,10 @@
-import { saveEvent, saveInvitee, loadEvents } from '../api/storage';
-import type { AppEvent, Invitee } from '../types';
+import type { AppEvent, Invitee, AppState } from '../types';
+import { importBackupData } from '../api/storage';
 
-export const DEMO_EVENT_ID = 'demo-event-2026-08';
+// Fixed IDs so repeated demo loads are idempotent (Dexie put = upsert).
+export const DEMO_EVENT_ID = 'demo-event-2026-08-14';
 
-export const DEMO_EVENT: AppEvent = {
+const DEMO_EVENT: AppEvent = {
   id: DEMO_EVENT_ID,
   name: 'Capital Region Leadership Summit',
   date: '2026-08-14',
@@ -21,62 +22,50 @@ export const DEMO_EVENT: AppEvent = {
   googleClientId: '',
 };
 
-function makeInv(
-  partial: Omit<Invitee, 'id' | 'eventId' | 'rsvpLink' | 'sentAt' | 'rsvpDate' | 'notes'>
-): Invitee {
-  return {
-    id: crypto.randomUUID(),
-    eventId: DEMO_EVENT_ID,
-    rsvpLink: '',
-    sentAt: partial.inviteStatus !== 'pending' ? '2026-07-21T10:00:00Z' : '',
-    rsvpDate: partial.rsvpStatus !== 'No Response' ? '2026-07-23T14:30:00Z' : '',
-    notes: '',
-    ...partial,
-  };
-}
-
-export const DEMO_INVITEES: Invitee[] = [
+const DEMO_INVITEES: Invitee[] = [
   // Federal — sent
-  makeInv({ firstName: 'Robert',    lastName: 'Hayes',    title: 'US Senator',             category: 'Federal',   email: 'r.hayes@hayes.senate.gov',     inviteStatus: 'sent',   rsvpStatus: 'Attending'   }),
-  makeInv({ firstName: 'Patricia',  lastName: 'Summers',  title: 'US Representative',      category: 'Federal',   email: 'p.summers@mail.house.gov',     inviteStatus: 'sent',   rsvpStatus: 'Attending'   }),
-  makeInv({ firstName: 'Marcus',    lastName: 'Webb',     title: 'US Representative',      category: 'Federal',   email: 'm.webb@mail.house.gov',        inviteStatus: 'sent',   rsvpStatus: 'No Response' }),
+  { id: 'demo-inv-01', eventId: DEMO_EVENT_ID, firstName: 'Robert',      lastName: 'Hayes',      title: 'US Senator',              category: 'Federal',   email: 'r.hayes@hayes.senate.gov',   inviteStatus: 'sent',    rsvpStatus: 'Attending',   rsvpLink: '', sentAt: '2026-07-21T10:00:00Z', rsvpDate: '2026-07-23T14:30:00Z', notes: '' },
+  { id: 'demo-inv-02', eventId: DEMO_EVENT_ID, firstName: 'Patricia',    lastName: 'Summers',    title: 'US Representative',       category: 'Federal',   email: 'p.summers@mail.house.gov',   inviteStatus: 'sent',    rsvpStatus: 'Attending',   rsvpLink: '', sentAt: '2026-07-21T10:00:00Z', rsvpDate: '2026-07-24T09:00:00Z', notes: '' },
+  { id: 'demo-inv-03', eventId: DEMO_EVENT_ID, firstName: 'Marcus',      lastName: 'Webb',       title: 'US Representative',       category: 'Federal',   email: 'm.webb@mail.house.gov',      inviteStatus: 'sent',    rsvpStatus: 'No Response', rsvpLink: '', sentAt: '2026-07-21T10:00:00Z', rsvpDate: '', notes: '' },
   // State — sent
-  makeInv({ firstName: 'Jennifer',  lastName: 'Caldwell', title: 'NC Governor',            category: 'State',     email: 'j.caldwell@governor.nc.gov',   inviteStatus: 'sent',   rsvpStatus: 'Attending'   }),
-  makeInv({ firstName: 'Thomas',    lastName: 'Reeves',   title: 'NC Senate President',    category: 'State',     email: 't.reeves@ncleg.gov',           inviteStatus: 'sent',   rsvpStatus: 'Declined'    }),
-  makeInv({ firstName: 'Diane',     lastName: 'Holloway', title: 'NC House Speaker',       category: 'State',     email: 'd.holloway@ncleg.gov',         inviteStatus: 'sent',   rsvpStatus: 'Declined'    }),
-  makeInv({ firstName: 'Samuel',    lastName: 'Torres',   title: 'NC State Senator',       category: 'State',     email: 's.torres@ncleg.gov',           inviteStatus: 'sent',   rsvpStatus: 'No Response' }),
+  { id: 'demo-inv-04', eventId: DEMO_EVENT_ID, firstName: 'Jennifer',    lastName: 'Caldwell',   title: 'NC Governor',             category: 'State',     email: 'j.caldwell@governor.nc.gov', inviteStatus: 'sent',    rsvpStatus: 'Attending',   rsvpLink: '', sentAt: '2026-07-21T10:00:00Z', rsvpDate: '2026-07-22T16:00:00Z', notes: '' },
+  { id: 'demo-inv-05', eventId: DEMO_EVENT_ID, firstName: 'Thomas',      lastName: 'Reeves',     title: 'NC Senate President',     category: 'State',     email: 't.reeves@ncleg.gov',         inviteStatus: 'sent',    rsvpStatus: 'Declined',    rsvpLink: '', sentAt: '2026-07-21T10:00:00Z', rsvpDate: '2026-07-22T11:00:00Z', notes: '' },
+  { id: 'demo-inv-06', eventId: DEMO_EVENT_ID, firstName: 'Diane',       lastName: 'Holloway',   title: 'NC House Speaker',        category: 'State',     email: 'd.holloway@ncleg.gov',       inviteStatus: 'sent',    rsvpStatus: 'Declined',    rsvpLink: '', sentAt: '2026-07-21T10:00:00Z', rsvpDate: '2026-07-23T08:00:00Z', notes: '' },
+  { id: 'demo-inv-07', eventId: DEMO_EVENT_ID, firstName: 'Samuel',      lastName: 'Torres',     title: 'NC State Senator',        category: 'State',     email: 's.torres@ncleg.gov',         inviteStatus: 'sent',    rsvpStatus: 'No Response', rsvpLink: '', sentAt: '2026-07-21T10:00:00Z', rsvpDate: '', notes: '' },
   // City — sent
-  makeInv({ firstName: 'Mary',      lastName: 'Washington', title: 'Mayor',               category: 'City',      email: 'm.washington@raleighnc.gov',   inviteStatus: 'sent',   rsvpStatus: 'No Response' }),
-  makeInv({ firstName: 'Daniel',    lastName: 'Park',     title: 'Mayor',                  category: 'City',      email: 'd.park@durhamgov.gov',         inviteStatus: 'sent',   rsvpStatus: 'No Response' }),
+  { id: 'demo-inv-08', eventId: DEMO_EVENT_ID, firstName: 'Mary',        lastName: 'Washington', title: 'Mayor',                   category: 'City',      email: 'm.washington@raleighnc.gov', inviteStatus: 'sent',    rsvpStatus: 'No Response', rsvpLink: '', sentAt: '2026-07-21T10:00:00Z', rsvpDate: '', notes: '' },
+  { id: 'demo-inv-09', eventId: DEMO_EVENT_ID, firstName: 'Daniel',      lastName: 'Park',       title: 'Mayor',                   category: 'City',      email: 'd.park@durhamgov.gov',       inviteStatus: 'sent',    rsvpStatus: 'No Response', rsvpLink: '', sentAt: '2026-07-21T10:00:00Z', rsvpDate: '', notes: '' },
   // County — sent
-  makeInv({ firstName: 'Lisa',      lastName: 'Monroe',   title: 'County Commission Chair', category: 'County',   email: 'l.monroe@wakegov.com',         inviteStatus: 'sent',   rsvpStatus: 'No Response' }),
+  { id: 'demo-inv-10', eventId: DEMO_EVENT_ID, firstName: 'Lisa',        lastName: 'Monroe',     title: 'County Commission Chair', category: 'County',    email: 'l.monroe@wakegov.com',       inviteStatus: 'sent',    rsvpStatus: 'No Response', rsvpLink: '', sentAt: '2026-07-21T10:00:00Z', rsvpDate: '', notes: '' },
   // Business — pending
-  makeInv({ firstName: 'Christopher', lastName: 'Lee',    title: 'CEO',                    category: 'Business',  email: 'c.lee@triangletech.com',       inviteStatus: 'pending', rsvpStatus: 'No Response' }),
-  makeInv({ firstName: 'Amanda',    lastName: 'Foster',   title: 'Executive Director',     category: 'Business',  email: 'a.foster@ncchamber.com',       inviteStatus: 'pending', rsvpStatus: 'No Response' }),
+  { id: 'demo-inv-11', eventId: DEMO_EVENT_ID, firstName: 'Christopher', lastName: 'Lee',        title: 'CEO',                     category: 'Business',  email: 'c.lee@triangletech.com',     inviteStatus: 'pending', rsvpStatus: 'No Response', rsvpLink: '', sentAt: '', rsvpDate: '', notes: '' },
+  { id: 'demo-inv-12', eventId: DEMO_EVENT_ID, firstName: 'Amanda',      lastName: 'Foster',     title: 'Executive Director',      category: 'Business',  email: 'a.foster@ncchamber.com',     inviteStatus: 'pending', rsvpStatus: 'No Response', rsvpLink: '', sentAt: '', rsvpDate: '', notes: '' },
   // Education — pending
-  makeInv({ firstName: 'Kevin',     lastName: 'Marsh',    title: 'University President',   category: 'Education', email: 'k.marsh@unc-demo.edu',         inviteStatus: 'pending', rsvpStatus: 'No Response' }),
+  { id: 'demo-inv-13', eventId: DEMO_EVENT_ID, firstName: 'Kevin',       lastName: 'Marsh',      title: 'University President',    category: 'Education', email: 'k.marsh@unc-demo.edu',       inviteStatus: 'pending', rsvpStatus: 'No Response', rsvpLink: '', sentAt: '', rsvpDate: '', notes: '' },
   // Failed
-  makeInv({ firstName: 'Richard',   lastName: 'Novak',    title: 'NC Lt. Governor',        category: 'State',     email: 'r.novak@ltgov.nc.gov',         inviteStatus: 'failed', rsvpStatus: 'No Response' }),
+  { id: 'demo-inv-14', eventId: DEMO_EVENT_ID, firstName: 'Richard',     lastName: 'Novak',      title: 'NC Lt. Governor',         category: 'State',     email: 'r.novak@ltgov.nc.gov',       inviteStatus: 'failed',  rsvpStatus: 'No Response', rsvpLink: '', sentAt: '2026-07-21T10:00:00Z', rsvpDate: '', notes: '' },
 ];
 
-export const DEMO_COMPOSE = {
+// Shaped exactly like an app export (exportData() in SettingsPage strips sendLog/sending/sendProgress).
+export const DEMO_BACKUP: Omit<AppState, 'sending' | 'sendLog' | 'sendProgress'> & { exportedAt: string } = {
+  exportedAt: '2026-07-21T10:00:00.000Z',
+  activeEventId: DEMO_EVENT_ID,
+  events: [DEMO_EVENT],
+  invitees: DEMO_INVITEES,
+  tab: 'tracker',
+  textSubject: "You're Invited: {{EventName}} — {{EventDate}}",
+  htmlBody: '',
   templateId: 'generic',
   templateParams: {
     greeting: 'Dear',
     body: "You are cordially invited to {{EventName}} on {{EventDate}} at {{Venue}}.\n\nThis exclusive gathering brings together North Carolina's leading voices in government, business, and education for an evening of dialogue and partnership.\n\nVIP Reception: {{VIPStart}}–{{VIPEnd}}\n\nPlease RSVP at your earliest convenience: {{RSVP_Link}}",
     closing: 'With warm regards,',
   },
-  textSubject: "You're Invited: {{EventName}} — {{EventDate}}",
+  unsaved: false,
 };
 
+// Same code path as SettingsPage importBackup: write to Dexie, then caller dispatches LOAD_STATE.
 export async function loadDemoData() {
-  // Skip if demo event already in Dexie to prevent duplicate inserts.
-  const existing = await loadEvents();
-  if (!existing.find(e => e.id === DEMO_EVENT_ID)) {
-    await saveEvent(DEMO_EVENT);
-    for (const inv of DEMO_INVITEES) {
-      await saveInvitee(inv);
-    }
-  }
-  return { event: DEMO_EVENT, invitees: DEMO_INVITEES, compose: DEMO_COMPOSE };
+  await importBackupData(DEMO_BACKUP);
+  return DEMO_BACKUP;
 }

--- a/src/inviteflow/data/helpContent.ts
+++ b/src/inviteflow/data/helpContent.ts
@@ -43,7 +43,7 @@ export const helpSections: HelpSection[] = [
       {
         num: '05',
         title: 'Discover Officials (Optional)',
-        body: 'Use the Discover page to find and verify elected officials for your jurisdiction. Configure your AI provider API key, endpoint, and SerpAPI key in Settings, then run scans. Add discovered officials directly to your invitees.',
+        body: 'Use the Discover page to find and verify elected officials for your jurisdiction. Configure your AI provider API key, endpoint, and web search key in Settings, then run scans. Add discovered officials directly to your invitees.',
       },
     ],
   },
@@ -79,7 +79,7 @@ export const helpSections: HelpSection[] = [
       {
         num: '06',
         title: 'Configure Discover (Optional)',
-        body: 'To discover elected officials: 1) Get a SerpAPI key from https://serpapi.com/; 2) Get an API key from any OpenAI-compatible provider (OpenAI, Anthropic, etc.); 3) Go to Discover → Settings and enter your endpoint, API key, and SerpAPI key.',
+        body: 'To discover elected officials: 1) Get a web search API key (e.g. serpapi.com — 100 free/month); 2) Get an AI provider API key (OpenAI, Anthropic, or any compatible provider); 3) Go to Discover → Settings and enter your endpoint, AI key, and web search key.',
       },
     ],
   },
@@ -108,7 +108,7 @@ export const helpSections: HelpSection[] = [
     label: 'TIPS',
     bullets: [
       'Start small — test with 3–5 guests before your full list.',
-      'Use Discover to find officials for your jurisdiction — search results are grounded with real-time web data via SerpAPI.',
+      'Use Discover to find officials for your jurisdiction — search results are grounded with real-time web data.',
       'Use Compose → Preview to check merged emails before sending.',
       'InviteFlow sends in batches with delays to respect rate limits.',
       'Connect a Google Form to RSVP tracking and responses will auto-populate in the Tracker.',
@@ -124,7 +124,7 @@ export const helpSections: HelpSection[] = [
       'Emails not sending? Check that all required fields are configured in Setup.',
       'Template tokens not merging? Verify token names match exactly (case-sensitive: {{FirstName}}, not {{firstname}}).',
       'CSV import failed? Ensure CSV has a header row and email column. Check for proper CSV formatting.',
-      'Discover page not working? Configure your AI provider API key, endpoint, and jurisdiction in Discover → Settings.',
+      'Discover page not working? Configure your AI provider API key, endpoint, and jurisdiction in Discover → Settings. Web search requires a separate web search key.',
     ],
   },
 ];

--- a/src/inviteflow/pages/EventDashboard.tsx
+++ b/src/inviteflow/pages/EventDashboard.tsx
@@ -24,7 +24,7 @@ interface NextStep {
 
 function getNextStep(state: AppState): NextStep {
   const hasInvitees = state.invitees.length > 0;
-  const hasTemplate = !!state.htmlBody.trim();
+  const hasTemplate = !!state.htmlBody.trim() || !!state.templateId;
   const pendingCount = state.invitees.filter(i => i.inviteStatus === 'pending').length;
   const sentCount    = state.invitees.filter(i => i.inviteStatus === 'sent').length;
 
@@ -53,7 +53,7 @@ function getNextStep(state: AppState): NextStep {
 const WORKFLOW: WorkflowRow[] = [
   { num: '01', icon: 'users',    title: 'Invitees',   sub: 'IMPORT, MANAGE & REVIEW GUEST LIST',  route: 'invitees' },
   { num: '02', icon: 'pen',      title: 'Compose',    sub: 'WRITE & PREVIEW THE INVITE EMAIL',    route: 'compose'  },
-  { num: '03', icon: 'send',     title: 'Send',       sub: 'BULK SEND VIA GMAIL',                 route: 'send'     },
+  { num: '03', icon: 'send',     title: 'Send',       sub: 'BULK SEND VIA RESEND',                route: 'send'     },
   { num: '04', icon: 'calendar', title: 'Tracker',    sub: 'MONITOR RSVP RESPONSES',              route: 'tracker'  },
   { num: '05', icon: 'sync',     title: 'Sync',       sub: 'PUSH / PULL GOOGLE SHEETS',           route: 'sync'     },
 ];
@@ -182,7 +182,7 @@ export default function EventDashboard() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 12 }}>
           {WORKFLOW.slice(0, 4).map((w) => {
             const isCompleted = w.route === 'invitees' && state.invitees.length > 0
-              || w.route === 'compose' && !!state.htmlBody.trim()
+              || w.route === 'compose' && (!!state.htmlBody.trim() || !!state.templateId)
               || w.route === 'send' && state.invitees.filter(i => i.inviteStatus === 'sent').length > 0;
             const isCurrent = nextStep.route === w.route;
 

--- a/src/inviteflow/pages/EventDashboard.tsx
+++ b/src/inviteflow/pages/EventDashboard.tsx
@@ -53,9 +53,9 @@ function getNextStep(state: AppState): NextStep {
 const WORKFLOW: WorkflowRow[] = [
   { num: '01', icon: 'users',    title: 'Invitees',   sub: 'IMPORT, MANAGE & REVIEW GUEST LIST',  route: 'invitees' },
   { num: '02', icon: 'pen',      title: 'Compose',    sub: 'WRITE & PREVIEW THE INVITE EMAIL',    route: 'compose'  },
-  { num: '03', icon: 'send',     title: 'Send',       sub: 'BULK SEND VIA RESEND',                route: 'send'     },
+  { num: '03', icon: 'send',     title: 'Send',       sub: 'BULK SEND INVITATIONS',               route: 'send'     },
   { num: '04', icon: 'calendar', title: 'Tracker',    sub: 'MONITOR RSVP RESPONSES',              route: 'tracker'  },
-  { num: '05', icon: 'sync',     title: 'Sync',       sub: 'PUSH / PULL GOOGLE SHEETS',           route: 'sync'     },
+  { num: '05', icon: 'sync',     title: 'Sync',       sub: 'SYNC WITH SPREADSHEET',               route: 'sync'     },
 ];
 
 function CardRow({

--- a/src/inviteflow/pages/EventSetupPage.tsx
+++ b/src/inviteflow/pages/EventSetupPage.tsx
@@ -80,8 +80,9 @@ export default function EventSetupPage() {
         <div className="if-section-label" style={{ padding: '12px 0 8px' }}>GOOGLE OAUTH</div>
         <div className="if-card" style={{ marginBottom: 12 }}>
           <div style={{ padding: 'var(--rt-row-pad)', borderBottom: '1px solid var(--border)' }}>
-            <label className="if-label" style={{ display: 'block', marginBottom: 6 }}>GOOGLE CLIENT ID</label>
+            <label htmlFor="setup-google-client-id" className="if-label" style={{ display: 'block', marginBottom: 6 }}>GOOGLE CLIENT ID</label>
             <input
+              id="setup-google-client-id"
               className="if-input"
               style={{ width: '100%' }}
               value={clientIdDraft}
@@ -101,8 +102,9 @@ export default function EventSetupPage() {
           <div style={{ display: 'grid', gap: 12 }}>
             {FIELDS_DETAILS.map(f => (
               <div key={f.key}>
-                <label className="if-label" style={{ display: 'block', marginBottom: 5 }}>{f.label}</label>
+                <label htmlFor={`setup-${f.key}`} className="if-label" style={{ display: 'block', marginBottom: 5 }}>{f.label}</label>
                 <input
+                  id={`setup-${f.key}`}
                   className="if-input"
                   style={{ width: '100%' }}
                   type={f.type ?? 'text'}
@@ -123,8 +125,9 @@ export default function EventSetupPage() {
           <div style={{ display: 'grid', gap: 12 }}>
             {FIELDS_CONTACT.map(f => (
               <div key={f.key}>
-                <label className="if-label" style={{ display: 'block', marginBottom: 5 }}>{f.label}</label>
+                <label htmlFor={`setup-${f.key}`} className="if-label" style={{ display: 'block', marginBottom: 5 }}>{f.label}</label>
                 <input
+                  id={`setup-${f.key}`}
                   className="if-input"
                   style={{ width: '100%' }}
                   type={f.type ?? 'text'}
@@ -142,8 +145,9 @@ export default function EventSetupPage() {
           <div style={{ display: 'grid', gap: 12 }}>
             {FIELDS_LINKS.map(f => (
               <div key={f.key}>
-                <label className="if-label" style={{ display: 'block', marginBottom: 5 }}>{f.label}</label>
+                <label htmlFor={`setup-${f.key}`} className="if-label" style={{ display: 'block', marginBottom: 5 }}>{f.label}</label>
                 <input
+                  id={`setup-${f.key}`}
                   className="if-input"
                   style={{ width: '100%' }}
                   type={f.type ?? 'text'}

--- a/src/inviteflow/pages/EventSetupPage.tsx
+++ b/src/inviteflow/pages/EventSetupPage.tsx
@@ -92,7 +92,6 @@ export default function EventSetupPage() {
           </div>
           <div style={{ padding: 'var(--rt-row-pad)', display: 'flex', gap: 8, flexWrap: 'wrap' }}>
             <button className="if-btn ghost sm" onClick={() => authorize('spreadsheets')}>Authorize Sheets</button>
-            <button className="if-btn ghost sm" onClick={() => authorize('gmail.send')}>Authorize Gmail</button>
             <button className="if-btn ghost sm" onClick={() => authorize('drive.appdata')}>Authorize Drive</button>
           </div>
         </div>

--- a/src/inviteflow/pages/EventsPage.tsx
+++ b/src/inviteflow/pages/EventsPage.tsx
@@ -4,6 +4,7 @@ import { useRouter } from '../state/RouterContext';
 import PageHeader from '../components/PageHeader';
 import Icon from '../components/Icon';
 import { loadEvents as fetchEventsFromDb, saveEvent, deleteEvent } from '../api/storage';
+import { loadDemoData } from '../data/demoSeed';
 import type { AppEvent } from '../types';
 
 function blankEvent(id: string): AppEvent {
@@ -31,6 +32,7 @@ export default function EventsPage() {
   const dispatch = useAppDispatch();
   const { navigate } = useRouter();
   const [loading, setLoading] = useState(false);
+  const [loadingDemo, setLoadingDemo] = useState(false);
   const [err, setErr] = useState('');
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 
@@ -55,6 +57,21 @@ export default function EventsPage() {
       dispatch({ type: 'SET_ACTIVE_EVENT', id });
       navigate('event-setup');
     } catch (e) { setErr(String(e)); }
+  }
+
+  async function tryDemo() {
+    setLoadingDemo(true); setErr('');
+    try {
+      const { event, invitees, compose } = await loadDemoData();
+      dispatch({ type: 'ADD_EVENT', event });
+      dispatch({ type: 'SET_ACTIVE_EVENT', id: event.id });
+      dispatch({ type: 'SET_INVITEES', invitees });
+      dispatch({ type: 'SET_TEMPLATE', templateId: compose.templateId, templateParams: compose.templateParams });
+      dispatch({ type: 'SET_COMPOSE', subject: compose.textSubject, html: '' });
+      await refresh();
+      navigate('event-home');
+    } catch (e) { setErr(String(e)); }
+    finally { setLoadingDemo(false); }
   }
 
   async function handleDelete(id: string) {
@@ -100,14 +117,27 @@ export default function EventsPage() {
             <div style={{ fontFamily: 'var(--font-body)', fontSize: 12, color: 'var(--text-muted)', marginBottom: 20 }}>
               Each event has its own guest list, email template, and send history.
             </div>
-            <button
-              className="if-btn pri"
-              style={{ minHeight: 44 }}
-              onClick={createEvent}
-            >
-              <Icon name="plus" size={13} style={{ marginRight: 6 }} />
-              New Event
-            </button>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10, alignItems: 'center' }}>
+              <button
+                className="if-btn pri"
+                style={{ minHeight: 44, minWidth: 160 }}
+                onClick={createEvent}
+              >
+                <Icon name="plus" size={13} style={{ marginRight: 6 }} />
+                New Event
+              </button>
+              <button
+                className="if-btn ghost"
+                style={{ minHeight: 40, minWidth: 160 }}
+                onClick={tryDemo}
+                disabled={loadingDemo}
+              >
+                {loadingDemo ? 'Loading…' : '▶ Try a demo'}
+              </button>
+            </div>
+            <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 10, color: 'var(--text-muted)', marginTop: 14, letterSpacing: '0.04em' }}>
+              Demo loads a pre-filled event — no emails sent, no API calls made.
+            </div>
           </div>
         )}
 
@@ -176,7 +206,7 @@ export default function EventsPage() {
                             {!isActive && (
                               <button className="if-btn sm" onClick={() => openEvent(ev.id)}>Open</button>
                             )}
-                            <button className="if-btn del sm" onClick={() => setConfirmDelete(ev.id)}>
+                            <button className="if-btn del sm" onClick={() => setConfirmDelete(ev.id)} aria-label={`Delete ${ev.name || 'event'}`}>
                               <Icon name="x" size={11} />
                             </button>
                           </>

--- a/src/inviteflow/pages/EventsPage.tsx
+++ b/src/inviteflow/pages/EventsPage.tsx
@@ -62,13 +62,8 @@ export default function EventsPage() {
   async function tryDemo() {
     setLoadingDemo(true); setErr('');
     try {
-      const { event, invitees, compose } = await loadDemoData();
-      dispatch({ type: 'ADD_EVENT', event });
-      dispatch({ type: 'SET_ACTIVE_EVENT', id: event.id });
-      dispatch({ type: 'SET_INVITEES', invitees });
-      dispatch({ type: 'SET_TEMPLATE', templateId: compose.templateId, templateParams: compose.templateParams });
-      dispatch({ type: 'SET_COMPOSE', subject: compose.textSubject, html: '' });
-      await refresh();
+      const backup = await loadDemoData();
+      dispatch({ type: 'LOAD_STATE', partial: backup });
       navigate('event-home');
     } catch (e) { setErr(String(e)); }
     finally { setLoadingDemo(false); }

--- a/src/inviteflow/pages/ScoutPage.tsx
+++ b/src/inviteflow/pages/ScoutPage.tsx
@@ -215,7 +215,7 @@ export default function ScoutPage() {
               API keys required
             </div>
             <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 11, color: 'var(--text-secondary)', marginBottom: 10 }}>
-              Configure your AI provider API key and endpoint. Optionally add SerpAPI key for web search.
+              Configure your AI provider API key and endpoint. Optionally add a web search key for grounded results.
             </div>
             <button
               onClick={() => setShowKeysModal(true)}
@@ -273,7 +273,7 @@ export default function ScoutPage() {
               <optgroup label="Fast — no web search">
                 <option value="openstates">State Legislators (Open States — all chambers)</option>
               </optgroup>
-              <optgroup label="AI provider + SerpAPI web search">
+              <optgroup label="AI + web search">
                 {SCAN_TARGETS.map(t => (
                   <option key={t.id} value={t.id}>{t.label}</option>
                 ))}

--- a/src/inviteflow/pages/SettingsPage.tsx
+++ b/src/inviteflow/pages/SettingsPage.tsx
@@ -19,14 +19,14 @@ export default function SettingsPage() {
 
   function saveResendConfig() {
     localStorage.setItem('resend_api_key', resendKey);
-    setStatus('Resend API key saved.');
+    setStatus('Email API key saved.');
   }
 
   function saveLlmConfig() {
     sessionStorage.setItem('cs_api_key', llmApiKey);
     sessionStorage.setItem('cs_endpoint', llmEndpoint || DEFAULT_ENDPOINT);
     sessionStorage.setItem('cs_search_key', serpApiKey);
-    setStatus('LLM & SerpAPI configuration saved.');
+    setStatus('Scout configuration saved.');
   }
 
   function exportData() {
@@ -92,18 +92,18 @@ export default function SettingsPage() {
           <span style={{ color: 'var(--warning)', fontSize: 8, marginLeft: 6 }}>REQUIRED FOR SENDING</span>
         </div>
         <div className="if-card" style={{ padding: 14, marginBottom: 12, borderLeft: '3px solid var(--warning)' }}>
-          <label className="if-label" style={{ display: 'block', marginBottom: 6 }}>RESEND API KEY</label>
+          <label className="if-label" style={{ display: 'block', marginBottom: 6 }}>EMAIL API KEY</label>
           <input
             className="if-input"
             style={{ width: '100%', marginBottom: 8 }}
             type="password"
             value={resendKey}
             onChange={e => setResendKey(e.target.value)}
-            placeholder="re_xxxxxxxxxxxxx — get from resend.com"
+            placeholder="re_xxxxxxxxxxxxx"
           />
           <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 11, color: 'var(--text-secondary)', marginBottom: 8, lineHeight: 1.5 }}>
             Required to send invitation emails. Free tier: 3,000 emails/month.<br />
-            <a href="https://resend.com" target="_blank" rel="noopener" style={{ color: 'var(--accent)' }}>Sign up at resend.com →</a>
+            <a href="https://resend.com" target="_blank" rel="noopener" style={{ color: 'var(--accent)' }}>Get your key at resend.com →</a>
           </div>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <span style={{ fontFamily: 'var(--rf-mono)', fontSize: 11, color: 'var(--text-secondary)', letterSpacing: '0.06em' }}>
@@ -141,14 +141,14 @@ export default function SettingsPage() {
             Supports OpenAI, Anthropic, Ollama, or any OpenAI-compatible endpoint.
           </div>
 
-          <label className="if-label" style={{ display: 'block', marginBottom: 6 }}>SERPAPI KEY</label>
+          <label className="if-label" style={{ display: 'block', marginBottom: 6 }}>WEB SEARCH KEY</label>
           <input
             className="if-input"
             style={{ width: '100%', marginBottom: 8 }}
             type="password"
             value={serpApiKey}
             onChange={e => setSerpApiKey(e.target.value)}
-            placeholder="Get from https://serpapi.com/"
+            placeholder="serpapi.com — 100 free searches/month"
           />
 
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>

--- a/src/inviteflow/pages/SettingsPage.tsx
+++ b/src/inviteflow/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { useRouter } from '../state/RouterContext';
 import PageHeader from '../components/PageHeader';
 import Icon from '../components/Icon';
 import { DEFAULT_ENDPOINT } from '../../scout/constants';
+import { importBackupData } from '../api/storage';
 
 export default function SettingsPage() {
   const state = useAppState();
@@ -41,10 +42,11 @@ export default function SettingsPage() {
 
   function importBackup(file: File) {
     const reader = new FileReader();
-    reader.onload = e => {
+    reader.onload = async e => {
       try {
         const parsed = JSON.parse(e.target?.result as string);
         if (parsed.events) {
+          await importBackupData(parsed);
           dispatch({ type: 'LOAD_STATE', partial: parsed });
           setStatus('Backup imported.');
         } else {


### PR DESCRIPTION
## Summary

This PR consolidates several sessions of maintenance work on InviteFlow.

### Codebase cleanup
- Deleted 8 dead files: `api/gmail.ts`, `styles/tiptap.css`, legacy `tabs/` stubs (EventsTab, InviteesTab, SetupTab, SyncTab, TrackerTab), completed migration plan doc
- Fixed stale references: `tsconfig.json` exclude, `rsvp-docker-compose.yml` hardcoded version, `.env.example` stale version line + old endpoint
- Updated `gas/Code.gs` to v5.1.1 with modern ES syntax matching `SyncPage.tsx`

### LiteLLM → generic OpenAI-compatible API
- Renamed `callLiteLLM` → `callAIProvider` in `src/scout/api.ts`
- Changed `DEFAULT_ENDPOINT` from `http://127.0.0.1:4000/v1` → `https://api.openai.com/v1`
- Updated all references across `ScoutPage.tsx`, `ScoutKeysModal.tsx`, `helpContent.ts`, `QUICKSTART.md`, `.env.example`

### UI strings de-branded
App labels describe what a feature does, not which service implements it. Service names remain only in setup help text and links where users need them to sign up.
- `BULK SEND VIA RESEND` → `BULK SEND INVITATIONS`
- `PUSH / PULL GOOGLE SHEETS` → `SYNC WITH SPREADSHEET`
- `RESEND API KEY` → `EMAIL API KEY`
- `SERPAPI KEY` → `WEB SEARCH KEY`
- `SerpAPI Key` → `Web Search Key` (ScoutKeysModal label)
- `AI provider + SerpAPI web search` → `AI + web search` (ScoutPage optgroup)
- Status messages de-branded (`Scout configuration saved.`)
- Removed dead `Authorize Gmail` button (Gmail replaced by Resend; Sheets/Drive kept)

### Demo event
- `src/inviteflow/data/demoSeed.ts` — pre-filled "Capital Region Leadership Summit" with 14 invitees across Federal, State, City, County, Business, Education categories; mixed statuses (3 attending, 2 declined, 5 no-response sent, 3 pending, 1 failed)
- `DEMO_BACKUP` is shaped exactly like a real app export — same fields, same structure
- Fixed invitee IDs (`demo-inv-01` … `demo-inv-14`) make repeated loads idempotent
- `loadDemoData()` uses the same two-step path as `importBackup` in SettingsPage: `importBackupData()` (Dexie writes) + `LOAD_STATE` (state/localStorage)
- **"▶ Try a demo"** button on the empty EventsPage; no API calls, nothing sent

### importBackup Dexie fix
`importBackupData()` added to `api/storage.ts`. Previously, `importBackup` in SettingsPage only dispatched `LOAD_STATE` (localStorage/state only). Events imported from a backup would disappear the moment EventsPage re-fetched from Dexie. Both file import and demo now go through the same shared function.

### `hasTemplate` fix
`EventDashboard.getNextStep()` checked only `state.htmlBody` to determine whether Compose was done. React Email templates don't write `htmlBody`, so selecting a template left the dashboard pointing users back to Compose. Fixed to also check `state.templateId`. Same fix applied to the workflow step chip `isCompleted` logic.

### Accessibility improvements
- `ScoutKeysModal`: `role="dialog"`, `aria-modal`, `aria-labelledby`, `htmlFor`/`id` on all 9 label-input pairs, `aria-invalid` + `aria-describedby` + `role="alert"` on error states, Escape key handler
- `EventSetupPage`: `htmlFor`/`id` on all label-input groups
- `EventsPage`: `aria-label` on icon-only delete button

### Documentation
- `docs/MEMORY.md` — new institutional knowledge file covering non-obvious learnings across sessions
- `README.md`, `docs/QUICKSTART.md` — demo callout, updated workflow descriptions
- `AGENTS.md` — Documentation Map section: which doc to update for each kind of change, what belongs in MEMORY.md, UI-strings-vs-docs principle

## Test plan

- [ ] Fresh browser (no localStorage): empty EventsPage shows "New Event" + "▶ Try a demo"
- [ ] Click demo → EventDashboard shows stats (10 sent, 3 attending, 5 no response); Next Step = "Send to 3 pending invitees →"
- [ ] Workflow chips: Invitees ✓, Compose ✓, Send = current step
- [ ] Invitees tab: 14 rows with correct statuses and categories
- [ ] Compose tab: Generic template selected with pre-filled params
- [ ] Tracker tab: 3 attending / 2 declined / 9 no response
- [ ] Refresh page → demo data persists
- [ ] Click demo again → idempotent, no duplicate rows
- [ ] Settings → Import backup (real JSON file) → events survive EventsPage refresh
- [ ] ScoutKeysModal: tab through all fields; submit empty key → `aria-invalid` fires; Escape closes modal
- [ ] EventSetupPage: click any label → focuses the correct input

https://claude.ai/code/session_01XFCUfBbNadLCv4tRgJJ7zd