### PR TITLE
chore: bump to v5.1.2, add Shipping Checklist to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,15 @@ Keep tech implementation details **out of UI labels and action text**. Describe 
 
 Not in: button labels, workflow step subtitles, status messages, section headers.
 
+## Shipping Checklist
+
+Before marking a PR ready or closing a task, verify:
+
+- [ ] **Version bumped** — edit `package.json` `"version"` for any user-visible change (new feature, fix, or significant refactor). Patch = `x.y.Z`, minor = `x.Y.0`, major = `X.0.0`. Run `npm run build` after bumping so `inject-version.js` bakes it into `README.md` and `SyncPage.tsx`.
+- [ ] **PR description current** — reflects the full set of changes actually merged, not just the initial scope. Update it as the PR evolves.
+- [ ] **Docs updated** — see Documentation Map above.
+- [ ] **Build passes** — `npm run build` with no TypeScript errors.
+
 ## Agent Operating Principles
 
 - **Think before coding** — state assumptions, present tradeoffs, ask when unclear

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# InviteFlow v5.1.1
+# InviteFlow v5.1.2
 
 > Event invitation management — no Google account required
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inviteflow-v4",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/inviteflow/pages/SyncPage.tsx
+++ b/src/inviteflow/pages/SyncPage.tsx
@@ -5,7 +5,7 @@ import Icon from '../components/Icon';
 
 const MASTER_COLUMNS = ['FirstName', 'LastName', 'Title', 'Category', 'Email', 'RSVP_Link', 'InviteSent', 'InviteSentDate', 'RSVP_Status', 'RSVP_Date', 'Notes'];
 
-const GAS_CODE = `// InviteFlow v5.1.1 — RSVP ingest trigger
+const GAS_CODE = `// InviteFlow v5.1.2 — RSVP ingest trigger
 // Deploy: Extensions → Apps Script → add trigger: onFormSubmit (Form Submit)
 // Set script property MASTER_SHEET_URL via Project Settings → Script Properties
 


### PR DESCRIPTION
Single follow-up commit after #47 merged.

- Bump `package.json` → `5.1.2` for the changes landed in #47 (demo seed, accessibility improvements, UI de-branding, importBackup Dexie fix, hasTemplate fix, doc audit). `inject-version.js` baked the new version into `README.md` and `SyncPage.tsx`.
- Add **Shipping Checklist** section to `AGENTS.md` — version bump, PR description, docs, build pass — so future sessions don't skip these steps.

https://claude.ai/code/session_01XFCUfBbNadLCv4tRgJJ7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFCUfBbNadLCv4tRgJJ7zd)_