### PR TITLE
fix: nav back buttons, demo invitees, typography consistency, SendTab template check

### DIFF
--- a/src/inviteflow/pages/EventDashboard.tsx
+++ b/src/inviteflow/pages/EventDashboard.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from 'react';
 import { useAppState, useAppDispatch } from '../state/AppContext';
 import { useRouter } from '../state/RouterContext';
 import PageHeader from '../components/PageHeader';
 import Icon from '../components/Icon';
+import { loadInvitees } from '../api/storage';
 import type { RouteId } from '../state/RouterContext';
 import type { AppState } from '../types';
 
@@ -97,7 +99,17 @@ function CardRow({
 
 export default function EventDashboard() {
   const state = useAppState();
+  const dispatch = useAppDispatch();
   const { navigate } = useRouter();
+
+  // Reload invitees from Dexie when state is empty but an event is active.
+  // This handles the case where SET_ACTIVE_EVENT clears invitees (e.g. switching events).
+  useEffect(() => {
+    if (!state.activeEventId || state.invitees.length > 0) return;
+    loadInvitees(state.activeEventId).then(invitees => {
+      if (invitees.length > 0) dispatch({ type: 'LOAD_STATE', partial: { invitees } });
+    });
+  }, [state.activeEventId, state.invitees.length]);
 
   const ev = state.events.find(e => e.id === state.activeEventId);
 

--- a/src/inviteflow/pages/TrackerPage.tsx
+++ b/src/inviteflow/pages/TrackerPage.tsx
@@ -181,7 +181,7 @@ export default function TrackerPage() {
                     <tr>
                       {['Category', 'Total', 'Sent', 'Attending', 'Declined', 'No Response'].map(h => (
                         <th key={h} style={{
-                          fontSize: 8, color: 'var(--text-secondary)', letterSpacing: '0.12em',
+                          fontSize: 10, color: 'var(--text-secondary)', letterSpacing: '0.12em',
                           textTransform: 'uppercase', textAlign: 'left', padding: '7px 12px',
                           borderBottom: '1px solid var(--border)', background: 'var(--bg-subtle)',
                         }}>

--- a/src/inviteflow/state/reducer.ts
+++ b/src/inviteflow/state/reducer.ts
@@ -32,6 +32,7 @@ export function reducer(state: AppState, action: Action): AppState {
       return { ...state, events, activeEventId, unsaved: true };
     }
     case 'SET_ACTIVE_EVENT':
+      if (state.activeEventId === action.id) return { ...state, unsaved: false };
       return { ...state, activeEventId: action.id, invitees: [], unsaved: false };
     case 'SET_INVITEES':
       return { ...state, invitees: action.invitees, unsaved: true };

--- a/src/inviteflow/tabs/ComposeTab.tsx
+++ b/src/inviteflow/tabs/ComposeTab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { useAppState, useAppDispatch } from '../state/AppContext';
 import { buildEmailHtml } from '../api/email';
 import { TEMPLATES, type ParamField } from '../emails';
+import PageHeader from '../components/PageHeader';
 
 export default function ComposeTab() {
   const state = useAppState();
@@ -68,32 +69,29 @@ export default function ComposeTab() {
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      {/* ── Top bar ────────────────────────────────────────────────────── */}
-      <div
-        className="px-4 pt-3 pb-2.5 flex flex-col gap-2.5 shrink-0"
-        style={{ borderBottom: '1px solid var(--border)' }}
-      >
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <div className="if-eyebrow" style={{ marginBottom: 2 }}>COMPOSE</div>
-            <div className="if-page-title" style={{ fontSize: 15 }}>Invitation template</div>
-          </div>
+      <PageHeader
+        eyebrow="COMPOSE"
+        title="Invitation template"
+        showBack
+        right={
           <div className="if-tab-switcher" style={{ width: 200, flexShrink: 0 }}>
             <button
               className={`if-tab-option${activePane === 'edit' ? ' active' : ''}`}
               onClick={() => setActivePane('edit')}
-            >
-              Edit
-            </button>
+            >Edit</button>
             <button
               className={`if-tab-option${activePane === 'preview' ? ' active' : ''}`}
               onClick={() => setActivePane('preview')}
-            >
-              Preview
-            </button>
+            >Preview</button>
           </div>
-        </div>
+        }
+      />
 
+      {/* ── Subject + Template toolbar ─────────────────────────────────── */}
+      <div
+        className="shrink-0 flex flex-col gap-2.5 px-[18px] pb-3"
+        style={{ borderBottom: '1px solid var(--border)' }}
+      >
         {/* Subject field */}
         <div className="flex items-center gap-2.5">
           <label className="if-label" style={{ flexShrink: 0, marginBottom: 0 }}>Subject</label>
@@ -197,20 +195,12 @@ export default function ComposeTab() {
 
           <div className="flex gap-3 mt-4">
             <div style={{ textAlign: 'center' }}>
-              <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 7, letterSpacing: '0.1em', color: 'var(--text-muted)' }}>
-                TOKENS
-              </div>
-              <div style={{ fontFamily: 'var(--rf-serif)', fontSize: 16, fontWeight: 500, color: 'var(--text-heading)', lineHeight: 1 }}>
-                {Object.keys(state.templateParams).length}
-              </div>
+              <div className="if-stat-chip-label">TOKENS</div>
+              <div className="if-stat-chip-value">{Object.keys(state.templateParams).length}</div>
             </div>
             <div style={{ textAlign: 'center' }}>
-              <div style={{ fontFamily: 'var(--rf-mono)', fontSize: 7, letterSpacing: '0.1em', color: 'var(--text-muted)' }}>
-                RECIPIENTS
-              </div>
-              <div style={{ fontFamily: 'var(--rf-serif)', fontSize: 16, fontWeight: 500, color: 'var(--text-heading)', lineHeight: 1 }}>
-                {recipientCount}
-              </div>
+              <div className="if-stat-chip-label">RECIPIENTS</div>
+              <div className="if-stat-chip-value">{recipientCount}</div>
             </div>
           </div>
         </div>

--- a/src/inviteflow/tabs/SendTab.tsx
+++ b/src/inviteflow/tabs/SendTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useAppState, useAppDispatch } from '../state/AppContext';
 import { buildEmailHtml, sendEmail } from '../api/email';
+import PageHeader from '../components/PageHeader';
 
 type Filter = 'all' | 'pending' | 'failed';
 
@@ -44,9 +45,17 @@ export default function SendTab() {
   const sentCount    = state.invitees.filter(i => i.inviteStatus === 'sent').length;
   const failedCount  = state.invitees.filter(i => i.inviteStatus === 'failed').length;
 
+  const templateSaved = !!state.htmlBody.trim() || !!state.templateId;
+  const hasMissingEmail = state.invitees.some(i => !i.email);
+  const allChecks = ev && templateSaved && !hasMissingEmail;
+
+  const progress = state.sendProgress.total > 0
+    ? Math.round((state.sendProgress.current / state.sendProgress.total) * 100)
+    : 0;
+
   async function sendBulk() {
     if (!ev) { setErr('No active event — go to Setup.'); return; }
-    if (!state.htmlBody.trim()) { setErr('No email body — go to Compose.'); return; }
+    if (!state.htmlBody.trim() && !state.templateId) { setErr('No email body — go to Compose.'); return; }
     if (filtered.length === 0) { setErr('No invitees match the current filter.'); return; }
     if (!testSent || !testApproved) { setErr('Complete pre-flight test first.'); return; }
 
@@ -74,7 +83,7 @@ export default function SendTab() {
 
   async function sendTestEmail() {
     if (!ev) { setErr('No active event — go to Setup.'); return; }
-    if (!state.htmlBody.trim()) { setErr('No email body — go to Compose.'); return; }
+    if (!state.htmlBody.trim() && !state.templateId) { setErr('No email body — go to Compose.'); return; }
     if (!testEmail.trim()) { setErr('Enter a test email address.'); return; }
     setErr('');
     setTestSending(true);
@@ -98,275 +107,271 @@ export default function SendTab() {
     }
   }
 
-  const progress = state.sendProgress.total > 0
-    ? Math.round((state.sendProgress.current / state.sendProgress.total) * 100)
-    : 0;
-
-  const templateSaved = !!state.htmlBody.trim();
-  const hasMissingEmail = state.invitees.some(i => !i.email);
-  const allChecks = ev && templateSaved && !hasMissingEmail;
-
   return (
-    <div className="p-5 max-w-[760px] mx-auto w-full">
-      {/* ── Page header ───────────────────────────────────────────────── */}
-      <div className="flex items-start justify-between mb-4">
-        <div>
-          <div className="if-eyebrow mb-1.5">SEND</div>
-          <div className="if-page-title">Bulk send</div>
-        </div>
-        <div className="if-tab-switcher" style={{ width: 200 }}>
-          <button
-            className={`if-tab-option${activePane === 'preflight' ? ' active' : ''}`}
-            onClick={() => setActivePane('preflight')}
-          >
-            Pre-flight
-          </button>
-          <button
-            className={`if-tab-option${activePane === 'log' ? ' active' : ''}`}
-            onClick={() => setActivePane('log')}
-          >
-            Log
-          </button>
-        </div>
-      </div>
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg-root)' }}>
+      <PageHeader
+        eyebrow="SEND"
+        title="Bulk send"
+        showBack
+        right={
+          <div className="if-tab-switcher" style={{ width: 200 }}>
+            <button
+              className={`if-tab-option${activePane === 'preflight' ? ' active' : ''}`}
+              onClick={() => setActivePane('preflight')}
+            >Pre-flight</button>
+            <button
+              className={`if-tab-option${activePane === 'log' ? ' active' : ''}`}
+              onClick={() => setActivePane('log')}
+            >Log</button>
+          </div>
+        }
+      />
 
-      {/* Meta line */}
-      <div className="if-meta-line mb-4">
-        {ev ? (
-          <>
-            <span style={{ width: 6, height: 6, borderRadius: '50%', background: allChecks ? 'var(--success)' : 'var(--warning)', display: 'inline-block', marginRight: 8 }}/>
-            <span>{ev.contactEmail ? `GMAIL · ${ev.contactEmail.split('@')[0].toUpperCase()}@…` : 'SENDER NOT CONFIGURED'}</span>
-            <span className="if-meta-sep">·</span>
-            <span style={{ color: 'var(--accent)' }}>{filtered.length} {filter.toUpperCase()}</span>
-            {sentCount > 0 && (
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        <div className="p-5 max-w-[760px] mx-auto w-full">
+
+          {/* Meta line */}
+          <div className="if-meta-line mb-4">
+            {ev ? (
               <>
+                <span style={{ width: 6, height: 6, borderRadius: '50%', background: allChecks ? 'var(--success)' : 'var(--warning)', display: 'inline-block', marginRight: 8 }}/>
+                <span>{ev.contactEmail ? ev.contactEmail.toUpperCase() : 'SENDER NOT CONFIGURED'}</span>
                 <span className="if-meta-sep">·</span>
-                <span>{sentCount} SENT</span>
+                <span style={{ color: 'var(--accent)' }}>{filtered.length} {filter.toUpperCase()}</span>
+                {sentCount > 0 && (
+                  <>
+                    <span className="if-meta-sep">·</span>
+                    <span>{sentCount} SENT</span>
+                  </>
+                )}
               </>
+            ) : (
+              <span style={{ color: 'var(--warning)' }}>NO ACTIVE EVENT — GO TO SETUP</span>
             )}
-          </>
-        ) : (
-          <span style={{ color: 'var(--warning)' }}>NO ACTIVE EVENT — GO TO SETUP</span>
-        )}
-      </div>
-
-      {err && <div className="if-status err mb-4">{err}</div>}
-
-      {/* ── Pre-flight pane ───────────────────────────────────────────── */}
-      {activePane === 'preflight' && (
-        <>
-          {/* Checklist */}
-          <div className="if-section-label mb-2">PRE-FLIGHT CHECKS</div>
-          <div className="if-card mb-4">
-            {/* Sender */}
-            <div className={`if-card-row${!ev?.contactEmail ? '' : ''}`}>
-              <div className={`if-row-chip${ev?.contactEmail ? ' good' : ' warn'}`}>
-                {ev?.contactEmail ? '✓' : '!'}
-              </div>
-              <div className="if-card-row-body">
-                <div className="if-card-row-title">Sender configured</div>
-                <div className="if-card-row-sub">
-                  {ev?.contactEmail ? ev.contactEmail.toUpperCase() : 'CONTACT EMAIL NOT SET IN SETUP'}
-                </div>
-              </div>
-            </div>
-
-            {/* Template */}
-            <div className="if-card-row">
-              <div className={`if-row-chip${templateSaved ? ' good' : ' warn'}`}>
-                {templateSaved ? '✓' : '!'}
-              </div>
-              <div className="if-card-row-body">
-                <div className="if-card-row-title">Template saved</div>
-                <div className="if-card-row-sub">
-                  {templateSaved
-                    ? `${(state.htmlBody.match(/\{\{\w+\}\}/g) || []).length} MERGE TOKENS DETECTED`
-                    : 'NO BODY — GO TO COMPOSE'}
-                </div>
-              </div>
-            </div>
-
-            {/* Recipients */}
-            <div className="if-card-row">
-              <div className={`if-row-chip${!hasMissingEmail ? ' good' : ' warn'}`}>
-                {!hasMissingEmail ? '✓' : '!'}
-              </div>
-              <div className="if-card-row-body">
-                <div className="if-card-row-title">Recipients validated</div>
-                <div className="if-card-row-sub">
-                  {state.invitees.length} TOTAL
-                  {hasMissingEmail ? ` · ${state.invitees.filter(i => !i.email).length} MISSING EMAIL` : ' · ALL HAVE EMAIL'}
-                </div>
-              </div>
-            </div>
-
-            {/* Filter */}
-            <div className="if-card-row last no-action" style={{ cursor: 'default' }}>
-              <div className="if-row-chip">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
-                  stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M3 5h18M6 12h12M10 19h4"/>
-                </svg>
-              </div>
-              <div className="if-card-row-body">
-                <div className="if-card-row-title">Active filter</div>
-                <div className="if-card-row-sub">{filter.toUpperCase()} · {filtered.length} WILL RECEIVE</div>
-              </div>
-              <div style={{ display: 'flex', gap: 6 }}>
-                {(['pending', 'failed', 'all'] as Filter[]).map(f => (
-                  <button
-                    key={f}
-                    className={`if-filter-chip${filter === f ? ' active' : ''}`}
-                    onClick={() => setFilter(f)}
-                  >
-                    {f}
-                    <span className="count"> {
-                      f === 'all' ? state.invitees.length :
-                      f === 'pending' ? pendingCount : failedCount
-                    }</span>
-                  </button>
-                ))}
-              </div>
-            </div>
           </div>
 
-          {/* Test Email Section */}
-          <div className="if-section-label mb-2">PRE-FLIGHT TEST</div>
-          <div className="if-card mb-4">
-            <div style={{ padding: 'var(--rt-row-pad)' }}>
-              <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
-                <input
-                  type="email"
-                  value={testEmail}
-                  onChange={e => { setTestEmail(e.target.value); setTestSent(false); setTestApproved(false); }}
-                  placeholder="test@example.com"
-                  className="if-input"
-                  style={{ flex: 1 }}
-                />
-                <button
-                  className="if-btn"
-                  onClick={sendTestEmail}
-                  disabled={testSending || !testEmail.trim()}
-                  style={{ whiteSpace: 'nowrap' }}
-                >
-                  {testSending ? 'SENDING…' : 'Send Test Email'}
-                </button>
-              </div>
-              {testSent && (
-                <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', userSelect: 'none' }}>
-                  <input
-                    type="checkbox"
-                    checked={testApproved}
-                    onChange={e => setTestApproved(e.target.checked)}
-                    style={{ width: 16, height: 16, accentColor: 'var(--accent)' }}
-                  />
-                  <span style={{ fontSize: 12, color: testApproved ? 'var(--text-base)' : 'var(--text-muted)' }}>
-                    Confirm test email received
-                  </span>
-                </label>
-              )}
-            </div>
-          </div>
+          {err && <div className="if-status err mb-4">{err}</div>}
 
-          {/* Stat strip */}
-          <div className="if-section-label mb-2">THIS EVENT</div>
-          <div style={{ display: 'flex', gap: 10, marginBottom: 20 }}>
-            <div className="if-stat-chip">
-              <div className="if-stat-chip-label">Pending</div>
-              <div className="if-stat-chip-value" style={{ color: 'var(--text-secondary)' }}>{pendingCount}</div>
-            </div>
-            <div className="if-stat-chip">
-              <div className="if-stat-chip-label">Sent</div>
-              <div className="if-stat-chip-value" style={{ color: 'var(--success)' }}>{sentCount}</div>
-            </div>
-            <div className="if-stat-chip">
-              <div className="if-stat-chip-label">Failed</div>
-              <div className="if-stat-chip-value" style={{ color: 'var(--danger)' }}>{failedCount}</div>
-            </div>
-            <div className="if-stat-chip">
-              <div className="if-stat-chip-label">Ready to send</div>
-              <div className="if-stat-chip-value" style={{ color: 'var(--accent)' }}>{filtered.length}</div>
-            </div>
-          </div>
-
-          {/* Progress bar (sending) */}
-          {state.sending && (
-            <div className="mb-5">
-              <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--text-muted)', marginBottom: 6, letterSpacing: '0.08em' }}>
-                <span>SENDING IN PROGRESS</span>
-                <span>{state.sendProgress.current} / {state.sendProgress.total} ({progress}%)</span>
-              </div>
-              <div className="if-progress-track">
-                <div className="if-progress-fill" style={{ width: `${progress}%` }}/>
-              </div>
-            </div>
-          )}
-
-          {/* CTA */}
-          <button
-            className="if-primary-btn"
-            onClick={sendBulk}
-            disabled={state.sending || filtered.length === 0 || !testSent || !testApproved}
-          >
-            {state.sending
-              ? `SENDING… ${state.sendProgress.current}/${state.sendProgress.total}`
-              : `SEND ${filtered.length} INVITATION${filtered.length !== 1 ? 'S' : ''} →`}
-          </button>
-          {(!testSent || !testApproved) && (
-            <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 8, textAlign: 'center' }}>
-              Send a test email and confirm receipt to enable bulk send
-            </div>
-          )}
-        </>
-      )}
-
-      {/* ── Log pane ──────────────────────────────────────────────────── */}
-      {activePane === 'log' && (
-        <>
-          <div className="if-section-label mb-2">DELIVERY LOG</div>
-          {state.sendLog.length === 0 ? (
-            <div className="if-card">
-              <div className="if-empty" style={{ padding: '32px 18px' }}>
-                No sends yet
-                <div className="if-empty-sub" style={{ marginTop: 6, marginBottom: 0 }}>
-                  RUN A SEND TO SEE DELIVERY LOG
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div className="if-card" style={{ overflow: 'hidden' }}>
-              <div style={{ maxHeight: 480, overflowY: 'auto' }}>
-                {state.sendLog.map((entry, i) => (
-                  <div
-                    key={entry.id}
-                    style={{
-                      display: 'flex',
-                      gap: 10,
-                      alignItems: 'baseline',
-                      padding: 'var(--rt-row-pad)',
-                      borderBottom: i < state.sendLog.length - 1 ? '1px solid var(--border)' : 'none',
-                      fontFamily: 'var(--rf-mono)',
-                      fontSize: 11,
-                    }}
-                  >
-                    <span style={{
-                      minWidth: 40, fontSize: 9, letterSpacing: '0.07em',
-                      color: entry.status === 'sent' ? 'var(--success)' : 'var(--danger)',
-                    }}>
-                      {entry.status.toUpperCase()}
-                    </span>
-                    <span style={{ color: 'var(--text-base)', minWidth: 160 }}>{entry.name}</span>
-                    <span style={{ color: 'var(--text-muted)', flex: 1, fontSize: 10 }}>{entry.email}</span>
-                    {entry.error && (
-                      <span style={{ fontSize: 9, color: 'var(--danger)' }}>{entry.error}</span>
-                    )}
+          {/* ── Pre-flight pane ───────────────────────────────────────────── */}
+          {activePane === 'preflight' && (
+            <>
+              {/* Checklist */}
+              <div className="if-section-label mb-2">PRE-FLIGHT CHECKS</div>
+              <div className="if-card mb-4">
+                {/* Sender */}
+                <div className={`if-card-row${!ev?.contactEmail ? '' : ''}`}>
+                  <div className={`if-row-chip${ev?.contactEmail ? ' good' : ' warn'}`}>
+                    {ev?.contactEmail ? '✓' : '!'}
                   </div>
-                ))}
+                  <div className="if-card-row-body">
+                    <div className="if-card-row-title">Sender configured</div>
+                    <div className="if-card-row-sub">
+                      {ev?.contactEmail ? ev.contactEmail.toUpperCase() : 'CONTACT EMAIL NOT SET IN SETUP'}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Template */}
+                <div className="if-card-row">
+                  <div className={`if-row-chip${templateSaved ? ' good' : ' warn'}`}>
+                    {templateSaved ? '✓' : '!'}
+                  </div>
+                  <div className="if-card-row-body">
+                    <div className="if-card-row-title">Template saved</div>
+                    <div className="if-card-row-sub">
+                      {templateSaved
+                        ? state.templateId
+                          ? `REACT EMAIL TEMPLATE · ${state.templateId.toUpperCase()}`
+                          : `${(state.htmlBody.match(/\{\{\w+\}\}/g) || []).length} MERGE TOKENS DETECTED`
+                        : 'NO TEMPLATE — GO TO COMPOSE'}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Recipients */}
+                <div className="if-card-row">
+                  <div className={`if-row-chip${!hasMissingEmail ? ' good' : ' warn'}`}>
+                    {!hasMissingEmail ? '✓' : '!'}
+                  </div>
+                  <div className="if-card-row-body">
+                    <div className="if-card-row-title">Recipients validated</div>
+                    <div className="if-card-row-sub">
+                      {state.invitees.length} TOTAL
+                      {hasMissingEmail ? ` · ${state.invitees.filter(i => !i.email).length} MISSING EMAIL` : ' · ALL HAVE EMAIL'}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Filter */}
+                <div className="if-card-row last no-action" style={{ cursor: 'default' }}>
+                  <div className="if-row-chip">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+                      stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M3 5h18M6 12h12M10 19h4"/>
+                    </svg>
+                  </div>
+                  <div className="if-card-row-body">
+                    <div className="if-card-row-title">Active filter</div>
+                    <div className="if-card-row-sub">{filter.toUpperCase()} · {filtered.length} WILL RECEIVE</div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    {(['pending', 'failed', 'all'] as Filter[]).map(f => (
+                      <button
+                        key={f}
+                        className={`if-filter-chip${filter === f ? ' active' : ''}`}
+                        onClick={() => setFilter(f)}
+                      >
+                        {f}
+                        <span className="count"> {
+                          f === 'all' ? state.invitees.length :
+                          f === 'pending' ? pendingCount : failedCount
+                        }</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
               </div>
-            </div>
+
+              {/* Test Email Section */}
+              <div className="if-section-label mb-2">PRE-FLIGHT TEST</div>
+              <div className="if-card mb-4">
+                <div style={{ padding: 'var(--rt-row-pad)' }}>
+                  <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+                    <input
+                      type="email"
+                      value={testEmail}
+                      onChange={e => { setTestEmail(e.target.value); setTestSent(false); setTestApproved(false); }}
+                      placeholder="test@example.com"
+                      className="if-input"
+                      style={{ flex: 1 }}
+                    />
+                    <button
+                      className="if-btn"
+                      onClick={sendTestEmail}
+                      disabled={testSending || !testEmail.trim()}
+                      style={{ whiteSpace: 'nowrap' }}
+                    >
+                      {testSending ? 'SENDING…' : 'Send Test Email'}
+                    </button>
+                  </div>
+                  {testSent && (
+                    <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', userSelect: 'none' }}>
+                      <input
+                        type="checkbox"
+                        checked={testApproved}
+                        onChange={e => setTestApproved(e.target.checked)}
+                        style={{ width: 16, height: 16, accentColor: 'var(--accent)' }}
+                      />
+                      <span style={{ fontSize: 12, color: testApproved ? 'var(--text-base)' : 'var(--text-muted)' }}>
+                        Confirm test email received
+                      </span>
+                    </label>
+                  )}
+                </div>
+              </div>
+
+              {/* Stat strip */}
+              <div className="if-section-label mb-2">THIS EVENT</div>
+              <div style={{ display: 'flex', gap: 10, marginBottom: 20 }}>
+                <div className="if-stat-chip">
+                  <div className="if-stat-chip-label">Pending</div>
+                  <div className="if-stat-chip-value" style={{ color: 'var(--text-secondary)' }}>{pendingCount}</div>
+                </div>
+                <div className="if-stat-chip">
+                  <div className="if-stat-chip-label">Sent</div>
+                  <div className="if-stat-chip-value" style={{ color: 'var(--success)' }}>{sentCount}</div>
+                </div>
+                <div className="if-stat-chip">
+                  <div className="if-stat-chip-label">Failed</div>
+                  <div className="if-stat-chip-value" style={{ color: 'var(--danger)' }}>{failedCount}</div>
+                </div>
+                <div className="if-stat-chip">
+                  <div className="if-stat-chip-label">Ready to send</div>
+                  <div className="if-stat-chip-value" style={{ color: 'var(--accent)' }}>{filtered.length}</div>
+                </div>
+              </div>
+
+              {/* Progress bar (sending) */}
+              {state.sending && (
+                <div className="mb-5">
+                  <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--rf-mono)', fontSize: 9, color: 'var(--text-muted)', marginBottom: 6, letterSpacing: '0.08em' }}>
+                    <span>SENDING IN PROGRESS</span>
+                    <span>{state.sendProgress.current} / {state.sendProgress.total} ({progress}%)</span>
+                  </div>
+                  <div className="if-progress-track">
+                    <div className="if-progress-fill" style={{ width: `${progress}%` }}/>
+                  </div>
+                </div>
+              )}
+
+              {/* CTA */}
+              <button
+                className="if-primary-btn"
+                onClick={sendBulk}
+                disabled={state.sending || filtered.length === 0 || !testSent || !testApproved}
+              >
+                {state.sending
+                  ? `SENDING… ${state.sendProgress.current}/${state.sendProgress.total}`
+                  : `SEND ${filtered.length} INVITATION${filtered.length !== 1 ? 'S' : ''} →`}
+              </button>
+              {(!testSent || !testApproved) && (
+                <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 8, textAlign: 'center' }}>
+                  Send a test email and confirm receipt to enable bulk send
+                </div>
+              )}
+            </>
           )}
-        </>
-      )}
+
+          {/* ── Log pane ──────────────────────────────────────────────────── */}
+          {activePane === 'log' && (
+            <>
+              <div className="if-section-label mb-2">DELIVERY LOG</div>
+              {state.sendLog.length === 0 ? (
+                <div className="if-card">
+                  <div className="if-empty" style={{ padding: '32px 18px' }}>
+                    No sends yet
+                    <div className="if-empty-sub" style={{ marginTop: 6, marginBottom: 0 }}>
+                      RUN A SEND TO SEE DELIVERY LOG
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="if-card" style={{ overflow: 'hidden' }}>
+                  <div style={{ maxHeight: 480, overflowY: 'auto' }}>
+                    {state.sendLog.map((entry, i) => (
+                      <div
+                        key={entry.id}
+                        style={{
+                          display: 'flex',
+                          gap: 10,
+                          alignItems: 'baseline',
+                          padding: 'var(--rt-row-pad)',
+                          borderBottom: i < state.sendLog.length - 1 ? '1px solid var(--border)' : 'none',
+                          fontFamily: 'var(--rf-mono)',
+                          fontSize: 11,
+                        }}
+                      >
+                        <span style={{
+                          minWidth: 40, fontSize: 9, letterSpacing: '0.07em',
+                          color: entry.status === 'sent' ? 'var(--success)' : 'var(--danger)',
+                        }}>
+                          {entry.status.toUpperCase()}
+                        </span>
+                        <span style={{ color: 'var(--text-base)', minWidth: 160 }}>{entry.name}</span>
+                        <span style={{ color: 'var(--text-muted)', flex: 1, fontSize: 10 }}>{entry.email}</span>
+                        {entry.error && (
+                          <span style={{ fontSize: 9, color: 'var(--danger)' }}>{entry.error}</span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Navigation**: ComposeTab and SendTab now have a back button via `PageHeader` (tab switcher moved to the `right` slot) — users were previously stranded with no way to navigate back
- **Demo invitees missing**: two-part fix — reducer preserves invitees when re-selecting the same already-active event; EventDashboard has a Dexie fallback load when `state.invitees` is empty but an active event is set
- **SendTab template bug**: `templateSaved`, `sendBulk`, and `sendTestEmail` now check `templateId` as well as `htmlBody` — React Email templates set `templateId` but never write `htmlBody`, so pre-flight and send were always blocked for them
- **Typography**: ComposeTab TOKENS/RECIPIENTS labels use `if-stat-chip-*` classes instead of 7px inline styles; page title uses standard 18px via PageHeader; TrackerPage table headers 8px → 10px; SendTab "GMAIL ·" branding removed
- **SendTab layout**: changed to proper `height:100% flex-column + overflowY-auto` so content scrolls correctly on short viewports

## Root cause: demo invitees

`SET_ACTIVE_EVENT` in the reducer clears `state.invitees = []` (by design — switching events should clear the old event's roster). But when a user loads the demo, goes back to the events list, and clicks the demo event row again, `openEvent()` dispatches `SET_ACTIVE_EVENT` with the same ID — wiping the 14 demo invitees. Fix A: skip the clear when the new ID equals the current active ID. Fix B: EventDashboard loads from Dexie as a fallback (demo invitees are always in Dexie after `importBackupData`).

## Test plan

- [ ] Load demo from empty events screen → EventDashboard shows correct stats (10 invited, 3 attending, 3 pending)
- [ ] Navigate to Invitees page → 14 rows visible
- [ ] Navigate back → Events list → click demo event again → Invitees still visible
- [ ] Navigate to Compose → back arrow returns to EventDashboard
- [ ] Navigate to Send → back arrow returns to EventDashboard
- [ ] Send page pre-flight: "Template saved" check shows green for React Email template (templateId set, htmlBody empty)
- [ ] TrackerPage: category table headers are legible (10px, not 8px)

https://claude.ai/code/session_01XFCUfBbNadLCv4tRgJJ7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFCUfBbNadLCv4tRgJJ7zd)_